### PR TITLE
Add publish-proto Gradle script

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -20,7 +20,7 @@
 
 ext {
     // The version of the Spine Base module to be used in the project.
-    spineBaseVersion = '0.10.40-SNAPSHOT'
+    spineBaseVersion = '0.10.54-SNAPSHOT'
 
     // Publish artifacts of this project with the same version number as Base.
     versionToPublish = spineBaseVersion

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,8 @@ final def scripts = [
     testOutput             : "$rootDir/config/gradle/test-output.gradle",
     filterInternalJavadocs : "$rootDir/config/gradle/filter-internal-javadoc.gradle",
     jacoco                 : "$rootDir/config/gradle/jacoco.gradle",
-    publish                : "$rootDir/config/gradle/publish.gradle"
+    publish                : "$rootDir/config/gradle/publish.gradle",
+    publishProto           : "$rootDir/config/gradle/publish-proto.gradle",
 ]
 
 ext.deps = [

--- a/gradle/publish-proto.gradle
+++ b/gradle/publish-proto.gradle
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import com.google.common.collect.Lists
+
+
+/**
+ * This plugin enables a project to publish a JAR containing all the {@code .proto} definitions
+ * found in the project classpath, which is the definitions from {@code sourceSets.main.proto} and
+ * the proto files extracted from the JAR dependencies of the project.
+ *
+ * <p>The relative file paths are kept.
+ *
+ * <p>To depend onto such artifact of e.g. the spine-client module, use:
+ * <pre>
+ *     {@code
+ *     dependencies {
+ *         compile "io.spine:spine-client:$version@proto"
+ *     }
+ *     }
+ * </pre>
+ *
+ * <p>To enable the artifact publishing for a project, apply this plugin to it:
+ * <pre>
+ *     {@code
+ *     apply from: "$rootDir/config/gradle/publish-proto.gradle"
+ *     }
+ * </pre>
+ * 
+ * @author Dmytro Dashenkov
+ */
+
+buildscript {
+    repositories {
+        jcenter()
+        mavenLocal()
+    }
+
+    dependencies {
+        classpath deps.build.guava
+    }
+}
+
+/**
+ * Collects all the directories from current project and its dependencies (including zip tree
+ * directories) which contain {@code .proto} definitions.
+ *
+ * <p>The directories may in practice include files of other extension. The caller should take care
+ * of handling those files respectively.
+ *
+ * <p>It's guaranteed that there are no other Proto definitions in the current project classpath
+ * except those included into the returned {@code Collection}.
+ */
+Collection<File> collectProto() {
+    final def dependencies = configurations.compile.files
+    final def jarFiles = dependencies.collect { JarFileName.ofFile(it) }
+    final def result = new HashSet<>()
+    for (final File jarFile in dependencies) {
+        if (jarFile.name.endsWith(".jar")) {
+            final def zipTree = zipTree(jarFile)
+            try {
+                for (final File file in zipTree) {
+                    if (isProtoFile(file)) {
+                        result.add(getProtoRoot(file, jarFiles))
+                    }
+                }
+            } catch (GradleException e) {
+                /*
+                 * As the :assembleProto task configuration is resolved first upon the project
+                 * configuration (and we don't have the dependencies there yet) and then upon
+                 * the execution, the task should complete successfully.
+                 *
+                 * To make sure the configuration phase passes, we suppress the GradleException
+                 * thrown by `zipTree()` indicating that the given file, which is a dependency JAR
+                 * file does not exist.
+                 *
+                 * Though, if this error is thrown on the execution phase, this IS an error. Thus,
+                 * we log an error message.
+                 *
+                 * As a side effect, the message is shown upon `./gradlew clean build` or upon
+                 * a newly created version of framework build etc.
+                 */
+                logger.error(
+                        "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."
+                )
+            }
+        }
+    }
+    result.addAll(sourceSets.main.proto.srcDirs)
+    return result
+}
+
+/**
+ * Returns the root directory containing a Proto package.
+ *
+ * @param member the member File of the Proto package
+ * @param jarNames the full listing of the project JAR dependencies
+ */
+File getProtoRoot(final File member, final Collection<JarFileName> jarNames) {
+    File pkg = member
+    while (!jarNames.contains(jarName(pkg.parentFile))) {
+        pkg = pkg.parentFile
+    }
+    return pkg.parentFile
+}
+
+/**
+ * Retrieves the name of the given folder trimmed by {@code ".jar"} suffix.
+ *
+ * <p>More formally, returns the name of the given {@link File} if the name does not contain
+ * {@code ".jar"} substring or the substring of the name containing the characters from the start
+ * to the {@code ".jar"} sequence (inclusively).
+ *
+ * <p>This transformation corresponds to finding the name of a JAR file which was extracted to
+ * the given directory with Gradle {@code zipTree()} API.
+ *
+ * @param jar the folder to get the JAR name for
+ */
+JarFileName jarName(final File jar) {
+    final String unpackedJarInfix = ".jar"
+    final String name = jar.name
+    final int index = name.lastIndexOf(unpackedJarInfix)
+    if (index < 0) {
+        return null
+    } else {
+        return JarFileName.ofValue(name.substring(0, index + unpackedJarInfix.length()))
+    }
+}
+
+task assembleProto(type: Jar) {
+    description "Assembles a JAR artifact with all Proto definitions from the classpath."
+    from { collectProto() }
+    include { isProtoFileOrDir(it.file) }
+}
+
+/**
+ * Checks if the given abstract pathname represents either a {@code .proto} file, or a directory
+ * containing proto files.
+ *
+ * <p>If {@code candidate} is a directory, scans its children recursively.
+ *
+ * @param candidate the {@link File} to check
+ * @return {@code true} if the {@code candidate} {@linkplain #isProtoFile is a Protobuf file} or
+ *         a directory containing at least one Protobuf file
+ */
+boolean isProtoFileOrDir(final File candidate) {
+    final Deque<File> filesToCheck = Lists.newLinkedList()
+    filesToCheck.push(candidate)
+    if (candidate.isDirectory() && candidate.list().length == 0) {
+        return false
+    }
+    while (!filesToCheck.isEmpty()) {
+        final File file = filesToCheck.pop()
+        if (isProtoFile(file)) {
+            return true
+        }
+        if (file.isDirectory()) {
+            file.listFiles().each { filesToCheck.push(it) }
+        }
+    }
+    return false
+}
+
+/**
+ * Checks if the given file is a {@code .proto} file.
+ *
+ * @param file the file to check
+ * @return {@code true} if the {@code file} is a Protobuf file, {@code false} otherwise
+ */
+boolean isProtoFile(final File file) {
+    return file.isFile() && file.name.endsWith(".proto")
+}
+
+final String artifactIdForPublishing = "spine-${project.name}"
+publishing {
+    publications {
+        mavenProto(MavenPublication) {
+            groupId = "${group}"
+            artifactId = "${artifactIdForPublishing}"
+            version = "${version}"
+
+            from components.java
+
+            artifact assembleProto {
+                classifier = "proto"
+            }
+        }
+    }
+}
+
+/**
+ * The filename of a JAR dependency of the project.
+ */
+final class JarFileName {
+
+    final String value
+
+    private JarFileName(final String value) {
+        this.value = value
+    }
+
+    static JarFileName ofFile(final File jar) {
+        return new JarFileName(jar.name)
+    }
+
+    static JarFileName ofValue(final String value) {
+        return new JarFileName(value)
+    }
+
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (getClass() != o.class) return false
+
+        JarFileName that = (JarFileName) o
+
+        if (value != that.value) return false
+
+        return true
+    }
+
+    int hashCode() {
+        return (value != null ? value.hashCode() : 0)
+    }
+}


### PR DESCRIPTION
This PR adds a publish-proto.gradle under config. 

This script allows generating a JAR from all proto definitions available at a classpath (the definitions from `sourceSets.main.proto` and the proto files extracted from the JAR dependencies of the project.)
The script is used by simply applying it in the Gradle project.

