### PR TITLE
Make publish-proto script generate single JAR

### DIFF
--- a/gradle/publish-proto.gradle
+++ b/gradle/publish-proto.gradle
@@ -148,6 +148,7 @@ task assembleProto(type: Jar) {
     description "Assembles a JAR artifact with all Proto definitions from the classpath."
     from { collectProto() }
     include { isProtoFileOrDir(it.file) }
+    classifier "proto"
 }
 
 /**
@@ -198,9 +199,7 @@ publishing {
 
             from components.java
 
-            artifact assembleProto {
-                classifier = "proto"
-            }
+            artifacts = [assembleProto]
         }
     }
 }


### PR DESCRIPTION
This PR stops `mavenProto` publication from generating the default JAR artifact.

Previously it produced two artifacts: `jar` and `assembleProto`. Now it’s just single `assembleProto` artifact.