### PR TITLE
Add `UnstableApiUsage` Inspection Config

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -766,8 +766,8 @@
       <option name="ignoreReferencesToLocalInnerClasses" value="true" />
     </inspection_tool>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnstableApiUsage" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="WEAK WARNING" enabled="true" />
+    <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WEAK WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />


### PR DESCRIPTION
In this PR we configure the `UnstableApiUsage` IDEA inspection. The severity is `WEAK WARNING`. 

An example of such API is `com.google.common.collect.Streams` class.

<img width="404" alt="screen shot 2018-07-27 at 23 12 36" src="https://user-images.githubusercontent.com/18305364/43344491-9b3aae62-91f2-11e8-8601-f2eff52eca32.png">
