### PR TITLE
Add Gradle script enabling new Javadoc tags

### DIFF
--- a/gradle/add-javadoc-tags.gradle
+++ b/gradle/add-javadoc-tags.gradle
@@ -1,0 +1,41 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+/*
+ * This script enables the new Javadoc tags in the build.
+ *
+ * The tags are:
+ * 1. @apiNote - additional notes and commentaries regarding the API
+ * 2. @implSpec - the implementation specification
+ * 3. @implNote - the commentaries and notes about the implementation
+ *
+ * For the detailed description of the new tags, see:
+ * https://blog.codefx.org/java/new-javadoc-tags/#apiNote-implSpec-and-implNote
+ *
+ * This script should be applied to the `subprojects` section of the root project,
+ * or to the specific child projects.
+ */
+
+javadoc {
+    source = sourceSets.main.allJava
+    options.tags = ["apiNote:a:API Note:",
+                    "implSpec:a:Implementation Requirements:",
+                    "implNote:a:Implementation Note:"]
+}

--- a/gradle/add-javadoc-tags.gradle
+++ b/gradle/add-javadoc-tags.gradle
@@ -22,7 +22,7 @@
  * This script enables the new Javadoc tags in the build.
  *
  * The tags are:
- * 1. @apiNote - additional notes and commentaries regarding the API
+ * 1. @apiNote - the additional notes and commentaries regarding the API
  * 2. @implSpec - the implementation specification
  * 3. @implNote - the commentaries and notes about the implementation
  *

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -110,6 +110,7 @@ final def test = [
 final def scripts = [
     testArtifacts          : "$rootDir/config/gradle/test-artifacts.gradle",
     testOutput             : "$rootDir/config/gradle/test-output.gradle",
+    addJavadocTags         : "$rootDir/config/gradle/add-javadoc-tags.gradle",
     filterInternalJavadocs : "$rootDir/config/gradle/filter-internal-javadoc.gradle",
     jacoco                 : "$rootDir/config/gradle/jacoco.gradle",
     publish                : "$rootDir/config/gradle/publish.gradle",


### PR DESCRIPTION
This PR resolves issue https://github.com/SpineEventEngine/config/issues/14.

Now the new Javadoc tags - `@apiNote`, `@implSpec` and `@implNote` - can be enabled in the build using:

```
apply from: deps.scripts.addJavadocTags
```