### PR TITLE
Enable `AssignmentToCollectionFieldFromParameter` inspection in Idea

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -20,6 +20,9 @@
     <inspection_tool class="ArchaicSystemPropertyAccess" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ArrayEquality" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AssignmentOrReturnOfFieldWithMutableType" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="AssignmentToCollectionFieldFromParameter" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignorePrivateMethods" value="true" />
+    </inspection_tool>
     <inspection_tool class="AssignmentToDateFieldFromParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignorePrivateMethods" value="true" />
     </inspection_tool>


### PR DESCRIPTION
This PR enables the `AssignmentToCollectionFieldFromParameter` warning in the common IntelliJ IDEA configuration.

Previously, the check was disabled by default, and the compiler said nothing when the `Collection` was copied by reference from the method parameter. 

Now, it emits a warning and suggests doing deep copy instead.

The private methods are ignored by this check.