### PR TITLE
Remove JUnit 4 dependencies

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -484,7 +484,17 @@
     </inspection_tool>
     <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="INFO" enabled="false" />
+      <scope name="Tests" level="INFO" enabled="true">
+        <extension name="InstanceMethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+          <option name="m_maxLength" value="32" />
+        </extension>
+        <extension name="JUnit4MethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+        </extension>
+      </scope>
       <scope name="Production" level="WARNING" enabled="true">
         <extension name="InstanceMethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -129,12 +129,10 @@ final def grpc = [
 
 //noinspection GroovyAssignabilityCheck
 final def test = [
-    junit4        : "junit:junit:4.12",
     junit5Api     : ["org.junit.jupiter:junit-jupiter-api:$versions.junit5",
                      "org.junit.jupiter:junit-jupiter-params:$versions.junit5",
                      "org.apiguardian:apiguardian-api:1.0.0"],
-    junit5Runner  : ["org.junit.jupiter:junit-jupiter-engine:$versions.junit5",
-                     "org.junit.vintage:junit-vintage-engine:$versions.junit5"],
+    junit5Runner  : "org.junit.jupiter:junit-jupiter-engine:$versions.junit5",
     junitPioneer  : "org.junit-pioneer:junit-pioneer:$versions.junitPioneer",
     slf4j         : "org.slf4j:slf4j-jdk14:$versions.slf4j",
     guavaTestlib  : "com.google.guava:guava-testlib:$versions.guava",


### PR DESCRIPTION
This PR removes JUnit 4 and JUnit vintage runner dependencies.

Also, the convention for test methods naming was changed. Now, the names should be in `camelCase` instead of `snake_case`. So, the related inspection profile was enabled.