### PR TITLE
Explicit UTF-8 encoding of source files during generation of javadoc

### DIFF
--- a/gradle/javadoc-options.gradle
+++ b/gradle/javadoc-options.gradle
@@ -38,6 +38,7 @@ javadoc {
     options.tags = ["apiNote:a:API Note:",
                     "implSpec:a:Implementation Requirements:",
                     "implNote:a:Implementation Note:"]
+    options.encoding = 'UTF-8'
 }
 
 // The below config avoids numerous warnings for missing @param tags.

--- a/gradle/javadoc-options.gradle
+++ b/gradle/javadoc-options.gradle
@@ -26,6 +26,9 @@
  * 2. @implSpec - the implementation specification
  * 3. @implNote - the commentaries and notes about the implementation
  *
+ * It also explicitly states the encoding of the source files from which the javadoc is composed,
+ * broadening the range of environments that the `javadoc` task is runnable under.
+ *
  * For the detailed description of the new tags, see:
  * https://blog.codefx.org/java/new-javadoc-tags/#apiNote-implSpec-and-implNote
  *

--- a/gradle/javadoc-options.gradle
+++ b/gradle/javadoc-options.gradle
@@ -26,8 +26,8 @@
  * 2. @implSpec - the implementation specification
  * 3. @implNote - the commentaries and notes about the implementation
  *
- * It also explicitly states the encoding of the source files from which the javadoc is composed,
- * broadening the range of environments that the `javadoc` task is runnable under.
+ * It also explicitly states the encoding of the source files from which the Javadoc is composed,
+ * ensuring correct execution of the `javadoc` task..
  *
  * For the detailed description of the new tags, see:
  * https://blog.codefx.org/java/new-javadoc-tags/#apiNote-implSpec-and-implNote


### PR DESCRIPTION
This PR adds an option to the `javadoc` gradle task that explicitly states UTF-8 encoding of source files.

This broadens the range of supported environments, since during the execution of the `javadoc` task under some Windows-based environments, encoding different from UTF-8 is assumed, resulting in unrecognized symbols.