### PR TITLE
Remove redundant period from `javadoc-options` documentation

### DIFF
--- a/gradle/javadoc-options.gradle
+++ b/gradle/javadoc-options.gradle
@@ -27,7 +27,7 @@
  * 3. @implNote - the commentaries and notes about the implementation
  *
  * It also explicitly states the encoding of the source files from which the Javadoc is composed,
- * ensuring correct execution of the `javadoc` task..
+ * ensuring correct execution of the `javadoc` task.
  *
  * For the detailed description of the new tags, see:
  * https://blog.codefx.org/java/new-javadoc-tags/#apiNote-implSpec-and-implNote


### PR DESCRIPTION
https://github.com/SpineEventEngine/config/pull/30 has introduced changes to the documentation of the `javadoc-options.gradle` file under the `gradle` directory, which added a redundant period.

This PR removes the redundant period.