### PR TITLE
Add Firebase admin to the list of dependencies.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -74,7 +74,7 @@ final def versions = [
     errorProneJavac  : "9+181-r4173-1", // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.6/build.gradle.kts    
     errorPronePlugin : "0.6",
     protobufPlugin   : "0.8.5",
-    appengineApi     : "1.9.67",
+    appengineApi     : "1.9.70",
     appenginePlugin  : "1.3.5",
     findBugs         : "3.0.2",
     guava            : "26.0-jre",
@@ -83,7 +83,7 @@ final def versions = [
     junit5           : "5.3.1",
     junitPioneer     : "0.2.0",
     truth            : "0.42",
-    httpClient       : "1.26.0",
+    httpClient       : "1.27.0",
     apacheValidator  : "1.4.0"
 ]
 
@@ -157,7 +157,7 @@ final def scripts = [
     filterInternalJavadocs : "$rootDir/config/gradle/filter-internal-javadoc.gradle",
     jacoco                 : "$rootDir/config/gradle/jacoco.gradle",
     publish                : "$rootDir/config/gradle/publish.gradle",
-    publishProto           : "$rootDir/config/gradle/publish-proto.gradle",
+    publishProto            : "$rootDir/config/gradle/publish-proto.gradle",
     javacArgs              : "$rootDir/config/gradle/javac-args.gradle"
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -84,7 +84,8 @@ final def versions = [
     junitPioneer     : "0.2.0",
     truth            : "0.42",
     httpClient       : "1.27.0",
-    apacheValidator  : "1.4.0"
+    apacheValidator  : "1.4.0",
+    firebaseAdmin    : "6.6.0",
 ]
 
 //noinspection GroovyAssignabilityCheck
@@ -110,6 +111,8 @@ final def build = [
     googleHttpClient       : "com.google.http-client:google-http-client:$versions.httpClient",
     appengineApi           : "com.google.appengine:appengine-api-1.0-sdk:$versions.appengineApi",
     apacheValidator        : "commons-validator:commons-validator:$versions.apacheValidator",
+
+    firebaseAdmin          : "com.google.firebase:firebase-admin:$versions.firebaseAdmin",
 
     ci: "true" == System.getenv("CI"),
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -160,7 +160,7 @@ final def scripts = [
     filterInternalJavadocs : "$rootDir/config/gradle/filter-internal-javadoc.gradle",
     jacoco                 : "$rootDir/config/gradle/jacoco.gradle",
     publish                : "$rootDir/config/gradle/publish.gradle",
-    publishProto            : "$rootDir/config/gradle/publish-proto.gradle",
+    publishProto           : "$rootDir/config/gradle/publish-proto.gradle",
     javacArgs              : "$rootDir/config/gradle/javac-args.gradle"
 ]
 


### PR DESCRIPTION
This PR adds `firebase-admin` to the list of build dependencies, and bumps `appengineApi` and `httpClient ` versions.