### PR TITLE
Force UTF-8 encoding for Java compile tasks

### DIFF
--- a/gradle/javac-args.gradle
+++ b/gradle/javac-args.gradle
@@ -22,19 +22,15 @@
  * This script configures Java Compiler.
  */
 
+
+// Explicitly states the encoding of the source and test source files, ensuring
+// correct execution of the `javac` task.
+
 compileJava {
-
-    // Explicitly states the encoding of the source files, ensuring correct execution
-    // of the `javac` task.
-
     options.encoding = 'UTF-8'
 }
 
 compileTestJava {
-
-    // Explicitly states the encoding of the test source files, ensuring correct execution
-    // of the `javac` task.
-
     options.encoding = 'UTF-8'
 }
 
@@ -47,6 +43,6 @@ tasks.withType(JavaCompile) {
     //
     // For more config details see: 
     //    https://github.com/tbroyer/gradle-errorprone-plugin/tree/v0.6#usage
-    
+
     options.errorprone.errorproneArgs << "-XepExcludedPaths:.*/generated/.*" << "-Xep:ClassCanBeStatic:OFF"
 }

--- a/gradle/javac-args.gradle
+++ b/gradle/javac-args.gradle
@@ -22,6 +22,22 @@
  * This script configures Java Compiler.
  */
 
+compileJava {
+
+    // Explicitly states the encoding of the source files, ensuring correct execution
+    // of the `javac` task.
+
+    options.encoding = 'UTF-8'
+}
+
+compileTestJava {
+
+    // Explicitly states the encoding of the test source files, ensuring correct execution
+    // of the `javac` task.
+
+    options.encoding = 'UTF-8'
+}
+
 tasks.withType(JavaCompile) {
 
     // Configure Error Prone:
@@ -32,5 +48,5 @@ tasks.withType(JavaCompile) {
     // For more config details see: 
     //    https://github.com/tbroyer/gradle-errorprone-plugin/tree/v0.6#usage
     
-    options.errorprone.errorproneArgs << "-XepExcludedPaths:.*/generated/.*" << "-Xep:ClassCanBeStatic:OFF"  
+    options.errorprone.errorproneArgs << "-XepExcludedPaths:.*/generated/.*" << "-Xep:ClassCanBeStatic:OFF"
 }


### PR DESCRIPTION
This PR fixes #38 issue.

Now Gradle Java compile tasks are set to use `UTF-8` as the default encoding,