### PR TITLE
Introduce common scripts for JavaScript modules

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -165,7 +165,8 @@ final def scripts = [
     publish                : "$rootDir/config/gradle/publish.gradle",
     publishProto           : "$rootDir/config/gradle/publish-proto.gradle",
     javacArgs              : "$rootDir/config/gradle/javac-args.gradle",
-    js                     : "$rootDir/config/gradle/js/js.gradle",
+    jsBuildTasks           : "$rootDir/config/gradle/js/build-tasks.gradle",
+    npmPublishTasks        : "$rootDir/config/gradle/js/npm-publish-tasks.gradle",
     npmCli                 : "$rootDir/config/gradle/js/npm-cli.gradle",
     updatePackageVersion   : "$rootDir/config/gradle/js/update-package-version.gradle"
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -159,12 +159,15 @@ final def test = [
 final def scripts = [
     testArtifacts          : "$rootDir/config/gradle/test-artifacts.gradle",
     testOutput             : "$rootDir/config/gradle/test-output.gradle",
-    javadocOptions          : "$rootDir/config/gradle/javadoc-options.gradle",
+    javadocOptions         : "$rootDir/config/gradle/javadoc-options.gradle",
     filterInternalJavadocs : "$rootDir/config/gradle/filter-internal-javadoc.gradle",
     jacoco                 : "$rootDir/config/gradle/jacoco.gradle",
     publish                : "$rootDir/config/gradle/publish.gradle",
     publishProto           : "$rootDir/config/gradle/publish-proto.gradle",
-    javacArgs              : "$rootDir/config/gradle/javac-args.gradle"
+    javacArgs              : "$rootDir/config/gradle/javac-args.gradle",
+    js                     : "$rootDir/config/gradle/js/js.gradle",
+    npmCli                 : "$rootDir/config/gradle/js/npm-cli.gradle",
+    updatePackageVersion   : "$rootDir/config/gradle/js/update-package-version.gradle"
 ]
 
 ext.deps = [

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -24,23 +24,7 @@
  * <p>Most of the tasks launch a separate process which runs an NPM CLI command, so it's necessary
  * that the NPM command line tool is installed.
  *
- * <p>The most important tasks:
- * <ul>
- *     <li>downloading NPM dependencies -                   {@code installDependencies};
- *     <li>compile Protobuf into JavaScript -               {@code compileProtoToJs};
- *     <li>publishing NPM artifacts into the NPM registry - {@code publishJs};
- *     <li>linking the module to the local NPM registry -   {@code link}
- * </ul>
- *
- * <p>It is expected that declared tasks will be additionally configured according to the
- * needs of a project. E.g. {@code prepareJsPublication} does nothing by default, so it
- * should be additionally configured.
- *
  * <p>This script doesn't configure Protobuf plugin and Spine's Protobuf JS plugin.
- *
- * <p>In order to publish the NPM module, it is required that the {@code NPM_TOKEN} environment
- * variable is set to a valid NPM auth token. If the token is not set, a dummy value is added to
- * the NPM execution process, which is sufficient for the local development.
  */
 
 ext {
@@ -49,7 +33,6 @@ ext {
     workDirectory = "$projectDir"
     nodeModulesDir = "$projectDir/node_modules"
     packageJsonFile = "$projectDir/package.json"
-    publicationDirectory = "$buildDir/npm-publication/"
 
     npm = { final String... command ->
         ext.executeNpm(workDirectory as File, command)
@@ -116,49 +99,6 @@ task buildJs {
     dependsOn installDependencies
     dependsOn compileProtoToJs
     assemble.dependsOn buildJs
-}
-
-/**
- * Copies the NPM publication files into a temporary directory which they are published from.
- *
- * <p>Files to copy should be specified by a user of the task.
- */
-task prepareJsPublication(type: Copy) {
-    group = JAVA_SCRIPT_TASK_GROUP
-    description = 'Prepares the NPM package for publish.'
-
-    into publicationDirectory
-
-    dependsOn buildJs
-}
-
-/**
- * Publishes the NPM package locally with `npm link`.
- */
-task link {
-    group = JAVA_SCRIPT_TASK_GROUP
-    description = "Publishes the NPM package locally."
-
-    doLast {
-        executeNpm(publicationDirectory as File, 'link')
-    }
-
-    dependsOn prepareJsPublication
-}
-
-/**
- * Publishes the NPM package with `npm publish`.
- */
-task publishJs {
-    group = JAVA_SCRIPT_TASK_GROUP
-    description = 'Publishes the NPM package.'
-
-    doLast {
-        executeNpm(publicationDirectory as File, 'publish')
-    }
-
-    dependsOn prepareJsPublication
-    publish.dependsOn publishJs
 }
 
 idea.module {

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -75,7 +75,7 @@ task installDependencies {
     description = 'Installs the JavaScript dependencies.'
 
     inputs.file packageJsonFile
-    inputs.files(fileTree(nodeModulesDir))
+    output.files(fileTree(nodeModulesDir))
 
     doLast {
         npm 'install'
@@ -83,16 +83,17 @@ task installDependencies {
 }
 
 /**
- * Cleans installed NPM packages.
+ * Cleans output of `buildJs` and dependant tasks.
  */
-task cleanDependencies {
+task cleanJs {
     group = JAVA_SCRIPT_TASK_GROUP
-    description = 'Cleans the JavaScript dependencies.'
+    description = 'Cleans the output of JavaScript build.'
 
-    clean.dependsOn cleanDependencies
+    clean.dependsOn cleanJs
 
     doLast {
-        delete nodeModulesDir
+        delete buildJs.outputs
+        delete installDependencies.outputs
     }
 }
 

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -96,6 +96,7 @@ task cleanJs {
 
     doLast {
         delete buildJs.outputs
+        delete compileProtoToJs.outputs
         delete installDependencies.outputs
     }
 }
@@ -114,7 +115,7 @@ task buildJs {
     dependsOn updatePackageVersion
     dependsOn installDependencies
     dependsOn compileProtoToJs
-    build.dependsOn buildJs
+    assemble.dependsOn buildJs
 }
 
 /**

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -75,7 +75,7 @@ task installDependencies {
     description = 'Installs the JavaScript dependencies.'
 
     inputs.file packageJsonFile
-    outputs.files(fileTree(nodeModulesDir))
+    outputs.dir nodeModulesDir
 
     doLast {
         npm 'install'
@@ -116,7 +116,7 @@ task buildJs {
 
 /**
  * Copies the NPM publication files into a temporary directory which they are published from.
- * 
+ *
  * <p>Files to copy should be specified by a user of the task.
  */
 task prepareJsPublication(type: Copy) {

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -40,204 +40,118 @@
  * the NPM execution process, which is sufficient for the local development.
  */
 
+ext {
+    JAVA_SCRIPT_TASK_GROUP = 'JavaScript'
+
+    workDirectory = "$projectDir"
+    nodeModulesDir = "$projectDir/node_modules"
+    packageJsonFile = "$projectDir/package.json"
+    publicationDirectory = "$buildDir/npm-publication/"
+
+    npm = { final String... command ->
+        ext.executeNpm(workDirectory as File, command)
+    }
+}
+
 apply from: deps.scripts.npmCli
 apply from: deps.scripts.updatePackageVersion
 
-//ext {
-//    JAVA_SCRIPT_TASK_GROUP = 'JavaScript'
-//
-//    workDirectory = "$projectDir"
-//    publicationDirectory = "$buildDir/npm-publication/"
-//    srcDir = "$projectDir/main"
-//    testSrcDir = "$projectDir/test"
-//    genProtoBaseDir = projectDir
-//    genProtoSubDir = "proto"
-//    genProtoMain = "$genProtoBaseDir/main/$genProtoSubDir"
-//    genProtoTest = "$genProtoBaseDir/test/$genProtoSubDir"
-//    nodeModulesDir = "$projectDir/node_modules"
-//
-//    npm = { final String... command ->
-//        ext.executeNpm(workDirectory as File, command)
-//    }
-//}
-//
-///**
-// * Compiles Protobuf sources into JavaScript.
-// *
-// * <p>This is a lifecycle task. It performs no action but triggers all the tasks which perform
-// * the compilation.
-// */
-//task compileProtoToJs {
-//    description = "Compiles Protobuf sources into JavaScript."
-//}
-//
-//protobuf {
-//    generatedFilesBaseDir = genProtoBaseDir
-//    protoc {
-//        artifact = deps.build.protoc
-//    }
-//    generateProtoTasks {
-//        all().each { final task ->
-//            task.builtins {
-//                // Do not use java builtin output in this project.
-//                remove java
-//
-//                // For information on JavaScript code generation please see
-//                // https://github.com/google/protobuf/blob/master/js/README.md
-//                js {
-//                    option "import_style=commonjs"
-//                    outputSubDir = genProtoSubDir
-//                }
-//
-//                task.generateDescriptorSet = true
-//                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/known_types.desc"
-//            }
-//            compileProtoToJs.dependsOn task
-//        }
-//    }
-//}
-//
-//apply plugin: 'io.spine.tools.proto-js-plugin'
-//
-///**
-// * Cleans old module dependencies and build outputs.
-// */
-//task deleteCompiled {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = 'Cleans old module dependencies and build outputs.'
-//
-//    doLast {
-//        delete buildJs.outputs
-//        delete installDependencies.outputs
-//        delete genProtoMain
-//        delete genProtoTest
-//    }
-//}
-//
-///**
-// * Installs the module dependencies using the `npm install` command.
-// */
-//task installDependencies {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = 'Installs the JavaScript dependencies.'
-//
-//    inputs.files "$projectDir/package.json"
-//    outputs.files nodeModulesDir
-//
-//    dependsOn compileProtoToJs
-//
-//    doLast {
-//        npm 'install'
-//    }
-//}
-//
-//protoJs {
-//    mainGenProtoDir = genProtoMain
-//    testGenProtoDir = genProtoTest
-//
-//    generateParsersTask().dependsOn compileProtoToJs
-//    installDependencies.dependsOn generateParsersTask()
-//}
-//
-///**
-// * Assembles the bundled version of JS sources.
-// *
-// * This task is an analog of `build` for JS.
-// *
-// * To include a task into the JS build, depend `buildJs` onto that task.
-// */
-//task buildJs {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = "Assembles the JavaScript source files."
-//
-//    outputs.files "$projectDir/dist"
-//
-//    doLast {
-//        npm 'run', 'build'
-//        npm 'run', 'build-dev'
-//    }
-//
-//    dependsOn installDependencies
-//}
-//
-///**
-// * Copies bundled JS sources to the temporary NPM publication directory.
-// */
-//task copyBundeledJs(type: Copy) {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = 'Copies assembled JavaScript sources to the NPM publication directory.'
-//
-//    from buildJs.outputs
-//    into "$publicationDirectory/dist"
-//
-//    dependsOn buildJs
-//}
-//
-///**
-// * Transpiles JS sources before publishing them to NPM.
-// *
-// * Puts the resulting files to the temporary NPM publication directory.
-// */
-//task transpileSources {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = "Transpiles sources before publishing."
-//
-//    doLast {
-//        npm 'run', 'transpile-before-publish'
-//    }
-//}
-//
-///**
-// * Copies all remaining files into a temporary NPM publication directory.
-// *
-// * This task finalizes assembling of files in the temporary NPM publication
-// * directory which they are published from.
-// */
-//task prepareJsPublication(type: Copy) {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = 'Prepares the NPM package for publish.'
-//
-//    from (projectDir) {
-//        include 'index.js'
-//        include 'package.json'
-//        include '.npmrc'
-//    }
-//
-//    into publicationDirectory
-//
-//    dependsOn buildJs
-//    dependsOn copyBundeledJs
-//    dependsOn transpileSources
-//}
-//
-///**
-// * Publishes the NPM package locally with `npm link`.
-// */
-//task link {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = "Publishes the NPM package locally."
-//
-//    doLast {
-//        executeNpm(publicationDirectory as File, 'link')
-//    }
-//
-//    dependsOn prepareJsPublication
-//}
-//
-///**
-// * Publishes the NPM package with `npm publish`.
-// */
-//task publishJs {
-//    group = JAVA_SCRIPT_TASK_GROUP
-//    description = 'Publishes the NPM package.'
-//
-//    doLast {
-//        executeNpm(publicationDirectory as File, 'publish')
-//    }
-//
-//    dependsOn prepareJsPublication
-//}
-//
-//build.dependsOn buildJs
-//clean.dependsOn deleteCompiled
-//publish.dependsOn publishJs
+/**
+ * Compiles Protobuf sources into JavaScript.
+ *
+ * <p>This is a lifecycle task. It performs no action but triggers all the tasks which perform
+ * the compilation.
+ */
+task compileProtoToJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Compiles Protobuf sources to JavaScript."
+}
+
+/**
+ * Installs the module dependencies using the `npm install` command.
+ */
+task installDependencies {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Installs the JavaScript dependencies.'
+
+    inputs.file packageJsonFile
+    inputs.files(fileTree(nodeModulesDir))
+
+    doLast {
+        npm 'install'
+    }
+}
+
+/**
+ * Cleans installed NPM packages.
+ */
+task cleanDependencies {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Cleans the JavaScript dependencies.'
+
+    clean.dependsOn cleanDependencies
+
+    doLast {
+        delete nodeModulesDir
+    }
+}
+
+/**
+ * Assembles the JS sources.
+ *
+ * This task is an analog of `build` for JS.
+ *
+ * To include a task into the JS build, depend `buildJs` onto that task.
+ */
+task buildJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Assembles the JavaScript source files."
+
+    dependsOn updatePackageVersion
+    dependsOn installDependencies
+    dependsOn compileProtoToJs
+    build.dependsOn buildJs
+}
+
+/**
+ * Copies the NPM publication files into a temporary directory which they are published from.
+ * 
+ * <p>Files to copy should be specified by a user of the task.
+ */
+task prepareJsPublication(type: Copy) {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Prepares the NPM package for publish.'
+
+    into publicationDirectory
+
+    dependsOn buildJs
+}
+
+/**
+ * Publishes the NPM package locally with `npm link`.
+ */
+task link {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Publishes the NPM package locally."
+
+    doLast {
+        executeNpm(publicationDirectory as File, 'link')
+    }
+
+    dependsOn prepareJsPublication
+}
+
+/**
+ * Publishes the NPM package with `npm publish`.
+ */
+task publishJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Publishes the NPM package.'
+
+    doLast {
+        executeNpm(publicationDirectory as File, 'publish')
+    }
+
+    dependsOn prepareJsPublication
+    publish.dependsOn publishJs
+}

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This build script contains a Gradle plugin for JavaScript modules.
+ *
+ * <p>The plugin configures NPM tools execution and connects the JS assembly and test routines
+ * with the Gradle execution process.
+ *
+ * <p>The plugin defines tasks for:
+ * <ul>
+ *     <li>downloading NPM dependencies -                   {@code installDependencies};
+ *     <li>compile Protobuf into JavaScript -               {@code compileProtoToJs};
+ *     <li>publishing NPM artifacts into the NPM registry - {@code publishJs};
+ *     <li>linking the module to the local NPM registry -   {@code link}
+ * </ul>
+ *
+ * <p>Most of the tasks launch a separate process which runs an NPM CLI command, so it's necessary
+ * that the NPM command line tool is installed.
+ *
+ * <p>In order to publish the NPM module, it is required that the {@code NPM_TOKEN} environment
+ * variable is set to a valid NPM auth token. If the token is not set, a dummy value is added to
+ * the NPM execution process, which is sufficient for the local development.
+ */
+
+apply from: deps.scripts.npmCli
+apply from: deps.scripts.updatePackageVersion
+
+//ext {
+//    JAVA_SCRIPT_TASK_GROUP = 'JavaScript'
+//
+//    workDirectory = "$projectDir"
+//    publicationDirectory = "$buildDir/npm-publication/"
+//    srcDir = "$projectDir/main"
+//    testSrcDir = "$projectDir/test"
+//    genProtoBaseDir = projectDir
+//    genProtoSubDir = "proto"
+//    genProtoMain = "$genProtoBaseDir/main/$genProtoSubDir"
+//    genProtoTest = "$genProtoBaseDir/test/$genProtoSubDir"
+//    nodeModulesDir = "$projectDir/node_modules"
+//
+//    npm = { final String... command ->
+//        ext.executeNpm(workDirectory as File, command)
+//    }
+//}
+//
+///**
+// * Compiles Protobuf sources into JavaScript.
+// *
+// * <p>This is a lifecycle task. It performs no action but triggers all the tasks which perform
+// * the compilation.
+// */
+//task compileProtoToJs {
+//    description = "Compiles Protobuf sources into JavaScript."
+//}
+//
+//protobuf {
+//    generatedFilesBaseDir = genProtoBaseDir
+//    protoc {
+//        artifact = deps.build.protoc
+//    }
+//    generateProtoTasks {
+//        all().each { final task ->
+//            task.builtins {
+//                // Do not use java builtin output in this project.
+//                remove java
+//
+//                // For information on JavaScript code generation please see
+//                // https://github.com/google/protobuf/blob/master/js/README.md
+//                js {
+//                    option "import_style=commonjs"
+//                    outputSubDir = genProtoSubDir
+//                }
+//
+//                task.generateDescriptorSet = true
+//                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/known_types.desc"
+//            }
+//            compileProtoToJs.dependsOn task
+//        }
+//    }
+//}
+//
+//apply plugin: 'io.spine.tools.proto-js-plugin'
+//
+///**
+// * Cleans old module dependencies and build outputs.
+// */
+//task deleteCompiled {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = 'Cleans old module dependencies and build outputs.'
+//
+//    doLast {
+//        delete buildJs.outputs
+//        delete installDependencies.outputs
+//        delete genProtoMain
+//        delete genProtoTest
+//    }
+//}
+//
+///**
+// * Installs the module dependencies using the `npm install` command.
+// */
+//task installDependencies {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = 'Installs the JavaScript dependencies.'
+//
+//    inputs.files "$projectDir/package.json"
+//    outputs.files nodeModulesDir
+//
+//    dependsOn compileProtoToJs
+//
+//    doLast {
+//        npm 'install'
+//    }
+//}
+//
+//protoJs {
+//    mainGenProtoDir = genProtoMain
+//    testGenProtoDir = genProtoTest
+//
+//    generateParsersTask().dependsOn compileProtoToJs
+//    installDependencies.dependsOn generateParsersTask()
+//}
+//
+///**
+// * Assembles the bundled version of JS sources.
+// *
+// * This task is an analog of `build` for JS.
+// *
+// * To include a task into the JS build, depend `buildJs` onto that task.
+// */
+//task buildJs {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = "Assembles the JavaScript source files."
+//
+//    outputs.files "$projectDir/dist"
+//
+//    doLast {
+//        npm 'run', 'build'
+//        npm 'run', 'build-dev'
+//    }
+//
+//    dependsOn installDependencies
+//}
+//
+///**
+// * Copies bundled JS sources to the temporary NPM publication directory.
+// */
+//task copyBundeledJs(type: Copy) {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = 'Copies assembled JavaScript sources to the NPM publication directory.'
+//
+//    from buildJs.outputs
+//    into "$publicationDirectory/dist"
+//
+//    dependsOn buildJs
+//}
+//
+///**
+// * Transpiles JS sources before publishing them to NPM.
+// *
+// * Puts the resulting files to the temporary NPM publication directory.
+// */
+//task transpileSources {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = "Transpiles sources before publishing."
+//
+//    doLast {
+//        npm 'run', 'transpile-before-publish'
+//    }
+//}
+//
+///**
+// * Copies all remaining files into a temporary NPM publication directory.
+// *
+// * This task finalizes assembling of files in the temporary NPM publication
+// * directory which they are published from.
+// */
+//task prepareJsPublication(type: Copy) {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = 'Prepares the NPM package for publish.'
+//
+//    from (projectDir) {
+//        include 'index.js'
+//        include 'package.json'
+//        include '.npmrc'
+//    }
+//
+//    into publicationDirectory
+//
+//    dependsOn buildJs
+//    dependsOn copyBundeledJs
+//    dependsOn transpileSources
+//}
+//
+///**
+// * Publishes the NPM package locally with `npm link`.
+// */
+//task link {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = "Publishes the NPM package locally."
+//
+//    doLast {
+//        executeNpm(publicationDirectory as File, 'link')
+//    }
+//
+//    dependsOn prepareJsPublication
+//}
+//
+///**
+// * Publishes the NPM package with `npm publish`.
+// */
+//task publishJs {
+//    group = JAVA_SCRIPT_TASK_GROUP
+//    description = 'Publishes the NPM package.'
+//
+//    doLast {
+//        executeNpm(publicationDirectory as File, 'publish')
+//    }
+//
+//    dependsOn prepareJsPublication
+//}
+//
+//build.dependsOn buildJs
+//clean.dependsOn deleteCompiled
+//publish.dependsOn publishJs

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -75,7 +75,7 @@ task installDependencies {
     description = 'Installs the JavaScript dependencies.'
 
     inputs.file packageJsonFile
-    output.files(fileTree(nodeModulesDir))
+    outputs.files(fileTree(nodeModulesDir))
 
     doLast {
         npm 'install'

--- a/gradle/js/js.gradle
+++ b/gradle/js/js.gradle
@@ -19,12 +19,12 @@
  */
 
 /**
- * This build script contains a Gradle plugin for JavaScript modules.
+ * This script declares common Gradle tasks required for JavaScript modules.
  *
- * <p>The plugin configures NPM tools execution and connects the JS assembly and test routines
- * with the Gradle execution process.
+ * <p>Most of the tasks launch a separate process which runs an NPM CLI command, so it's necessary
+ * that the NPM command line tool is installed.
  *
- * <p>The plugin defines tasks for:
+ * <p>The most important tasks:
  * <ul>
  *     <li>downloading NPM dependencies -                   {@code installDependencies};
  *     <li>compile Protobuf into JavaScript -               {@code compileProtoToJs};
@@ -32,8 +32,11 @@
  *     <li>linking the module to the local NPM registry -   {@code link}
  * </ul>
  *
- * <p>Most of the tasks launch a separate process which runs an NPM CLI command, so it's necessary
- * that the NPM command line tool is installed.
+ * <p>It is expected that declared tasks will be additionally configured according to the
+ * needs of a project. E.g. {@code prepareJsPublication} does nothing by default, so it
+ * should be additionally configured.
+ *
+ * <p>This script doesn't configure Protobuf plugin and Spine's Protobuf JS plugin.
  *
  * <p>In order to publish the NPM module, it is required that the {@code NPM_TOKEN} environment
  * variable is set to a valid NPM auth token. If the token is not set, a dummy value is added to
@@ -155,4 +158,8 @@ task publishJs {
 
     dependsOn prepareJsPublication
     publish.dependsOn publishJs
+}
+
+idea.module {
+    excludeDirs += file(nodeModulesDir)
 }

--- a/gradle/js/npm-cli.gradle
+++ b/gradle/js/npm-cli.gradle
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+/**
+ * The script allowing to run NPM commands from Gradle.
+ */
+
+
+/**
+ * The name of an environmental variable which contains the NPM auth token.
+ *
+ * <p>The token is used for publishing only.
+ *
+ * <p>It is required to set this variable before invoking NPM commands.
+ */
+ext.NPM_TOKEN_VARIABLE = "NPM_TOKEN"
+
+/**
+ * @return the value of `NPM_TOKEN` environmental variable or a stub value, if the token is not set
+ */
+String npmToken() {
+    final def tokenVarValue = System.getenv(NPM_TOKEN_VARIABLE)
+    final def token = tokenVarValue?.isEmpty() ? "PUBLISHING_FORBIDDEN" : tokenVarValue
+    return token
+}
+
+/**
+ * Executes the given command depending on the current OS.
+ *
+ * @param workingDirArg  the directory to execute the command in
+ * @param windowsCommand the command to execute is the OS is Windows
+ * @param unixCommand    the command to execute is the OS is Unix-like
+ * @param params         the command params, platform-independent
+ */
+def execMultiplatform(final File workingDirArg,
+                      final String windowsCommand,
+                      final String unixCommand,
+                      final String[] params) {
+    exec {
+        final String command = Os.isFamily(Os.FAMILY_WINDOWS) ? windowsCommand : unixCommand
+        final List resultingParams = [command] + Arrays.asList(params)
+        workingDir = workingDirArg
+        commandLine = resultingParams
+        environment NPM_TOKEN_VARIABLE, npmToken()
+    }
+}
+
+def runNpm(final File launchDir, final String[] params) {
+    execMultiplatform launchDir, 'npm.cmd', 'npm', params
+}
+
+ext {
+
+    /**
+     * Executes an {@code npm} CLI command.
+     *
+     * For example, to execute command {@code npm run compile}, invoke this function as follows:
+     * {@code npm 'run', 'compile'}
+     *
+     * @param params the command parameters
+     */
+    executeNpm = { final File from = projectDir, final String... params ->
+        runNpm(from, params)
+    }
+}

--- a/gradle/js/npm-publish-tasks.gradle
+++ b/gradle/js/npm-publish-tasks.gradle
@@ -26,7 +26,11 @@
  * the NPM execution process, which is sufficient for the local development.
  */
 
-final String publicationDirectory = "$buildDir/npm-publication/"
+apply from: deps.scripts.jsBuildTasks
+
+ext {
+    publicationDirectory = "$buildDir/npm-publication/"
+}
 
 /**
  * Copies the NPM publication files into a temporary directory which they are published from.

--- a/gradle/js/npm-publish-tasks.gradle
+++ b/gradle/js/npm-publish-tasks.gradle
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * The script declares tasks for publishing to NPM.
+ *
+ * <p>In order to publish the NPM module, it is required that the {@code NPM_TOKEN} environment
+ * variable is set to a valid NPM auth token. If the token is not set, a dummy value is added to
+ * the NPM execution process, which is sufficient for the local development.
+ */
+
+final String publicationDirectory = "$buildDir/npm-publication/"
+
+/**
+ * Copies the NPM publication files into a temporary directory which they are published from.
+ *
+ * <p>Files to copy should be specified by a user of the task.
+ */
+task prepareJsPublication(type: Copy) {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Prepares the NPM package for publish.'
+
+    into publicationDirectory
+
+    dependsOn buildJs
+}
+
+/**
+ * Publishes the NPM package locally with `npm link`.
+ */
+task link {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Publishes the NPM package locally."
+
+    doLast {
+        executeNpm(publicationDirectory as File, 'link')
+    }
+
+    dependsOn prepareJsPublication
+}
+
+/**
+ * Publishes the NPM package with `npm publish`.
+ */
+task publishJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Publishes the NPM package.'
+
+    doLast {
+        executeNpm(publicationDirectory as File, 'publish')
+    }
+
+    dependsOn prepareJsPublication
+    publish.dependsOn publishJs
+}

--- a/gradle/js/update-package-version.gradle
+++ b/gradle/js/update-package-version.gradle
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+/**
+ * This script updates the version in package.json.
+ */
+
+ext.JS_PACKAGE_FILE_LOCATION = "$projectDir/package.json"
+ext.JS_PACKAGES_VERSION = versionToPublishJs
+
+Object readJsonFile(final String sourcePath) {
+    def final packageJsonFile = file(sourcePath)
+    return new JsonSlurper().parseText(packageJsonFile.text)
+}
+
+String prettify(final String jsonText) {
+    def prettyText = JsonOutput.prettyPrint(jsonText)
+    prettyText = prettyText.replace('  ', ' ')
+    prettyText = prettyText.replaceAll(/\{\s+}/, '{}')
+    prettyText = prettyText + '\n'
+    return prettyText
+}
+
+void updatePackageJson(final jsonObject, final String destinationPath) {
+    def final updatedText = JsonOutput.toJson(jsonObject)
+    def final prettyText = prettify(updatedText)
+    new File(destinationPath).text = prettyText
+}
+
+void updatePackageJsonVersion() {
+    def final packageFile = JS_PACKAGE_FILE_LOCATION
+    def final packageJsonObject = readJsonFile(packageFile)
+
+    packageJsonObject['version'] = JS_PACKAGES_VERSION
+    updatePackageJson(packageJsonObject, packageFile)
+}
+
+updatePackageJsonVersion()

--- a/gradle/js/update-package-version.gradle
+++ b/gradle/js/update-package-version.gradle
@@ -22,37 +22,52 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
 /**
- * This script updates the version in package.json.
+ * This script declares a task to update the version in in a package.json file.
  */
 
-ext.JS_PACKAGE_FILE_LOCATION = "$projectDir/package.json"
-ext.JS_PACKAGES_VERSION = versionToPublishJs
+/**
+ * Updates the package.json version to the specified one.
+ * 
+ * <p>The path of the package.json and the version to set are set to default values,
+ * but can be set to custom values:
+ * 
+ * <pre>{@code
+ * updatePackageVersion.packageJsonPath = "custom/package.json"
+ * updatePackageVersion.newVersion = npmPackageVersion
+ * }</pre>
+ */
+task updatePackageVersion() {
+    
+    ext.packageJsonPath = "$projectDir/package.json"
+    ext.newVersion = versionToPublishJs
+
+    doLast {
+        updatePackageJsonVersion(packageJsonPath as String, newVersion as String)
+    }
+}
+
+void updatePackageJsonVersion(final String packageJsonPath, final String newVersion) {
+    def final packageJsonObject = readJsonFile(packageJsonPath)
+
+    packageJsonObject['version'] = newVersion
+    updatePackageJson(packageJsonObject, packageJsonPath)
+}
 
 Object readJsonFile(final String sourcePath) {
     def final packageJsonFile = file(sourcePath)
     return new JsonSlurper().parseText(packageJsonFile.text)
 }
 
-String prettify(final String jsonText) {
+static void updatePackageJson(final jsonObject, final String destinationPath) {
+    def final updatedText = JsonOutput.toJson(jsonObject)
+    def final prettyText = prettify(updatedText)
+    new File(destinationPath).text = prettyText
+}
+
+static String prettify(final String jsonText) {
     def prettyText = JsonOutput.prettyPrint(jsonText)
     prettyText = prettyText.replace('  ', ' ')
     prettyText = prettyText.replaceAll(/\{\s+}/, '{}')
     prettyText = prettyText + '\n'
     return prettyText
 }
-
-void updatePackageJson(final jsonObject, final String destinationPath) {
-    def final updatedText = JsonOutput.toJson(jsonObject)
-    def final prettyText = prettify(updatedText)
-    new File(destinationPath).text = prettyText
-}
-
-void updatePackageJsonVersion() {
-    def final packageFile = JS_PACKAGE_FILE_LOCATION
-    def final packageJsonObject = readJsonFile(packageFile)
-
-    packageJsonObject['version'] = JS_PACKAGES_VERSION
-    updatePackageJson(packageJsonObject, packageFile)
-}
-
-updatePackageJsonVersion()

--- a/gradle/js/update-package-version.gradle
+++ b/gradle/js/update-package-version.gradle
@@ -37,8 +37,10 @@ import groovy.json.JsonSlurper
  * }</pre>
  */
 task updatePackageVersion() {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Updates the version in package.json.'
     
-    ext.packageJsonPath = "$projectDir/package.json"
+    ext.packageJsonPath = packageJsonFile
     ext.newVersion = versionToPublishJs
 
     doLast {

--- a/gradle/js/update-package-version.gradle
+++ b/gradle/js/update-package-version.gradle
@@ -28,8 +28,8 @@ import groovy.json.JsonSlurper
 /**
  * Updates the package.json version to the specified one.
  * 
- * <p>The path of the package.json and the version to set are set to default values,
- * but can be set to custom values:
+ * <p>The path of the package.json and the version to set has default values,
+ * but can be redefined:
  * 
  * <pre>{@code
  * updatePackageVersion.packageJsonPath = "custom/package.json"


### PR DESCRIPTION
This PR brings common Gradle tasks for JavaScript modules.

In particular:
- Tasks to run NPM commands from Gradle scripts.
- Tasks to install NPM dependencies and clean them up.
- A task to update a version of a `package.json`.
- A bunch of tasks for publishing to NPM.
