### PR TITLE
Add PMD rules and the Gradle configuration script

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -168,7 +168,8 @@ final def scripts = [
     jsBuildTasks           : "$rootDir/config/gradle/js/build-tasks.gradle",
     npmPublishTasks        : "$rootDir/config/gradle/js/npm-publish-tasks.gradle",
     npmCli                 : "$rootDir/config/gradle/js/npm-cli.gradle",
-    updatePackageVersion   : "$rootDir/config/gradle/js/update-package-version.gradle"
+    updatePackageVersion   : "$rootDir/config/gradle/js/update-package-version.gradle",
+    pmd                    : "$rootDir/config/gradle/pmd.gradle"        
 ]
 
 ext.deps = [

--- a/gradle/pmd.gradle
+++ b/gradle/pmd.gradle
@@ -30,6 +30,8 @@
 pmd {
     toolVersion = '6.11.0'
     consoleOutput= true
+
+    // The build is going to fail in case of violations.
     ignoreFailures = false
 
     // Disable the default rule set to use the custom rules (see below).

--- a/gradle/pmd.gradle
+++ b/gradle/pmd.gradle
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/*
+ * This script configures Gradle PMD plugin.
+ *
+ * Currently a warning on "use incremental analysis" is always emitted. But there is no way
+ * to enable it due to a Gradle issue.
+ *
+ * See https://github.com/gradle/gradle/issues/8277.
+ */
+pmd {
+    toolVersion = '6.11.0'
+    consoleOutput= true
+    ignoreFailures = false
+
+    // Disable the default rule set to use the custom rules (see below).
+    ruleSets = []
+
+    // A set of custom rules.
+    ruleSetFiles = files("$rootDir/config/quality/pmd.xml")
+
+    reportsDir = file("build/reports/pmd")
+
+    // Just analyze the main sources; do not analyze tests.
+    sourceSets = [sourceSets.main]
+}

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2019, TeamDev. All rights reserved.
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<ruleset name="Spine ruleset">
+
+    <description>
+        A set of PMD rules applied to Spine Event Engine projects.
+    </description>
+
+    <!-- Always exclude the Protobuf-generated files, as they generate a lot of warnings. -->
+    <exclude-pattern>.*/generated/.*</exclude-pattern>
+
+    <rule ref="category/java/errorprone.xml/NonCaseLabelInSwitchStatement"/>
+    <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
+    <rule ref="category/java/codestyle.xml/NoPackage"/>
+    <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
+    <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause"/>
+    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
+
+    <!-- Will become deprecated in Java 9 onwards. -->
+    <rule ref="category/java/errorprone.xml/AvoidCallingFinalize"/>
+
+    <rule ref="category/java/performance.xml/StringToString"/>
+    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+    <rule ref="category/java/errorprone.xml/EmptyIfStmt" />
+    <rule ref="category/java/errorprone.xml/EmptyStatementBlock" />
+
+    <!-- Will become deprecated in Java 9 onwards. -->
+    <rule ref="category/java/errorprone.xml/EmptyFinalizer" />
+
+    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock" />
+    <rule ref="category/java/errorprone.xml/EmptySwitchStatements" />
+    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock" />
+    <rule ref="category/java/errorprone.xml/EmptyTryBlock" />
+    <rule ref="category/java/codestyle.xml/DontImportJavaLang" />
+    <rule ref="category/java/performance.xml/BooleanInstantiation" />
+    <rule ref="category/java/performance.xml/ByteInstantiation" />
+    <rule ref="category/java/performance.xml/IntegerInstantiation" />
+    <rule ref="category/java/performance.xml/LongInstantiation" />
+    <rule ref="category/java/performance.xml/ShortInstantiation" />
+    <rule ref="category/java/performance.xml/StringInstantiation" />
+    <rule ref="category/java/design.xml/ExcessiveParameterList" />
+    <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
+    <rule ref="category/java/design.xml/ExcessiveClassLength" />
+    <rule ref="category/java/design.xml/ExcessiveMethodLength" />
+    <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters" />
+    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock" />
+    <rule ref="category/java/design.xml/AvoidThrowingNullPointerException" />
+    <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" />
+    <rule ref="category/java/design.xml/SimplifyBooleanExpressions" />
+    <rule ref="category/java/design.xml/SimplifyBooleanReturns" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryReturn" />
+    <rule ref="category/java/bestpractices.xml/UnusedImports" />
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+    <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
+    <rule ref="category/java/errorprone.xml/EqualsNull" />
+    <rule ref="category/java/codestyle.xml/ControlStatementBraces" />
+    <rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
+    <rule ref="category/java/errorprone.xml/CheckSkipResult" />
+    <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass" />
+    <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+        <properties>
+            <!-- Override the default "[A-Z][a-zA-Z0-9]+(Utils?|Helper)" value. -->
+            <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]*"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass" />
+    <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap" />
+    <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" />
+    <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard" />
+    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
+    <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody" />
+    <rule ref="category/java/multithreading.xml/DontCallThreadRun" />
+    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices" />
+    <rule ref="category/java/errorprone.xml/EmptyInitializer" />
+    <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" />
+    <rule ref="category/java/codestyle.xml/GenericsNaming" />
+    <rule ref="category/java/codestyle.xml/CallSuperInConstructor" />
+
+    <!-- Do we need that at all, given Google Truth? -->
+    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert" />
+
+    <rule ref="category/java/errorprone.xml/BrokenNullCheck" />
+    <rule ref="category/java/codestyle.xml/MethodNamingConventions" />
+    <rule ref="category/java/codestyle.xml/ExtendsObject" />
+    <rule ref="category/java/errorprone.xml/NonStaticInitializer" />
+    <rule ref="category/java/codestyle.xml/PackageCase" />
+    <rule ref="category/java/design.xml/SingularField" />
+    <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInComparisons" />
+    <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInCaseInsensitiveComparisons" />
+    <rule ref="category/java/errorprone.xml/AssignmentToNonFinalStatic" />
+    <rule ref="category/java/performance.xml/UseStringBufferForStringAppends" />
+    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter" />
+    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault" />
+    <rule ref="category/java/errorprone.xml/DoNotCallSystemExit" />
+    <rule ref="category/java/design.xml/NPathComplexity" />
+    <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
+    <rule ref="category/java/design.xml/CollapsibleIfStatements" />
+    <rule ref="category/java/performance.xml/SimplifyStartsWith" />
+    <rule ref="category/java/design.xml/FinalFieldCouldBeStatic" />
+    <rule ref="category/java/performance.xml/UseStringBufferLength" />
+    <rule ref="category/java/design.xml/TooManyFields" />
+    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName" />
+
+    <!-- Possible duplication with `ReplaceVectorWithList` -->
+    <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector" />
+
+    <rule ref="category/java/performance.xml/UseArraysAsList" />
+    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals" />
+    <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings" />
+    <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine" />
+    <rule ref="category/java/design.xml/LogicInversion" />
+    <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange" />
+    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators" />
+
+    <rule ref="category/java/errorprone.xml/JUnitStaticSuite" />
+    <rule ref="category/java/errorprone.xml/JUnitSpelling" />
+    <rule ref="category/java/design.xml/SimplifyBooleanAssertion" />
+    <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion" />
+
+</ruleset>


### PR DESCRIPTION
This PR intents to configure a PMD static code analysis during the Gradle build.

In scope of this request a set of PMD rules that are currently being used at Codacy is composed as XML. If any of the rules is violated, the build fails.

The generated codebase and the test sources are currently excluded from the analysis.

There is a `deps.scripts.pmd` script exported for a convenience.