### PR TITLE
Add Checkstyle rules and the Gradle configuration script

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -18,30 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 /*
- * This script configures Gradle PMD plugin.
- *
- * Currently a warning on "use incremental analysis" is always emitted. But there is no way
- * to enable it due to a Gradle issue.
- *
- * See https://github.com/gradle/gradle/issues/8277.
+ * This script configures Gradle Checkstyle plugin.
  */
-pmd {
-    toolVersion = "${deps.versions.pmd}"
-    consoleOutput= true
 
-    // The build is going to fail in case of violations.
-    ignoreFailures = false
+checkstyle {
+    toolVersion = "${deps.versions.checkstyle}"
+    configFile = file("$rootDir/config/quality/checkstyle.xml")
 
-    // Disable the default rule set to use the custom rules (see below).
-    ruleSets = []
-
-    // A set of custom rules.
-    ruleSetFiles = files("$rootDir/config/quality/pmd.xml")
-
-    reportsDir = file("build/reports/pmd")
-
-    // Just analyze the main sources; do not analyze tests.
-    sourceSets = [sourceSets.main]
+    // Disable checking the test sources.
+    checkstyleTest.enabled = false
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -73,6 +73,8 @@ final def versions = [
     errorProne       : "2.3.2",
     errorProneJavac  : "9+181-r4173-1", // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.6/build.gradle.kts    
     errorPronePlugin : "0.6",
+    pmd              : "6.11.0",
+    checkstyle       : "8.17",
     protobufPlugin   : "0.8.5",
     appengineApi     : "1.9.70",
     appenginePlugin  : "1.3.5",
@@ -169,7 +171,8 @@ final def scripts = [
     npmPublishTasks        : "$rootDir/config/gradle/js/npm-publish-tasks.gradle",
     npmCli                 : "$rootDir/config/gradle/js/npm-cli.gradle",
     updatePackageVersion   : "$rootDir/config/gradle/js/update-package-version.gradle",
-    pmd                    : "$rootDir/config/gradle/pmd.gradle"        
+    pmd                    : "$rootDir/config/gradle/pmd.gradle",
+    checkstyle             : "$rootDir/config/gradle/checkstyle.gradle"
 ]
 
 ext.deps = [

--- a/quality/checkstyle-suppressions.xml
+++ b/quality/checkstyle-suppressions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ Copyright 2019, TeamDev. All rights reserved.
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+
+    <!-- Suppress all checks for the Protobuf-generated files. -->
+    <suppress files=".*/generated/.*" checks=".*"/>
+
+</suppressions>

--- a/quality/checkstyle.xml
+++ b/quality/checkstyle.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Copyright 2019, TeamDev. All rights reserved.
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+
+    <module name="SuppressionFilter">
+        <property name="file" value="config/quality/checkstyle-suppressions.xml"/>
+        <property name="optional" value="false"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="AvoidStarImport"/>
+        <module name="EmptyCatchBlock"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InnerAssignment"/>
+        <module name="JavadocType"/>
+        <module name="MissingDeprecated"/>
+        <module name="MissingOverride"/>
+        <module name="MultipleStringLiterals"/>
+        <module name="NeedBraces"/>
+        <module name="OneStatementPerLine"/>
+        <module name="PackageAnnotation"/>
+        <module name="ParameterNumber"/>
+        <module name="RedundantImport"/>
+
+        <!-- Allow to-do comments, but emit a warning. -->
+        <module name="TodoComment">
+            <property name="severity" value="warning"/>
+        </module>
+    </module>
+    <module name="JavadocPackage"/>
+    <module name="NewlineAtEndOfFile"/>
+    <module name="UniqueProperties"/>
+</module>


### PR DESCRIPTION
This PR intents to configure a Checkstyle static code analysis during the Gradle build.

In scope of this request a set of Checkstyle modules that are currently being used at Codacy is composed as XML. If any of the modules emits a violation, the build fails.

A presense of `TODO` comments is covered with a Checkstyle module, but it is configured to emit warnings, not errors.

The generated codebase and the test sources are currently excluded from the analysis.

There is a `deps.scripts.checkstyle` script exported for a convenience.