### PR TITLE
Add "testJs" Gradle task.

### DIFF
--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -101,6 +101,20 @@ task buildJs {
     assemble.dependsOn buildJs
 }
 
+/**
+ * Tests the JS sources.
+ *
+ * This task is an analog of `test` for JS.
+ */
+task testJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Tests the JavaScript source files."
+
+    dependsOn installDependencies
+    dependsOn compileProtoToJs
+    test.dependsOn testJs
+}
+
 idea.module {
     excludeDirs += file(nodeModulesDir)
 }

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -104,7 +104,8 @@ task buildJs {
 /**
  * Tests the JS sources.
  *
- * This task is automatically executed after `test` task if it is scheduled to run.
+ * If `check` task is scheduled to run, this task is automatically added to
+ * the task graph and will be executed after `test` task completion.
  */
 task testJs {
     group = JAVA_SCRIPT_TASK_GROUP
@@ -112,7 +113,9 @@ task testJs {
 
     dependsOn installDependencies
     dependsOn compileProtoToJs
-    test.finalizedBy testJs
+    check.dependsOn testJs
+
+    testJs.mustRunAfter test
 }
 
 idea.module {

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -104,7 +104,7 @@ task buildJs {
 /**
  * Tests the JS sources.
  *
- * This task is an analog of `test` for JS.
+ * This task is automatically executed after `test` task if it is scheduled to run.
  */
 task testJs {
     group = JAVA_SCRIPT_TASK_GROUP
@@ -112,7 +112,7 @@ task testJs {
 
     dependsOn installDependencies
     dependsOn compileProtoToJs
-    test.dependsOn testJs
+    test.finalizedBy testJs
 }
 
 idea.module {


### PR DESCRIPTION
In this PR the "testJs" task was added to the set of JS-build tasks defined in the `/gradle/js/build-tasks.gradle`.

The `check` task is made dependent on `testJs` execution. Note, if the Gradle task graph contains `test` task, the `testJs` task will run __after__ it.