### PR TITLE
Force Gradle Protobuf plugin version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -212,7 +212,10 @@ ext.forceConfiguration = { final configurationContainer ->
                     "com.squareup.okio:okio:1.13.0",
 
                     // Force discontinued transitive dependency until everybody migrates off it.
-                    "org.checkerframework:checker-compat-qual:2.5.3"
+                    "org.checkerframework:checker-compat-qual:2.5.3",
+
+                    // Force the Gradle Protobuf plugin version.
+                    deps.build.gradlePlugins.protobuf
             )
         }
     }


### PR DESCRIPTION
To avoid the version clashes during the build, this PR enables a forced version of Gradle Protobuf plugin.