### PR TITLE
Add default Model Compiler configuration

### DIFF
--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This script configures Spine defaults for the Model Compiler code generation.
+ *
+ * Applies the following interfaces generation configurations:
+ * — all messages in Protobuf files ending with "commands.proto" are marked as `CommandMessage`;
+ * — all messages in Protobuf files ending with "events.proto" are marked as `EventMessage`;
+ * — all messages in Protobuf files ending with "rejections.proto" are marked as `RejectionMessage`;
+ * — all messages that qualify to be UUID values are marked as `UuidValue`.
+ *
+ * And the following method generations are applied:
+ * — all messages that qualify to be UUID values have helper `generate` and `of` methods
+ *   generated using `UuidMethodFactory`;
+ * — all messages that have validating builders have helper `vBuilder` and instance `toVBuilder`
+ *   methods generated using `VBuilderMethodFactory`.
+ *
+ * Be aware that the root project `buildscript` should already have a classpath
+ * `io.spine.tools:spine-model-compiler:<version>` classpath dependency.
+ */
+
+modelCompiler {
+    generateInterfaces {
+        mark filePattern().endsWith("commands.proto"), "io.spine.base.CommandMessage"
+        mark filePattern().endsWith("events.proto"), "io.spine.base.EventMessage"
+        mark filePattern().endsWith("rejections.proto"), "io.spine.base.RejectionMessage"
+        mark uuidMessage(), "io.spine.base.UuidValue"
+    }
+    generateMethods {
+        useFactory "io.spine.tools.protoc.method.uuid.UuidMethodFactory", uuidMessage()
+        useFactory "io.spine.tools.protoc.method.vbuilder.VBuilderMethodFactory", filePattern().all()
+    }
+}

--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -38,14 +38,16 @@
  */
 
 modelCompiler {
-    generateInterfaces {
-        mark filePattern().endsWith("commands.proto"), "io.spine.base.CommandMessage"
-        mark filePattern().endsWith("events.proto"), "io.spine.base.EventMessage"
-        mark filePattern().endsWith("rejections.proto"), "io.spine.base.RejectionMessage"
-        mark uuidMessage(), "io.spine.base.UuidValue"
+
+    interfaces {
+        mark messages().inFiles(suffix: "commands.proto"), asType("io.spine.base.CommandMessage")
+        mark messages().inFiles(suffix: "events.proto"), asType("io.spine.base.EventMessage")
+        mark messages().inFiles(suffix: "rejections.proto"), asType("io.spine.base.RejectionMessage")
+        mark messages().uuid(), asType("io.spine.base.UuidValue")
     }
-    generateMethods {
-        useFactory "io.spine.tools.protoc.method.uuid.UuidMethodFactory", uuidMessage()
-        useFactory "io.spine.tools.protoc.method.vbuilder.VBuilderMethodFactory", filePattern().all()
+
+    methods {
+        applyFactory "io.spine.tools.protoc.method.uuid.UuidMethodFactory", messages().uuid()
+        applyFactory "io.spine.tools.protoc.method.vbuilder.VBuilderMethodFactory", messages.all()
     }
 }

--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -25,10 +25,10 @@
  * — all messages in Protobuf files ending with "commands.proto" are marked as `CommandMessage`;
  * — all messages in Protobuf files ending with "events.proto" are marked as `EventMessage`;
  * — all messages in Protobuf files ending with "rejections.proto" are marked as `RejectionMessage`;
- * — all messages that qualify to be UUID values are marked as `UuidValue`.
+ * — all messages that qualify to be UUID messages are marked as `UuidValue`.
  *
  * And the following method generations are applied:
- * — all messages that qualify to be UUID values have helper `generate` and `of` methods
+ * — all messages that qualify to be UUID messages have helper `generate` and `of` methods
  *   generated using `UuidMethodFactory`;
  * — all messages that have validating builders have helper `vBuilder` and instance `toVBuilder`
  *   methods generated using `VBuilderMethodFactory`.

--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -48,6 +48,6 @@ modelCompiler {
 
     methods {
         applyFactory "io.spine.tools.protoc.method.uuid.UuidMethodFactory", messages().uuid()
-        applyFactory "io.spine.tools.protoc.method.vbuilder.VBuilderMethodFactory", messages.all()
+        applyFactory "io.spine.tools.protoc.method.vbuilder.VBuilderMethodFactory", messages().all()
     }
 }


### PR DESCRIPTION
The default Model Compiler configuration is now published as a `model-compiler` gradle script.

The script should be applied to every project that tends to have Spine code generation defaults.

Applying such configuration is mandatory for projects that use the version of the `base` module where the defaults are already not configured in Java (see [base#369](https://github.com/SpineEventEngine/base/issues/369) for details).