### PR TITLE
Fail JS builds if NPM dependencies contain vulnerabilities.

### DIFF
--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -77,7 +77,7 @@ task installNodePackages {
 /**
  * Audits the module dependencies using the `npm audit` command.
  *
- * Sets minimum level of vulnerability for npm audit to exit with a non-zero exit code
+ * Sets the minimum level of vulnerability for `npm audit` to exit with a non-zero exit code
  * to "high".
  */
 task auditNodePackages {

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -69,6 +69,8 @@ task installNodePackages {
     outputs.dir nodeModulesDir
 
     doLast {
+        // To turn off npm audit when installing all packages. Use `auditNodePackages` task
+        // to check installed Node packages for vulnerabilities.
         npm 'set', 'audit', 'false'
         npm 'install'
     }

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -55,17 +55,54 @@ task compileProtoToJs {
 
 /**
  * Installs the module dependencies using the `npm install` command.
+ *
+ * The `npm install` command is executed with the vulnerability check disabled since
+ * it cannot fail the task execution despite on vulnerabilities found.
+ *
+ * To check installed Node packages for vulnerabilities execute `auditNodePackages` task.
  */
-task installDependencies {
+task installNodePackages {
     group = JAVA_SCRIPT_TASK_GROUP
-    description = 'Installs the JavaScript dependencies.'
+    description = 'Installs the module`s Node dependencies.'
 
     inputs.file packageJsonFile
     outputs.dir nodeModulesDir
 
     doLast {
+        npm 'set', 'audit', 'false'
         npm 'install'
     }
+}
+
+/**
+ * Audits the module dependencies using the `npm audit` command.
+ *
+ * Sets minimum level of vulnerability for npm audit to exit with a non-zero exit code
+ * to "high".
+ */
+task auditNodePackages {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Audits the module`s Node dependencies.'
+
+    inputs.dir nodeModulesDir
+
+    doLast {
+        npm 'set', 'audit-level', 'high'
+        npm 'audit'
+    }
+}
+
+/**
+ * Installs the module dependencies and checks them for vulnerabilities.
+ */
+task installDependencies {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Installs the JavaScript dependencies.'
+
+    dependsOn installNodePackages
+    dependsOn auditNodePackages
+
+    auditNodePackages.mustRunAfter installNodePackages
 }
 
 /**
@@ -80,7 +117,7 @@ task cleanJs {
     doLast {
         delete buildJs.outputs
         delete compileProtoToJs.outputs
-        delete installDependencies.outputs
+        delete installNodePackages.outputs
     }
 }
 


### PR DESCRIPTION
### Summary
 The goal of this PR is to make JS builds to fail if installed dependencies contain vulnerabilities.

The JS-build tasks for installation of module dependencies: 

- `installNodePackages` - Installs the module dependencies using the `npm install` command. The `npm install` command is executed with the vulnerability check disabled since it cannot fail the task execution despite on vulnerabilities found;
- `auditNodePackages` - Audits the module dependencies using the `npm audit` command. Sets the minimum level of vulnerability for `npm audit` to exit with a non-zero exit code to "high".
- `installDependencies` - Installs the module dependencies and checks them for vulnerabilities. Depends on `installNodePackages` and `auditNodePackages` execution; 

This PR addresses https://github.com/SpineEventEngine/web/issues/74