### PR TITLE
Mention limitation of `npm` version when using JS build tasks.

### DIFF
--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -94,8 +94,13 @@ task auditNodePackages {
     }
 }
 
+// TODO:2019-03-25:yegor.udovchenko: Remove mentioning an explicit npm upgrade in `.travis.yml`
+// (when Travis has a good version by default).
+// See https://github.com/SpineEventEngine/config/issues/53
 /**
  * Installs the module dependencies and checks them for vulnerabilities.
+ *
+ * Note when using this task in your project, the `npm` version should be `6.1.0` or higher.
  */
 task installDependencies {
     group = JAVA_SCRIPT_TASK_GROUP


### PR DESCRIPTION
In this PR the `installDependencies` JS build tasks defined in `gradle\js\build-tasks.gradle` was documented with mentioning that the npm version of a project must be `6.1.0` or higher. This version is required by `npm audit` functionality to detect module dependencies with vulnerabilities.

See the https://github.com/SpineEventEngine/config/issues/53.