### PR TITLE
Ignore `io.spine.tools` group to report licenses only for 3rd-party

### DIFF
--- a/gradle/license-report-project.gradle
+++ b/gradle/license-report-project.gradle
@@ -45,7 +45,7 @@ apply from: deps.scripts.licenseReportCommon
 final reportOutputDir = "${project.buildDir}" + licenseReportConfig.relativePath
 licenseReport {
     outputDir = "$reportOutputDir"
-    excludeGroups = ['io.spine']
+    excludeGroups = ['io.spine', 'io.spine.tools']
     configurations = ALL
     renderers = [new MarkdownReportRenderer(licenseReportConfig.outputFilename)]
 }


### PR DESCRIPTION
This PR adjusts the license report scripts to avoid including the dependencies onto Spine artifacts into the report.