### PR TITLE
Ignore `io.spine.gcloud` group from license report

### DIFF
--- a/gradle/license-report-project.gradle
+++ b/gradle/license-report-project.gradle
@@ -45,7 +45,7 @@ apply from: deps.scripts.licenseReportCommon
 final reportOutputDir = "${project.buildDir}" + licenseReportConfig.relativePath
 licenseReport {
     outputDir = "$reportOutputDir"
-    excludeGroups = ['io.spine', 'io.spine.tools']
+    excludeGroups = ['io.spine', 'io.spine.tools', 'io.spine.gcloud']
     configurations = ALL
     renderers = [new MarkdownReportRenderer(licenseReportConfig.outputFilename)]
 }


### PR DESCRIPTION
This PR adds `io.spine.gcloud` group to the list of ignored groups during the composition of license report.