### PR TITLE
Show full stacktraces in case of an exception during tests

### DIFF
--- a/gradle/test-output.gradle
+++ b/gradle/test-output.gradle
@@ -33,6 +33,7 @@ tasks.withType(Test).each {
         showExceptions = true
         showStackTraces = true
         showCauses = true
+        exceptionFormat = 'full'
     }
 
     it.afterSuite { final testDescriptor, final result ->


### PR DESCRIPTION
The new logging configuration prints all necessary exception information directly to the console and thus we do not really need to check the test suite report to find out what happened in the test.