### PR TITLE
Disable audit of NPM packages for JS build pipeline.

### DIFF
--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -94,6 +94,11 @@ task auditNodePackages {
     }
 }
 
+// TODO:2019-05-22:yegor.udovchenko: Enable audit of NPM packages when
+// `npm audit` command stops failing due to NPM server overload.
+// See: https://github.com/SpineEventEngine/config/issues/64
+auditNodePackages.enabled = false
+
 /**
  * Installs the module dependencies and checks them for vulnerabilities.
  */


### PR DESCRIPTION
See https://github.com/SpineEventEngine/config/issues/64