### PR TITLE
Add `Roaster` dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -132,6 +132,9 @@ final def build = [
     firebaseAdmin          : "com.google.firebase:firebase-admin:$versions.firebaseAdmin",
     jacksonDatabind        : "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
 
+    roasterApi             : "org.jboss.forge.roaster:roaster-api:$versions.roaster",
+    roasterJdt             : "org.jboss.forge.roaster:roaster-jdt:$versions.roaster",
+
     ci: "true" == System.getenv("CI"),
 
     gradlePlugins: [


### PR DESCRIPTION
This PR adds `Roaster` library dependencies for the convenient reusage in Spine modules. 

Previously we had a library version, but not the dependencies themselves.

Is a part of https://github.com/SpineEventEngine/base/pull/430.