### PR TITLE
Extract generic IDEA configurations into a separate script

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -196,7 +196,8 @@ final def scripts = [
     licenseReportCommon    : "$rootDir/config/gradle/license-report-common.gradle",
     projectLicenseReport   : "$rootDir/config/gradle/license-report-project.gradle",
     repoLicenseReport      : "$rootDir/config/gradle/license-report-repo.gradle",
-    generatePom            : "$rootDir/config/gradle/generate-pom.gradle"
+    generatePom            : "$rootDir/config/gradle/generate-pom.gradle",
+    idea                   : "$rootDir/config/gradle/idea.gradle"
 ]
 
 ext.deps = [

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This script performs the default Intellij IDEA configuration:
+ *
+ * <ul>
+ *     <li>applies`idea` plugin;
+ *     <li>applies `org.inferred.processors` plugin;
+ *     <li>sets VCS mappings to Git;
+ *     <li>configures IDEA modules merging behavior;
+ *     <li>enforces javadocs and sources download.
+ * </ul>
+ */
+
+plugins {
+    id 'idea'
+    id 'org.inferred.processors' version '2.2.0'
+}
+
+idea {
+    module {
+        downloadJavadoc = true
+        downloadSources = true
+
+        iml {
+            beforeMerged { final module ->
+                module.dependencies.clear()
+            }
+            whenMerged { final module ->
+                module.dependencies*.exported = true
+            }
+        }
+    }
+    project {
+        ipr {
+            beforeMerged { final project ->
+                project.modulePaths.clear()
+            }
+            withXml { final provider ->
+                provider.node.component
+                        .find { it.@name == 'VcsDirectoryMappings' }
+                        .mapping.@vcs = 'Git'
+            }
+        }
+    }
+}

--- a/gradle/idea.gradle
+++ b/gradle/idea.gradle
@@ -26,7 +26,7 @@
  *     <li>applies `org.inferred.processors` plugin;
  *     <li>sets VCS mappings to Git;
  *     <li>configures IDEA modules merging behavior;
- *     <li>enforces javadocs and sources download.
+ *     <li>enforces Javadocs and sources download.
  * </ul>
  */
 


### PR DESCRIPTION
In the PR I have extracted our commonly-used IDEA configurations into a separate Gradle config script.

The [`org.inferred.processors`](https://github.com/palantir/gradle-processors) plugin is used to automate the configuration of the annotation processors for IDEA.