### PR TITLE
Slow tests script

### DIFF
--- a/gradle/slowTests.gradle
+++ b/gradle/slowTests.gradle
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+final def slowTag = 'slow' // See io.spine.testing.SlowTest
+
+// Configure the default `test` task to run only non-slow tests.
+test {
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter'
+
+        excludeTags slowTag
+    }
+}
+
+task functionalTest(type: Test) {
+    useJUnitPlatform {
+        includeTags slowTag
+    }
+    mustRunAfter test
+}

--- a/gradle/slowTests.gradle
+++ b/gradle/slowTests.gradle
@@ -30,6 +30,9 @@ test {
 }
 
 task functionalTest(type: Test) {
+    description = 'Executes JUnit tests tagged as "slow".'
+    group = 'Verification'
+
     useJUnitPlatform {
         includeTags slowTag
     }


### PR DESCRIPTION
This PR adds the `slowTests.gradle` plugin script which configures JUnit tests to skip the `"slow"` tests by default and execute them when required.