### PR TITLE
Fail the build if JDK is not JDK 8. 

### DIFF
--- a/gradle/javac-args.gradle
+++ b/gradle/javac-args.gradle
@@ -24,6 +24,13 @@
 
 tasks.withType(JavaCompile) {
 
+    if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        throw new GradleException("Spine Event Engine can be built with JDK 8 only." +
+                " Supporting JDK 11 and above at build-time is planned in 2.0 release." +
+                " Please use the pre-built binaries available in the Spine Maven repository." +
+                " See https://github.com/SpineEventEngine/base/issues/457.")
+    }
+
     // Explicitly states the encoding of the source and test source files, ensuring
     // correct execution of the `javac` task.
     options.encoding = 'UTF-8'


### PR DESCRIPTION
Before this PR the Spine build failed with some weird errors (ErrorProne failures, `NoClassDefFound`s etc) if built with non-Java 8 JDK. For a newcomer, it looked like she did something wrong, and it should have worked.

As long as we only support JDK 8 as a build runtime, we should say so directly.