### PR TITLE
Fix `-proto` artifact publishing

### DIFF
--- a/gradle/publish-proto.gradle
+++ b/gradle/publish-proto.gradle
@@ -56,6 +56,17 @@ buildscript {
     }
 }
 
+task assembleProto(type: Jar) {
+    description "Assembles a JAR artifact with all Proto definitions from the classpath."
+    from { collectProto() }
+    include { isProtoFileOrDir(it.file) }
+    classifier 'proto'
+}
+
+artifacts {
+    archives assembleProto
+}
+
 /**
  * Collects all the directories from current project and its dependencies (including zip tree
  * directories) which contain {@code .proto} definitions.
@@ -142,13 +153,6 @@ JarFileName jarName(final File jar) {
     }
 }
 
-task assembleProto(type: Jar) {
-    description "Assembles a JAR artifact with all Proto definitions from the classpath."
-    from { collectProto() }
-    include { isProtoFileOrDir(it.file) }
-    classifier "proto"
-}
-
 /**
  * Checks if the given abstract pathname represents either a {@code .proto} file, or a directory
  * containing proto files.
@@ -185,21 +189,6 @@ boolean isProtoFileOrDir(final File candidate) {
  */
 boolean isProtoFile(final File file) {
     return file.isFile() && file.name.endsWith(".proto")
-}
-
-final String artifactIdForPublishing = "spine-${project.name}"
-publishing {
-    publications {
-        mavenProto(MavenPublication) {
-            groupId = "${group}"
-            artifactId = "${artifactIdForPublishing}"
-            version = "${version}"
-
-            from components.java
-
-            artifacts = [assembleProto]
-        }
-    }
 }
 
 /**

--- a/gradle/publish-proto.gradle
+++ b/gradle/publish-proto.gradle
@@ -106,7 +106,7 @@ Collection<File> collectProto() {
                  * As a side effect, the message is shown upon `./gradlew clean build` or upon
                  * a newly created version of framework build etc.
                  */
-                logger.error(
+                logger.debug(
                         "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."
                 )
             }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -29,8 +29,6 @@
   ```
  */
 
-//
-
 // See `dependencies.gradle` for the selection of the target repository.
 final String credentialsPropertyFile = publishToRepository.credentials
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -56,8 +56,8 @@ task publish {
     }
 }
 
-void dependPublish(final Project project) {
-    final Set<Task> credentialsTasks = getTasksByName("readPublishingCredentials", false)
+void dependPublish(final project) {
+    final credentialsTasks = getTasksByName("readPublishingCredentials", false)
     project.getTasksByName("publish", false).each { final task ->
         task.dependsOn credentialsTasks
     }
@@ -69,6 +69,12 @@ projectsToPublish.each {
         apply plugin: 'maven-publish'
 
         logger.debug("Applying `maven-publish` plugin to ${currentProject.name}.")
+
+        currentProject.artifacts {
+            archives sourceJar
+            archives testOutputJar
+            archives javadocJar
+        }
 
         // Artifact IDs are composed as "spine-<project.name>". Example:
         //
@@ -88,9 +94,7 @@ projectsToPublish.each {
 
                         from components.java
 
-                        artifact sourceJar
-                        artifact testOutputJar
-                        artifact javadocJar
+                        artifacts = configurations.archives.allArtifacts
                     }
                 }
             }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,7 +18,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// Apply this script to add ability to publish the needed artifacts.
+/*
+  Apply this script to add ability to publish the needed artifacts.
+
+  To publish more artifacts for a certain project, add them to the archives configuration:
+  ```
+  artifacts {
+      archives myCustomJarTask
+  }
+  ```
+ */
+
+//
 
 // See `dependencies.gradle` for the selection of the target repository.
 final String credentialsPropertyFile = publishToRepository.credentials


### PR DESCRIPTION
In Gradle v5.6 the behaviour of publication config has been changed. Now it is impossible to have more than one publication with the same group ID, artifact name, and version. This breaks the mechanism of publishing `-proto` artifacts in `core-java`.

In order to work this around, we now publish all the artifacts in a single publication. The artifacts are collected through the `archives` configuration.

This is also more pluggable and helps configure to publish more artifacts in separate projects without changing the `config`.