### PR TITLE
Extract common Proto JS configuration

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -189,6 +189,7 @@ final def scripts = [
     publishProto           : "$rootDir/config/gradle/publish-proto.gradle",
     javacArgs              : "$rootDir/config/gradle/javac-args.gradle",
     jsBuildTasks           : "$rootDir/config/gradle/js/build-tasks.gradle",
+    jsConfigureProto       : "$rootDir/config/gradle/js/configure-proto.gradle",
     npmPublishTasks        : "$rootDir/config/gradle/js/npm-publish-tasks.gradle",
     npmCli                 : "$rootDir/config/gradle/js/npm-cli.gradle",
     updatePackageVersion   : "$rootDir/config/gradle/js/update-package-version.gradle",

--- a/gradle/js/configure-proto.gradle
+++ b/gradle/js/configure-proto.gradle
@@ -30,8 +30,8 @@
  * 1. The Spine Proto JS plugin applied to the project
  * (see https://github.com/SpineEventEngine/base/tree/master/tools/proto-js-plugin).
  *
- * 2. The extension variable {@code versionToPublishJs} configured to represent the version under
- * which the NPM packages should be published.
+ * 2. The extension variable `versionToPublishJs` configured to represent the version under which
+ * the NPM packages should be published.
  */
 
 ext {

--- a/gradle/js/configure-proto.gradle
+++ b/gradle/js/configure-proto.gradle
@@ -61,8 +61,10 @@ protobuf {
 
                 task.generateDescriptorSet = true
                 final def testClassifier = task.sourceSet.name == "test" ? "_test" : ""
-                final def descriptorName = "${project.group}_${project.name}_${project.version}${testClassifier}.desc"
-                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
+                final def descriptorName =
+                        "${project.group}_${project.name}_${project.version}${testClassifier}.desc"
+                task.descriptorSetOptions.path =
+                        "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
             }
             compileProtoToJs.dependsOn task
         }

--- a/gradle/js/configure-proto.gradle
+++ b/gradle/js/configure-proto.gradle
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Configures how the Proto definitions of the project are compiled into JavaScript and their
+ * publishing.
+ *
+ * Use this script if the project contains Proto files that should be published as a separate NPM
+ * module.
+ *
+ * The prerequisites for using the script are:
+ *
+ * 1. The Spine Proto JS plugin applied to the project
+ * (see https://github.com/SpineEventEngine/base/tree/master/tools/proto-js-plugin).
+ *
+ * 2. The extension variable {@code versionToPublishJs} configured to represent the version under
+ * which the NPM packages should be published.
+ */
+
+ext {
+    genProtoBaseDir = "$projectDir/generated"
+    genProtoMain = "$genProtoBaseDir/main/js"
+    genProtoTest = "$genProtoBaseDir/test/js"
+}
+
+apply from: deps.scripts.npmPublishTasks
+
+/**
+ * Configures the JS code generation.
+ */
+protobuf {
+    generatedFilesBaseDir = genProtoBaseDir
+    protoc {
+        artifact = deps.build.protoc
+    }
+    generateProtoTasks {
+        all().each { final task ->
+            task.builtins {
+                // For information on JavaScript code generation please see
+                // https://github.com/google/protobuf/blob/master/js/README.md
+                js {
+                    option "import_style=commonjs"
+                }
+
+                task.generateDescriptorSet = true
+                final def testClassifier = task.sourceSet.name == "test" ? "_test" : ""
+                final def descriptorName = "${project.group}_${project.name}_${project.version}${testClassifier}.desc"
+                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
+            }
+            compileProtoToJs.dependsOn task
+        }
+    }
+}
+
+/**
+ * Configures the generation of additional features for the Proto messages via Spine Proto JS
+ * plugin.
+ */
+protoJs {
+    mainGenProtoDir = genProtoMain
+    testGenProtoDir = genProtoTest
+
+    generateParsersTask().dependsOn compileProtoToJs
+    buildJs.dependsOn generateParsersTask() 
+}
+
+/**
+ * Prepares Proto files for publication, see {@code npm-publish-tasks.gradle}.
+ */
+prepareJsPublication {
+
+    doLast {
+        copy {
+            from (projectDir) {
+                include 'package.json'
+                include '.npmrc'
+            }
+
+            from (genProtoMain) {
+                include '**'
+            }
+
+            into publicationDirectory
+        }
+    }
+}


### PR DESCRIPTION
This PR extracts a common configuration of the JS-based Spine projects to a separate script.

Currently, the Protobuf configuration across `users`, `web` and [`money`](https://github.com/SpineEventEngine/money/pull/14) is almost the same.

This PR extracts the common traits to a new script `configure-proto.gradle`.