### PR TITLE
Update Guava to `28-1-jre`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -92,7 +92,8 @@ final def versions = [
     javaPoet         : '1.11.0',
     autoService      : '1.0-rc5',
     autoCommon       : '0.10',
-    jackson          : '2.9.9.2'
+    jackson          : '2.9.9.2',
+    animalSniffer    : '1.18'
 ]
 
 final def build = [
@@ -132,6 +133,7 @@ final def build = [
 
     roasterApi             : "org.jboss.forge.roaster:roaster-api:$versions.roaster",
     roasterJdt             : "org.jboss.forge.roaster:roaster-jdt:$versions.roaster",
+    animalSniffer          : "org.codehaus.mojo:animal-sniffer-annotations:$versions.animalSniffer",
 
     ci: "true" == System.getenv("CI"),
 
@@ -232,6 +234,7 @@ ext.forceConfiguration = { final configurationContainer ->
                     deps.build.checkerAnnotations,
                     deps.build.autoCommon,
                     deps.build.guava,
+                    deps.build.animalSniffer,
                     deps.build.protobuf,
                     deps.test.guavaTestlib,
                     deps.test.truth,

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ final def versions = [
     appengineApi     : "1.9.73",
     appenginePlugin  : "1.3.5",
     findBugs         : "3.0.2",
-    guava            : "28.0-jre",
+    guava            : "28.1-jre",
     protobuf         : "3.9.0",
     grpc             : "1.22.0",
     flogger          : "0.4",


### PR DESCRIPTION
This PR updates the Guava version.

Also, it forces the version of `org.codehaus.mojo:animal-sniffer-annotations` to `1.18` — to resolve the conflict with `1.17` version of the same library.