### PR TITLE
Update the Jackson Databind version to `2.9.10`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -92,7 +92,7 @@ final def versions = [
     javaPoet         : '1.11.0',
     autoService      : '1.0-rc5',
     autoCommon       : '0.10',
-    jackson          : '2.9.9.2',
+    jackson          : '2.9.10',
     animalSniffer    : '1.18'
 ]
 


### PR DESCRIPTION
The [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-16335) was discovered in the Jackson Databind library pre-`2.9.10`.

This PR updates the version to fix the vulnerability in dependent repositories.