### PR TITLE
Dart Gradle scripts

### DIFF
--- a/gradle/dart/build-tasks.gradle
+++ b/gradle/dart/build-tasks.gradle
@@ -33,7 +33,11 @@ task resolveDependencies {
     doLast {
         executePub 'get'
     }
+
+    mustRunAfter 'cleanPackageIndex'
 }
+
+tasks['assemble'].dependsOn 'resolveDependencies'
 
 task cleanPackageIndex(type: Delete) {
     group = GROUP
@@ -45,9 +49,13 @@ tasks['clean'].dependsOn 'cleanPackageIndex'
 
 task testDart {
     group = GROUP
-    description = 'Runs Dart tests declared in the `./test` directory.'
+    description = 'Runs Dart tests declared in the `./test` directory. See https://pub.dev/packages/test#running-tests'
 
     doLast {
-        executePub 'run', 'test', './test'
+        executePub 'run', 'test'
     }
+
+    mustRunAfter 'resolveDependencies'
 }
+
+tasks['check'].dependsOn 'testDart'

--- a/gradle/dart/build-tasks.gradle
+++ b/gradle/dart/build-tasks.gradle
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+apply from: "$rootDir/config/gradle/dart/pub-cli.gradle"
+
+final def GROUP = 'Dart'
+final def packageIndex = "$projectDir/.packages" as File
+
+task resolveDependencies(type: Exec) {
+    group = GROUP
+    description = 'Fetches the dependencies declared via `pubspec.yaml`.'
+
+    inputs.file "$projectDir/pubspec.yaml"
+    outputs.file packageIndex
+
+    doLast {
+        executePub 'get'
+    }
+}
+
+task cleanPackageIndex(type: Delete) {
+    group = GROUP
+    description = 'Deletes the `.packages` file on this Dart module.'
+    delete = [packageIndex]
+}
+
+tasks['clean'].dependsOn 'cleanPackageIndex'

--- a/gradle/dart/build-tasks.gradle
+++ b/gradle/dart/build-tasks.gradle
@@ -23,7 +23,7 @@ apply from: "$rootDir/config/gradle/dart/pub-cli.gradle"
 final def GROUP = 'Dart'
 final def packageIndex = "$projectDir/.packages" as File
 
-task resolveDependencies(type: Exec) {
+task resolveDependencies {
     group = GROUP
     description = 'Fetches the dependencies declared via `pubspec.yaml`.'
 
@@ -42,3 +42,12 @@ task cleanPackageIndex(type: Delete) {
 }
 
 tasks['clean'].dependsOn 'cleanPackageIndex'
+
+task testDart {
+    group = GROUP
+    description = 'Runs Dart tests declared in the `./test` directory.'
+
+    doLast {
+        executePub 'run', 'test', './test'
+    }
+}

--- a/gradle/dart/build-tasks.gradle
+++ b/gradle/dart/build-tasks.gradle
@@ -49,7 +49,7 @@ tasks['clean'].dependsOn 'cleanPackageIndex'
 
 task testDart {
     group = GROUP
-    description = 'Runs Dart tests declared in the `./test` directory. See https://pub.dev/packages/test#running-tests'
+    description = 'Runs Dart tests declared in the `./test` directory. See `https://pub.dev/packages/test#running-tests`.'
 
     doLast {
         executePub 'run', 'test'

--- a/gradle/dart/pub-cli.gradle
+++ b/gradle/dart/pub-cli.gradle
@@ -21,27 +21,8 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 /**
- * The script allowing to run NPM commands from Gradle.
+ * The script allowing to run `pub` commands from Gradle.
  */
-
-
-/**
- * The name of an environmental variable which contains the NPM auth token.
- *
- * <p>The token is used for publishing only.
- *
- * <p>It is required to set this variable before invoking NPM commands.
- */
-ext.NPM_TOKEN_VARIABLE = "NPM_TOKEN"
-
-/**
- * @return the value of `NPM_TOKEN` environmental variable or a stub value, if the token is not set
- */
-String npmToken() {
-    final def tokenVarValue = System.getenv(NPM_TOKEN_VARIABLE)
-    final def token = tokenVarValue?.isEmpty() ? "PUBLISHING_FORBIDDEN" : tokenVarValue
-    return token
-}
 
 /**
  * Executes the given command depending on the current OS.
@@ -60,25 +41,24 @@ def execMultiplatform(final File workingDirArg,
         final List resultingParams = [command] + Arrays.asList(params)
         workingDir = workingDirArg
         commandLine = resultingParams
-        environment NPM_TOKEN_VARIABLE, npmToken()
     }
 }
 
-def runNpm(final File launchDir, final String[] params) {
-    execMultiplatform launchDir, 'npm.cmd', 'npm', params
+def runPub(final File launchDir, final String[] params) {
+    execMultiplatform launchDir, 'pub.cmd', 'pub', params
 }
 
 ext {
 
     /**
-     * Executes an {@code npm} CLI command.
+     * Executes a {@code pub} CLI command.
      *
-     * For example, to execute command {@code npm run compile}, invoke this function as follows:
-     * {@code executeNpm 'run', 'compile'}
+     * For example, to execute command {@code pub run test ./test}, invoke this function as follows:
+     * {@code executePub 'run', 'test', './test'}
      *
      * @param params the command parameters
      */
-    executeNpm = { final File from = projectDir, final String... params ->
-        runNpm(from, params)
+    executePub = { final File from = projectDir, final String... params ->
+        runPub(from, params)
     }
 }


### PR DESCRIPTION
This PR introduces the basic Gradle scripts which manage a Dart module.

Only the most common configuration is extracted into `config`. Some minor additional config may still be required on a case-to-case basis.