### PR TITLE
Fix `SNAPSHOT` pattern

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -286,9 +286,6 @@ ext.defaultRepositories = { final repositoryContainer ->
                 includeGroup 'io.spine.tools'
                 includeGroup 'io.spine.gcloud'
             }
-            mavenContent {
-                snapshotsOnly()
-            }
         }
         jcenter()
         maven { url = repos.gradlePlugins }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -114,7 +114,7 @@ projectsToPublish.each {
             currentProject.afterEvaluate(publishingAction)
         }
 
-        final boolean isSnapshots = currentProject.version.endsWith('-SNAPSHOT')
+        final boolean isSnapshots = currentProject.version.matches('.+-SNAPSHOT(\\+\\d+)?')
 
         publishing {
             repositories {


### PR DESCRIPTION
Since the recent change of versioning conventions, all of our artifacts were published into the "releases" repository due to the check which determined the target repository from the version.

Previously, the requirement was that `SNAPSHOT` versions had `-SNAPSHOT` at the end. This is no longer the case as `SNAPSHOT` versions now may end with a build number (e.g. `1.1.3-SNAPSHOT+1`).

This PR makes the publishing script account for the possibility of build numbers.