### PR TITLE
`EntityState` marker interface

### DIFF
--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -42,6 +42,7 @@ modelCompiler {
         mark messages().inFiles(suffix: "events.proto"), asType("io.spine.base.EventMessage")
         mark messages().inFiles(suffix: "rejections.proto"), asType("io.spine.base.RejectionMessage")
         mark messages().uuid(), asType("io.spine.base.UuidValue")
+        mark messages().entityState(), asType("io.spine.base.EntityState")
     }
 
     methods {

--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -25,7 +25,8 @@
  * — all messages in Protobuf files ending with "commands.proto" are marked as `CommandMessage`;
  * — all messages in Protobuf files ending with "events.proto" are marked as `EventMessage`;
  * — all messages in Protobuf files ending with "rejections.proto" are marked as `RejectionMessage`;
- * — all messages that qualify to be UUID messages are marked as `UuidValue`.
+ * — all messages that qualify to be UUID messages are marked as `UuidValue`;
+ * — all messages that represent the entity state are marked as `EntityState`.
  *
  * And the following method generations are applied:
  * — all messages that qualify to be UUID messages have helper `generate` and `of` methods


### PR DESCRIPTION
This PR extends the default configuration of Spine Model Compiler to apply the `io.spine.base.EntityState` interface to all entity state messages.

See https://github.com/SpineEventEngine/base/pull/494.

Note: `config` with these changes is usable starting from Spine version `1.2.0`.