### PR TITLE
Update Checkstyle plugin version to 8.29

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ final def versions = [
         errorProneJavac  : '9+181-r4173-1', // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
         errorPronePlugin : '1.1.1',
         pmd              : '6.20.0',
-        checkstyle       : '8.28',
+        checkstyle       : '8.29',
         protobufPlugin   : '0.8.11',
         appengineApi     : '1.9.77',
         appenginePlugin  : '2.2.0',


### PR DESCRIPTION
Recently, GitHub has detected a vulnerability [reported in Checkstyle 8.28](https://github.com/SpineEventEngine/time/network/alert/pom.xml/com.puppycrawl.tools:checkstyle/open).

This changeset updates the Checkstyle version to 8.29 in which it was fixed.