### PR TITLE
Enable NPM audit

### DIFF
--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -89,15 +89,10 @@ task auditNodePackages {
     inputs.dir nodeModulesDir
 
     doLast {
-        npm 'set', 'audit-level', 'high'
+        npm 'set', 'audit-level', 'critical'
         npm 'audit'
     }
 }
-
-// TODO:2019-05-22:yegor.udovchenko: Enable audit of NPM packages when
-// `npm audit` command stops failing due to NPM server overload.
-// See: https://github.com/SpineEventEngine/config/issues/64
-auditNodePackages.enabled = false
 
 /**
  * Installs the module dependencies and checks them for vulnerabilities.


### PR DESCRIPTION
This PR enables the NPM audit for the JS packages.

The audit level is set to `critical` so the build fails only if critical vulnerabilities are discovered. For all other cases, the audit log is just printed to the console.