### PR TITLE
Pages publishing script

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -206,7 +206,8 @@ final def scripts = [
         licenseReportCommon    : "$rootDir/config/gradle/license-report-common.gradle",
         projectLicenseReport   : "$rootDir/config/gradle/license-report-project.gradle",
         repoLicenseReport      : "$rootDir/config/gradle/license-report-repo.gradle",
-        generatePom            : "$rootDir/config/gradle/generate-pom.gradle"
+        generatePom            : "$rootDir/config/gradle/generate-pom.gradle",
+        updateGitHubPages      : "$rootDir/config/gradle/update-gh-pages.gradle"
 ]
 
 ext.deps = [

--- a/scripts/update-gh-pages.gradle
+++ b/scripts/update-gh-pages.gradle
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This script publishes the generated documentation to the `spine.io` site via GitHub pages by
+ * pushing commits to the `gh-pages` branch.
+ *
+ * To configure docs publishing, apply this script to the repositories which should generate
+ * the doc:
+ * ```
+ * apply deps.scripts.updateGhPages
+ * ```
+ * After that, the `updateGitHubPages` task will be available for that project.
+ *
+ * By default, the non-internal Javadoc is included into the publication. If need, the publication
+ * may be extended to include other files. To do so, append more files/file collections to
+ * the `generatedDocs` extension property of the respective project.
+ *
+ * In order to work, the script needs a `deploy_key_rsa` private RSA key file in the repository
+ * root. It is recommended to decrypt it in the repository an then decrypt it on CI upon
+ * a publication. Also, the script uses the `FORMAL_GIT_HUB_PAGES_AUTHOR` environmental variable to
+ * set the author email for the commits. The `gh-pages` branch itself should exist before the script
+ * is run.
+ */
+
+import com.google.common.io.Files
+
+buildscript {
+
+    apply from: "$rootDir/config/gradle/dependencies.gradle"
+
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath deps.build.guava
+    }
+}
+
+apply from: deps.scripts.filterInternalJavadocs
+
+ext {
+    javadocDir = Files.createTempDir()
+    generatedDocs = files(javadocDir)
+    repositoryTempDir = Files.createTempDir()
+}
+
+/**
+ * Copies the Javadoc produced by {@code :noInternalJavadoc} task into a temporary folder.
+ */
+task copyJavadoc(type: Copy) {
+    from noInternalJavadoc
+    into javadocDir
+}
+
+/**
+ * Updates the Javadoc documentation on the {@code gh-pages} Git branch.
+ *
+ * <p>Run this task when it is required to update the Javadoc e.g. when merging a branch into
+ * {@code master}.
+ */
+task updateGitHubPages {
+    description "Updates the Javadoc published to GitHub Pages website."
+    dependsOn copyJavadoc
+}
+
+/**
+ * Waits for the given {@code process} to finish and retrieves the result of execution.
+ *
+ * @param process the process to execute
+ * @return a tuple of format: [exitCode:<Process exit code integer>,
+ *                             out: <Process stdout output as a String>,
+ *                             error: <Process stderr output as a String>]
+ */
+static def executeForResult(final Process process) {
+    final def outWriter = new StringWriter()
+    final def errWriter = new StringWriter()
+    process.consumeProcessOutputStream(outWriter)
+    process.consumeProcessErrorStream(errWriter)
+    final int exitCode = process.waitFor()
+    final def result = [out: outWriter.toString(), error: errWriter.toString(), exitCode: exitCode]
+    return result
+}
+
+/**
+ * Executes the given terminal command and retrieves the command output.
+ *
+ * <p>{@link Runtime#exec(String[], String[], File) Executes} the given {@code String} array as
+ * a CLI command. If the execution is successful, returns the command output. Throws
+ * an {@link IllegalStateException} otherwise.
+ *
+ * @param baseDir the directory of the command execution
+ * @param command the command to execute
+ * @return the command line output
+ * @throws IllegalStateException upon an execution error
+ */
+String execute(final File baseDir, final String... command) {
+    final Runtime runtime = Runtime.getRuntime()
+    final Process proc = runtime.exec(command, /*env=*/ (String[]) null, baseDir)
+    final def result = executeForResult(proc)
+    if (result.exitCode == 0) {
+        return result.out
+    } else {
+        final String errorMsg = "Command `$command` finished with exit code $result.exitCode:" +
+                " ${System.lineSeparator()}${result.error}"
+        throw new IllegalStateException(errorMsg)
+    }
+}
+
+/**
+ * Executes the given CLI command and retrieves the command output.
+ *
+ * <p>This is a convenience method. Calling this method is equivalent to calling
+ * {@code execute(project.rootDir, command)}.
+ */
+String execute(final String... command) {
+    return execute(rootDir, command)
+}
+
+/**
+ * The GitHub URL to the {@code core-java} project.
+ *
+ * <p>The host name is {@code github.com-publish}, though resolved to {@code github.com} by SSH on
+ * Travis due to the SSH configuration. This is used to make it possible to have multiple SSH
+ * private keys on Travis (since there is one already on Travis).
+ */
+final String GIT_HOST = "git@github.com-publish:SpineEventEngine/core-java.git"
+
+/**
+ * The GitHub deploy key used to push the doc changes to the {@code gh-pages} branch.
+ */
+final File gitHubAccessKey = "$rootDir/deploy_key_rsa" as File
+
+updateGitHubPages.doLast {
+    if (!gitHubAccessKey.exists()) {
+        throw new GradleException("File $gitHubAccessKey does not exist. It should be encrypted" +
+                " in the repository and decrypted on CI.")
+    }
+
+    final def GH_PAGES_BRANCH = "gh-pages"
+
+    final def repoBaseDir = "$repositoryTempDir/$GH_PAGES_BRANCH" as File
+    final def docDirPostfix = "reference/$project.name"
+    final def docDir = "$repoBaseDir/$docDirPostfix" as File
+    final def versionedDocDir = "$docDir/v/$project.version" as File
+
+    // Create SSH config file to allow pushing commits to the repository.
+    final File sshConfigFile = file("${System.getProperty("user.home")}/.ssh/config")
+    if (!sshConfigFile.exists()) {
+        Files.createParentDirs(sshConfigFile)
+        sshConfigFile.createNewFile()
+    }
+    sshConfigFile << """
+Host github.com-publish
+	HostName github.com
+	User git
+	IdentityFile $gitHubAccessKey.absolutePath
+"""
+    execute 'eval', '$(ssh-agent -s)'
+    execute 'ssh-add', gitHubAccessKey.absolutePath
+
+    execute 'git', 'clone', GIT_HOST, "$repoBaseDir"
+    execute repoBaseDir, "git", "checkout", GH_PAGES_BRANCH
+    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`")
+    docDir.mkdir()
+
+    copy {
+        from generatedDocs
+        into docDir
+    }
+
+    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`")
+    versionedDocDir.mkdir()
+    copy {
+        from generatedDocs
+        into versionedDocDir
+    }
+
+    execute repoBaseDir, "git", "add", docDirPostfix
+
+    /**
+     * Publish the changes under "UpdateGitHubPages Plugin" Git user name and email stored in
+     * "FORMAL_GIT_HUB_PAGES_AUTHOR" env variable.
+     *
+     * <p>When changing the value of "FORMAL_GIT_HUB_PAGES_AUTHOR", also change the SSH private
+     * (deploy_key_rsa.enc) and public ("GitHub Pages publisher (Travis CI)" on GitHub) keys.
+     */
+    execute repoBaseDir, "git", "config", "user.name", "\"UpdateGitHubPages Plugin\""
+    execute repoBaseDir, "git", "config", "user.email", System.env.FORMAL_GIT_HUB_PAGES_AUTHOR
+
+    execute repoBaseDir, "git", "commit", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
+    execute repoBaseDir, "git", "push"
+    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` sucessfully")
+}

--- a/scripts/update-gh-pages.gradle
+++ b/scripts/update-gh-pages.gradle
@@ -29,7 +29,7 @@
  * ```
  * After that, the `updateGitHubPages` task will be available for that project.
  *
- * By default, the non-internal Javadoc is included into the publication. If need, the publication
+ * By default, the non-internal Javadoc is included into the publication. If needed, the publication
  * may be extended to include other files. To do so, append more files/file collections to
  * the `generatedDocs` extension property of the respective project.
  *


### PR DESCRIPTION
This PR adds the Gradle script for publishing generated docs and GitHub Pages. The script is moved from `core-java` with a couple of significant changes:
1. The links will now look like `<repo name>/reference/<project name>` instead of `<repo name>/javadoc/<project name>`.
2. The docs for previous versions will be stored under `<repo name>/reference/<project name>/v/<version number>`. The docs for the current version will be both stored under the non-versioned path (as by point 1) and under the versioned path.
3. To add extra docs to publish, the user should append the `ext.generatedDocs` file collection.
4. Extra files are not required anymore, except for the credential file. See the script header for the full preconditions.