### PR TITLE
Disable the NPM audit

### DIFF
--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -98,8 +98,8 @@ task auditNodePackages {
 //
 // The audit periodically fails due to NPM service being not available. Although the corresponding
 // issue ('https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642') is closed, the problem
-// still persists. Due to these issues, the developers building projects which include NPM audit
-// task must constantly restart their builds locally and on CI.
+// still persists. Due to these issues, the developers building projects which include the NPM
+// audit task must constantly restart their builds locally and on CI.
 //
 // The audit can be enabled again when the NPM audit service proves to be stable enough so its
 // availability is not an issue when doing project builds.

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -99,10 +99,10 @@ task auditNodePackages {
 // The audit periodically fails due to NPM service being not available. Although the corresponding
 // issue ('https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642') is closed, the
 // problem still persists. Due to these issues, the developers building projects which include the
-// NPM audit task must constantly restart their builds locally and on CI.
+// NPM `audit` task must constantly restart their builds locally and on CI.
 //
 // The audit can be enabled again when the NPM audit service proves to be stable enough so its
-// availability is not an issue when doing project builds.
+// availability is not an issue when doing project builds in any environment.
 //
 // The related Spine `config` issue: 'https://github.com/SpineEventEngine/config/issues/64'.
 auditNodePackages.enabled = false

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -97,9 +97,9 @@ task auditNodePackages {
 // Disable the NPM audit.
 //
 // The audit periodically fails due to NPM service being not available. Although the corresponding
-// issue ('https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642') is closed, the problem
-// still persists. Due to these issues, the developers building projects which include the NPM
-// audit task must constantly restart their builds locally and on CI.
+// issue ('https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642') is closed, the
+// problem still persists. Due to these issues, the developers building projects which include the
+// NPM audit task must constantly restart their builds locally and on CI.
 //
 // The audit can be enabled again when the NPM audit service proves to be stable enough so its
 // availability is not an issue when doing project builds.

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -94,6 +94,19 @@ task auditNodePackages {
     }
 }
 
+// Disable the NPM audit.
+//
+// The audit periodically fails due to NPM service being not available. Although the corresponding
+// issue (https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642) is closed, the problem
+// still persists. Due to these issues, the developers building projects which include NPM audit
+// task must constantly restart their builds locally and on CI.
+//
+// The audit can be enabled again when the NPM audit service proves to be stable enough so its
+// availability is not an issue when doing project builds.
+//
+// The related Spine `config` issue: https://github.com/SpineEventEngine/config/issues/64.
+auditNodePackages.enabled = false
+
 /**
  * Installs the module dependencies and checks them for vulnerabilities.
  */

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -97,7 +97,7 @@ task auditNodePackages {
 // Disable the NPM audit.
 //
 // The audit periodically fails due to NPM service being not available. Although the corresponding
-// issue (https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642) is closed, the problem
+// issue ('https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642') is closed, the problem
 // still persists. Due to these issues, the developers building projects which include NPM audit
 // task must constantly restart their builds locally and on CI.
 //

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -104,7 +104,7 @@ task auditNodePackages {
 // The audit can be enabled again when the NPM audit service proves to be stable enough so its
 // availability is not an issue when doing project builds.
 //
-// The related Spine `config` issue: https://github.com/SpineEventEngine/config/issues/64.
+// The related Spine `config` issue: 'https://github.com/SpineEventEngine/config/issues/64'.
 auditNodePackages.enabled = false
 
 /**


### PR DESCRIPTION
This PR disables the NPM audit task [enabled](#98) previously.

The audit still periodically fails project builds due to service unavailability.

Although the corresonding NPM [issue](https://npm.community/t/enoaudit-from-registry-npmjs-org-503/4642) is closed, the problem still persists.

This PR disables the `auditNodePackages` task so the developers don't have to constantly restart project builds locally and on CI.