### PR TITLE
Extract script

### DIFF
--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -174,8 +174,7 @@ Host github.com-publish
 	User git
 	IdentityFile $gitHubAccessKey.absolutePath
 """
-    execute 'eval', '$(ssh-agent -s)'
-    execute 'ssh-add', gitHubAccessKey.absolutePath
+    execute "$rootDir/config/scripts/register-ssh-key.sh", gitHubAccessKey.absolutePath
 
     execute 'git', 'clone', GIT_HOST, "$repoBaseDir"
     execute repoBaseDir, "git", "checkout", GH_PAGES_BRANCH

--- a/scripts/register-ssh-key.sh
+++ b/scripts/register-ssh-key.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+eval "$(ssh-agent -s)"
+ssh-add "$1"


### PR DESCRIPTION
This PR extracts a bash script into a separate file.

By default, `eval` function is not supported by the Java process execution mechanism. Thus, we extract it into a separate file and run It with Bash.