### PR TITLE
Turn `UnnecessaryLocalVariable` inspection off

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -825,6 +825,7 @@
     <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreReferencesToLocalInnerClasses" value="true" />
     </inspection_tool>
+    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />


### PR DESCRIPTION
Since recently, the IDEA started reporting an `UnnecessaryLocalVariable` warning on constructs such as:
```java
boolean result = repositories.contains(repository);
return result;
```
Such variables have a great value for debugging as well as for readability.
The change in the IDE behaviour is probably related to the new version.

In this PR we disable the check.