### PR TITLE
Constants for javadoc options

### DIFF
--- a/gradle/filter-internal-javadoc.gradle
+++ b/gradle/filter-internal-javadoc.gradle
@@ -30,6 +30,7 @@ dependencies {
     excludeInternalDoclet "io.spine.tools:spine-javadoc-filter:$spineBaseVersion"
 }
 
+// This task uses constants defined in `javadoc-options.gradle`.
 task noInternalJavadoc(type: Javadoc) {
     source = sourceSets.main.allJava.filter {
         !it.absolutePath.contains('generated')
@@ -37,13 +38,13 @@ task noInternalJavadoc(type: Javadoc) {
     classpath = javadoc.getClasspath()
 
     options {
+        tags = javadocOptions.tags
+        encoding = javadocOptions.encoding
+
         // Doclet fully qualified name.
         doclet = 'io.spine.tools.javadoc.ExcludeInternalDoclet'
 
         // Path to the JAR containing the doclet.
         docletpath = configurations.excludeInternalDoclet.files.asType(List)
-
-        // Encoding of the source files.
-        encoding = 'UTF8'
     }
 }

--- a/gradle/javadoc-options.gradle
+++ b/gradle/javadoc-options.gradle
@@ -36,12 +36,23 @@
  * or to the specific child projects.
  */
 
+ext {
+    javadocOptions = [
+
+            // New tags which are used in the code and titles for them.
+            "tags" : ["apiNote:a:API Note:",
+                      "implSpec:a:Implementation Requirements:",
+                      "implNote:a:Implementation Note:"],
+
+            // Encoding of the source files.
+            "encoding" : 'UTF-8'
+    ]
+}
+
 javadoc {
     source = sourceSets.main.allJava
-    options.tags = ["apiNote:a:API Note:",
-                    "implSpec:a:Implementation Requirements:",
-                    "implNote:a:Implementation Note:"]
-    options.encoding = 'UTF-8'
+    options.tags = javadocOptions.tags
+    options.encoding = javadocOptions.encoding
 }
 
 // The below config avoids numerous warnings for missing @param tags.

--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -151,7 +151,10 @@ updateGitHubPages.doLast {
 
     final String repoSlug = System.getenv('TRAVIS_REPO_SLUG')
     if (repoSlug == null || repoSlug.isEmpty()) {
-        throw new GradleException('`TRAVIS_REPO_SLUG` environmental variable is not set.')
+        throw new GradleException(
+                '`TRAVIS_REPO_SLUG` environmental variable is not set.' +
+                        ' Publishing must be performed from the CI environment.'
+        )
     }
 
     /**


### PR DESCRIPTION
This PR extracts Javadoc options and uses them for the task of removing `@Internal` elements of API from generated Javadocs.

Also the error message for publishing Javadocs from non-CI environment is improved.
