### PR TITLE
Update `jackson-databind`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -93,7 +93,7 @@ final def versions = [
         javaPoet         : '1.12.1',
         autoService      : '1.0-rc6',
         autoCommon       : '0.10',
-        jackson          : '2.11.0',
+        jackson          : '2.9.10.4',
         animalSniffer    : '1.18'
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -93,7 +93,7 @@ final def versions = [
         javaPoet         : '1.12.1',
         autoService      : '1.0-rc6',
         autoCommon       : '0.10',
-        jackson          : '2.9.10.3',
+        jackson          : '2.11.0',
         animalSniffer    : '1.18'
 ]
 


### PR DESCRIPTION
This PR updates the `com.fasterxml.jackson.core:jackson-databind` to a newer version in order to fix the [vulnerability](https://github.com/SpineEventEngine/web/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open) found in the `spine-web`.