### PR TITLE
Remove backticks from `pull`

### DIFF
--- a/pull
+++ b/pull
@@ -57,7 +57,7 @@ if [ ! -f ../.gitignore ]; then
     cp .gitignore ..
 fi
 
-echo "Updating Gradle `buildSrc` scripts"
+echo "Updating Gradle buildSrc scripts"
 cp -R gradle/buildSrc ..
 
 cd ..

--- a/pull.bat
+++ b/pull.bat
@@ -55,7 +55,7 @@ IF NOT EXIST "..\.gitignore" (
 	xcopy /F/Y .gitignore ..\
 )
 
-echo "Updating Gradle `buildSrc` scripts"
+echo "Updating Gradle buildSrc scripts"
 xcopy /S/E/I/F/Y gradle\buildSrc ..\buildSrc
 
 cd ..


### PR DESCRIPTION
Backticks in `echo` caused the `pull` script to fail. Now we remove them.