### PR TITLE
Exclude `protobuf-lite`

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -316,6 +316,17 @@ object DependencyResolution {
         }
     }
 
+    fun excludeProtobufLite(configurations: ConfigurationContainer) {
+        excludeProtoLite(configurations, "runtime")
+        excludeProtoLite(configurations, "testRuntime")
+    }
+
+    private fun excludeProtoLite(configurations: ConfigurationContainer,
+                                 configurationName: String) {
+        configurations.named(configurationName).get()
+                .exclude(mapOf("group" to "com.google.protobuf", "module" to "protobuf-lite"))
+    }
+
     fun defaultRepositories(repositories: RepositoryHandler) {
         repositories.mavenLocal()
         repositories.maven { repository ->


### PR DESCRIPTION
It's a commodity in our projects to exclude `protobuf-lite` artifacts from runtime. In this PR we add a method to do just that.