### PR TITLE
Increment guard

### DIFF
--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -26,3 +26,9 @@ repositories {
     mavenLocal()
     jcenter()
 }
+
+val jacksonVersion = "2.11.0"
+
+dependencies {
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+}

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -29,8 +29,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.net.URL
 
-private const val FILE_NAME = "maven-metadata.xml"
-
 /**
  * A task which verifies that the current version of the library has not been published to the given
  * Maven repository yet.
@@ -51,7 +49,7 @@ open class CheckVersionIncrement : AbstractTask() {
 
     @TaskAction
     private fun fetchAndCheck() {
-        val artifact = "${project.artifactPath()}/$FILE_NAME"
+        val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
         val repoUrl = repository.releases
         val metadata = fetch(repoUrl, artifact)
         val versions = metadata.versioning.versions
@@ -87,6 +85,8 @@ open class CheckVersionIncrement : AbstractTask() {
 private data class MavenMetadata(var versioning: Versioning = Versioning()) {
 
     companion object {
+
+        const val FILE_NAME = "maven-metadata.xml"
 
         private val mapper = XmlMapper()
 

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -31,8 +31,18 @@ import java.net.URL
 
 private const val FILE_NAME = "maven-metadata.xml"
 
+/**
+ * A task which verifies that the current version of the library has not been published to the given
+ * Maven repository yet.
+ */
 open class CheckVersionIncrement : AbstractTask() {
 
+    /**
+     * The Maven repository in which to look for published artifacts.
+     *
+     * We only check the `releases` repository. Artifacts in `snapshots` repository still may be
+     * overridden.
+     */
     @Input
     lateinit var repository: Repository
 

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.internal
+
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.net.URL
+
+private const val FILE_NAME = "maven-metadata.xml"
+
+open class CheckVersionIncrement : AbstractTask() {
+
+    @Input
+    lateinit var repository: Repository
+
+    @Input
+    private val version: String = project.version as String
+
+    @TaskAction
+    private fun fetchAndCheck() {
+        val artifact = "${project.artifactPath()}/$FILE_NAME"
+        val repoUrl = repository.releases
+        val metadata = fetch(repoUrl, artifact)
+        val versions = metadata.versioning.versions
+        val versionExists = versions.contains(version)
+        if (versionExists) {
+            throw GradleException("""
+                    Version `$version` is already published to maven repository `$repoUrl`.
+                    Try incrementing the library version.
+                    All available versions are: ${versions.joinToString(separator = ", ")}. 
+                    
+                    To disable this check, run Gradle with `-x $name`. 
+                    """.trimIndent()
+            )
+        }
+    }
+
+    private fun fetch(repository: String, artifact: String): MavenMetadata {
+        val url = URL("$repository/$artifact")
+        return MavenMetadata.fetchAndParse(url)
+    }
+
+    private fun Project.artifactPath(): String {
+        val group = this.group as String
+        val name = "spine-${this.name}"
+
+        val pathElements = ArrayList(group.split('.'))
+        pathElements.add(name)
+        val path = pathElements.joinToString(separator = "/")
+        return path
+    }
+}
+
+private data class MavenMetadata(var versioning: Versioning = Versioning()) {
+
+    companion object {
+
+        private val mapper = XmlMapper()
+
+        init {
+            mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
+
+        fun fetchAndParse(url: URL): MavenMetadata {
+            val metadata = mapper.readValue(url, MavenMetadata::class.java)
+            return metadata
+        }
+    }
+}
+
+private data class Versioning(var versions: List<String> = listOf())

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.internal
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Gradle plugin which adds a [CheckVersionIncrement] task.
+ *
+ * The task is called `checkVersionIncrement` inserted before the `check` task.
+ */
+class IncrementGuard : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val tasks = target.tasks
+        tasks.register("checkVersionIncrement",
+                CheckVersionIncrement::class.java) {
+            it.repository = PublishingRepos.cloudRepo
+            tasks.getByName("check").dependsOn(it)
+
+            it.shouldRunAfter("test")
+        }
+    }
+}

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -30,10 +30,13 @@ import org.gradle.api.Project
  */
 class IncrementGuard : Plugin<Project> {
 
+    companion object {
+        const val taskName = "checkVersionIncrement"
+    }
+
     override fun apply(target: Project) {
         val tasks = target.tasks
-        tasks.register("checkVersionIncrement",
-                CheckVersionIncrement::class.java) {
+        tasks.register(taskName, CheckVersionIncrement::class.java) {
             it.repository = PublishingRepos.cloudRepo
             tasks.getByName("check").dependsOn(it)
 


### PR DESCRIPTION
In this PR we implement the `IncrementGuard` plugin.

Before, PRs could override existing versions of Spine libraries intentionally or otherwise. This is a bad practice in general. It also may result in an incompatible change within a single version of the library. This kills any build which depends on that library.

In this PR we introduce the `IncrementGuard` Gradle plugin. The plugin creates the `checkVersionIncrement`  task which fails of the current version of the library has already been published to the Maven repository.

Note that the task checks the version upon all the matching artifacts present in the Maven repository, not only upon the latest one.

The `checkVersionIncrement`  task runs upon `check`.

Fixes [this issue](https://github.com/SpineEventEngine/base/issues/537) in `base`.