### PR TITLE
Less common dependencies

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -97,6 +97,7 @@ object Versions {
     val jackson          = "2.9.10.4"
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
+    val servletApi       = "3.1.0"
 
     /**
      * Version of the SLF4J library.
@@ -150,8 +151,10 @@ object Build {
     val roasterApi             = "org.jboss.forge.roaster:roaster-api:${Versions.roaster}"
     val roasterJdt             = "org.jboss.forge.roaster:roaster-jdt:${Versions.roaster}"
     val animalSniffer          = "org.codehaus.mojo:animal-sniffer-annotations:${Versions.animalSniffer}"
-    val ci = "true".equals(System.getenv("CI"))
-    val gradlePlugins = GradlePlugins
+    @Deprecated("Use Env instead.", replaceWith = ReplaceWith("Deps.env.ci"))
+    val ci                     = "true".equals(System.getenv("CI"))
+    val gradlePlugins          = GradlePlugins
+    val servletApi             = "javax.servlet:javax.servlet-api:${Versions.servletApi}"
     @Deprecated("Use Flogger over SLF4J.", replaceWith = ReplaceWith("flogger"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j                  = "org.slf4j:slf4j-api:${Versions.slf4j}"
@@ -265,6 +268,17 @@ object Scripts {
     private fun Project.script(name: String) = "${rootDir}$COMMON_PATH$name"
 }
 
+object Env {
+
+    /**
+     * Flag which shows if the current runtime is on a CI server or not.
+     *
+     * If the `CI` environment variable is set to `"true"`, the value is `true`. Otherwise,
+     * the value is `false`.
+     */
+    val ci = "true".equals(System.getenv("CI"))
+}
+
 object Deps {
     val build = Build
     val grpc = Grpc
@@ -273,6 +287,7 @@ object Deps {
     val test = Test
     val versions = Versions
     val scripts = Scripts
+    val env = Env
 }
 
 object DependencyResolution {

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -98,6 +98,8 @@ object Versions {
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
     val servletApi       = "3.1.0"
+    val gCloudDatastore  = "1.102.4"
+    val gCloudTrace      = "1.0.3"
 
     /**
      * Version of the SLF4J library.
@@ -192,6 +194,12 @@ object Grpc {
     val grpcNettyShaded = nettyShaded
     @Deprecated("Use the shorter form.", replaceWith = ReplaceWith("context"))
     val grpcContext = context
+}
+
+object GoogleCloud {
+
+    val datastore = "com.google.cloud:google-cloud-datastore:${Versions.gCloudDatastore}"
+    val trace     = "com.google.cloud:google-cloud-trace:${Versions.gCloudTrace}"
 }
 
 object Runtime {

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -197,11 +197,24 @@ object Grpc {
 object Runtime {
 
     val flogger = Flogger
+    val slf4J = Slf4J
 
     object Flogger {
         val systemBackend = "com.google.flogger:flogger-system-backend:${Versions.flogger}"
         val log4J         = "com.google.flogger:flogger-log4j:${Versions.flogger}"
         val slf4J         = "com.google.flogger:slf4j-backend-factory:${Versions.flogger}"
+    }
+
+    object Slf4J {
+
+        /**
+         * A runtime SLF4J binding for `java.util.logging`.
+         *
+         * Use only if a binding is required. Prefer Flogger if the choice of a logging platform is
+         * on us.
+         */
+        @Suppress("DEPRECATION") // OK to use SLF4J for runtime bindings.
+        val slf4j = "org.slf4j:slf4j-jdk14:${Versions.slf4j}"
     }
 
     @Deprecated("Use the `flogger` object.", replaceWith = ReplaceWith("flogger.systemBackend"))
@@ -230,7 +243,7 @@ object Test {
             "com.google.truth.extensions:truth-proto-extension:${Versions.truth}"
     )
     @Deprecated("Use Flogger over SLF4J.",
-                replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
+                replaceWith = ReplaceWith("Deps.runtime.flogger.systemBackend"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j         = "org.slf4j:slf4j-jdk14:${Versions.slf4j}"
 }

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -100,6 +100,10 @@ object Versions {
     val servletApi       = "3.1.0"
     val gCloudDatastore  = "1.102.4"
     val gCloudTrace      = "1.0.3"
+    val hsqldb           = "2.5.0"
+    val h2database       = "1.4.200"
+    val hikari           = "3.4.5"
+    val querydsl         = "4.3.1"
 
     /**
      * Version of the SLF4J library.
@@ -153,10 +157,15 @@ object Build {
     val roasterApi             = "org.jboss.forge.roaster:roaster-api:${Versions.roaster}"
     val roasterJdt             = "org.jboss.forge.roaster:roaster-jdt:${Versions.roaster}"
     val animalSniffer          = "org.codehaus.mojo:animal-sniffer-annotations:${Versions.animalSniffer}"
-    @Deprecated("Use Env instead.", replaceWith = ReplaceWith("Deps.env.ci"))
-    val ci                     = "true".equals(System.getenv("CI"))
     val gradlePlugins          = GradlePlugins
     val servletApi             = "javax.servlet:javax.servlet-api:${Versions.servletApi}"
+    val hsqldb                 = "org.hsqldb:hsqldb:${Versions.hsqldb}"
+    val h2database             = "com.h2database:h2:${Versions.h2database}"
+    val hikari                 = "com.zaxxer:HikariCP:${Versions.hikari}"
+    val querydsl               = "com.querydsl:querydsl-sql:${Versions.querydsl}"
+
+    @Deprecated("Use Env instead.", replaceWith = ReplaceWith("Deps.env.ci"))
+    val ci                     = "true".equals(System.getenv("CI"))
     @Deprecated("Use Flogger over SLF4J.", replaceWith = ReplaceWith("flogger"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j                  = "org.slf4j:slf4j-api:${Versions.slf4j}"


### PR DESCRIPTION
In this PR we add dependencies which usually are only used by one Spine library, such as `web` (e.g. servlet API), `gcloud` (cloud libraries), and `jdbc-storage` (SQL-related dependencies).

From now on, they will be managed centrally, just like all other dependencies.
 