### PR TITLE
Allow custom compiled scripts

### DIFF
--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -19,8 +19,6 @@
  */
 
 plugins {
-    // Use Kotlin for `buildSrc`.
-    // https://kotlinlang.org/docs/reference/using-gradle.html#targeting-the-jvm
     `kotlin-dsl`
 }
 

--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -21,7 +21,7 @@
 plugins {
     // Use Kotlin for `buildSrc`.
     // https://kotlinlang.org/docs/reference/using-gradle.html#targeting-the-jvm
-    kotlin("jvm").version("1.3.72")
+    `kotlin-dsl`
 }
 
 repositories {

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -45,7 +45,7 @@ open class CheckVersionIncrement : AbstractTask() {
     lateinit var repository: Repository
 
     @Input
-    private val version: String = project.version as String
+    val version: String = project.version as String
 
     @TaskAction
     private fun fetchAndCheck() {

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -22,9 +22,9 @@ package io.spine.gradle.internal
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import java.net.URL
@@ -33,7 +33,7 @@ import java.net.URL
  * A task which verifies that the current version of the library has not been published to the given
  * Maven repository yet.
  */
-open class CheckVersionIncrement : AbstractTask() {
+open class CheckVersionIncrement : DefaultTask() {
 
     /**
      * The Maven repository in which to look for published artifacts.

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -37,10 +37,10 @@ class IncrementGuard : Plugin<Project> {
     override fun apply(target: Project) {
         val tasks = target.tasks
         tasks.register(taskName, CheckVersionIncrement::class.java) {
-            it.repository = PublishingRepos.cloudRepo
-            tasks.getByName("check").dependsOn(it)
+            repository = PublishingRepos.cloudRepo
+            tasks.getByName("check").dependsOn(this)
 
-            it.shouldRunAfter("test")
+            shouldRunAfter("test")
         }
     }
 }

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -20,8 +20,8 @@
 
 package io.spine.gradle.internal
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
@@ -36,7 +36,7 @@ import java.io.File
  * The build writes verbose log into `$directory/build/debug-out.txt`. The error output is written
  * into `$directory/build/error-out.txt`.
  */
-open class RunBuild : AbstractTask() {
+open class RunBuild : DefaultTask() {
 
     /**
      * Path to the directory which contains a Gradle wrapper script.

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -22,6 +22,7 @@ package io.spine.gradle.internal
 
 import org.gradle.api.GradleException
 import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 import java.io.File
@@ -40,6 +41,7 @@ open class RunBuild : AbstractTask() {
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */
+    @Internal
     lateinit var directory: String
 
     @TaskAction

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -278,12 +278,12 @@ object Deps {
 object DependencyResolution {
 
     fun forceConfiguration(configurations: ConfigurationContainer) {
-        configurations.all { config ->
-            config.resolutionStrategy { strategy ->
-                strategy.failOnVersionConflict()
-                strategy.cacheChangingModulesFor(0, "seconds")
+        configurations.all {
+            resolutionStrategy {
+                failOnVersionConflict()
+                cacheChangingModulesFor(0, "seconds")
                 @Suppress("DEPRECATION") // Force SLF4J version.
-                strategy.force(
+                force(
                         Deps.build.slf4j,
                         Deps.build.errorProneAnnotations,
                         Deps.build.jsr305Annotations,
@@ -329,17 +329,17 @@ object DependencyResolution {
 
     fun defaultRepositories(repositories: RepositoryHandler) {
         repositories.mavenLocal()
-        repositories.maven { repository ->
-            repository.url = URI(Repos.spine)
-            repository.content { descriptor ->
-                descriptor.includeGroup("io.spine")
-                descriptor.includeGroup("io.spine.tools")
-                descriptor.includeGroup("io.spine.gcloud")
+        repositories.maven {
+            url = URI(Repos.spine)
+            content {
+                includeGroup("io.spine")
+                includeGroup("io.spine.tools")
+                includeGroup("io.spine.gcloud")
             }
         }
         repositories.jcenter()
-        repositories.maven { repository ->
-            repository.url = URI(Repos.gradlePlugins)
+        repositories.maven {
+            url = URI(Repos.gradlePlugins)
         }
     }
 }


### PR DESCRIPTION
With Kotlin we are able to place script plugins into the `buildSrc` dir. Those plugins become [precompiled](https://docs.gradle.org/current/userguide/custom_plugins.html#sec:precompiled_plugins).

At this point, this is the only usable way in which we can develop custom script plugins which use other Gradle plugins. Just placing a `.gradle.kts` file and applying it via `apply(from = "...")` is flawed, as the file cannot use any type-safe accessors for the Gradle model.

In this repository, we prepare the `buildSrc` project for those plugins.
In library repositories, we may define custom script plugins and place them under `buildSrc/src/main/kotlin`. For example, `custom-jar-magic.gradle.kts`:
```kotlin
plugins {
    java
}

tasks.jar {
    exclude("**/*.properties")
}
```
Then, such plugins become available to the target projects. For example, `spine-lib/build.gradle.kts`:
```kotlin
plugins {
    `custom-jar-magic`
}
```

Later we will migrate the most (or all) the script plugins in this repository (which are currently in Groovy) into precompiled script plugins.