### PR TITLE
Add `javax.annotation-api` dependency

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -97,6 +97,8 @@ object Versions {
     val jackson          = "2.9.10.4"
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
+    val javaxAnnotation  = "1.3.2"
+
 
     /**
      * Version of the SLF4J library.
@@ -163,7 +165,8 @@ object Build {
 }
 
 object Gen {
-    val javaPoet = "com.squareup:javapoet:${Versions.javaPoet}"
+    val javaPoet        = "com.squareup:javapoet:${Versions.javaPoet}"
+    val javaxAnnotation = "javax.annotation:javax.annotation-api:${Versions.javaxAnnotation}"
 }
 
 object Grpc {

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -99,7 +99,6 @@ object Versions {
     val apiguardian      = "1.1.0"
     val javaxAnnotation  = "1.3.2"
 
-
     /**
      * Version of the SLF4J library.
      *


### PR DESCRIPTION
In this PR I have added the `annotation-api` dependency that is required for the Spine `protoc` plugin in order to be run safely with Java11.