### PR TITLE
Fail build during publishing and print stacktrace if any

### DIFF
--- a/scripts/publish-artifacts.sh
+++ b/scripts/publish-artifacts.sh
@@ -5,6 +5,9 @@
 # If the build is successful and the branch is `master`, script triggers the publishing process.
 #
 # Tests are skipped during the publishing, as the script should be executed after their execution.
+#
+# If the publishing fails, the script returns an error code `1` that is treated by Travis as a
+# failure and stops the build immediately.
 
 echo " -- PUBLISHING: current branch is $TRAVIS_BRANCH."
 
@@ -25,5 +28,3 @@ else
 fi
 
 echo " -- PUBLISHING: completed."
-
-exit 0

--- a/scripts/publish-artifacts.sh
+++ b/scripts/publish-artifacts.sh
@@ -11,8 +11,12 @@ echo " -- PUBLISHING: current branch is $TRAVIS_BRANCH."
 if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_TEST_RESULT" == 0 ]; then
         echo " ------ Publishing the artifacts to the repository..."
-        ./gradlew publish -x test
-        echo " ------ Artifacts published."
+        if ./gradlew publish -x test --stacktrace; then
+          echo " ------ Artifacts published."
+        else
+          echo " ------ Artifacts publishing FAILED."
+          exit 1
+        fi
     else
         echo " ------ The build is broken. Publishing will not be performed."
     fi
@@ -21,3 +25,5 @@ else
 fi
 
 echo " -- PUBLISHING: completed."
+
+exit 0


### PR DESCRIPTION
In this PR I modified the publishing script to fail the build if the publishing was not successful.