### PR TITLE
Specify the -Xmx for the publishing process itself.

### DIFF
--- a/scripts/publish-artifacts.sh
+++ b/scripts/publish-artifacts.sh
@@ -14,7 +14,7 @@ echo " -- PUBLISHING: current branch is $TRAVIS_BRANCH."
 if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_TEST_RESULT" == 0 ]; then
         echo " ------ Publishing the artifacts to the repository..."
-        if ./gradlew publish -x test --stacktrace; then
+        if ./gradlew publish -x test --stacktrace -Dorg.gradle.jvmargs="-Xmx4g -XX:+HeapDumpOnOutOfMemoryError"; then
           echo " ------ Artifacts published."
         else
           echo " ------ Artifacts publishing FAILED."


### PR DESCRIPTION
This change is an attempt to make sure the publishing process itself could use more memory.