### PR TITLE
Add a setting to allow `@Internal` Javadoc

### DIFF
--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -55,19 +55,31 @@ buildscript {
     }
 }
 
-apply from: deps.scripts.filterInternalJavadocs
-
 ext {
     javadocDir = Files.createTempDir()
     generatedDocs = files(javadocDir)
     repositoryTempDir = Files.createTempDir()
 }
 
+final String propertyName = 'allowInternalJavadoc'
+
+final boolean allowInternalJavadoc = ext.has(propertyName) && ext.get(propertyName)
+
+if (allowInternalJavadoc) {
+    apply from: deps.scripts.filterInternalJavadocs
+}
+
 /**
- * Copies the Javadoc produced by {@code :noInternalJavadoc} task into a temporary folder.
+ * Copies the Javadoc produced by a Javadoc task into a temporary folder.
+ *
+ * If `@Internal` Javadoc is allowed, uses the `:javadoc` task. Otherwise, uses
+ * the `:noInternalJavadoc` task.
+ *
+ * To allow `@Internal` Javadoc, set `ext.allowInternalJavadoc` property to `true` before applying
+ * this script to the project.
  */
 task copyJavadoc(type: Copy) {
-    from noInternalJavadoc
+    from allowInternalJavadoc ? tasks['javadoc'] : tasks['noInternalJavadoc']
     into javadocDir
 }
 

--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -25,13 +25,14 @@
  * To configure docs publishing, apply this script to the repositories which should generate
  * the doc:
  * ```
- * apply deps.scripts.updateGhPages
+ * apply(from: deps.scripts.updateGitHubPages)
  * ```
  * After that, the `updateGitHubPages` task will be available for that project.
  *
- * By default, the non-internal Javadoc is included into the publication. If needed, the publication
- * may be extended to include other files. To do so, append more files/file collections to
- * the `generatedDocs` extension property of the respective project.
+ * By default, the non-internal Javadoc is included into the publication. It is possible to publish
+ * all the Javadoc regardless of API status by setting the value of the `allowInternalJavadoc`
+ * extension property to `true`. If needed, the publication may be extended to include other files.
+ * To do so, append more files/file collections to the `generatedDocs` extension property.
  *
  * In order to work, the script needs a `deploy_key_rsa` private RSA key file in the repository
  * root. It is recommended to decrypt it in the repository an then decrypt it on CI upon


### PR DESCRIPTION
The Gradle script which publishes Javadoc to spine.io excludes the doc for components marked as `@Internal`. This is handy for external users, who might try to navigate the framework API via Javadoc. However, the module which configures the Javadoc filtering is a part of `base`, which makes it impossible to publish `base` (due to the bootstrapping problem).

In this PR we make the dependency between the Gradle script and the Javadoc filter agile. By default, `@Internal` doc won't be published. With a single line of Gradle config, the dependency may be removed, allowing for the Gradle script to be used in `base` but making it publish all the doc without filtering it.

To allow publishing all the Javadoc, set the value of `ext.allowInternalJavadoc` to `true`:
```gradle
ext {
    allowInternalJavadoc = true
}

apply(from: deps.scripts.updateGitHubPages)
```
