### PR TITLE
Fix Javadoc exclusion logic

### DIFF
--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -66,7 +66,7 @@ final String propertyName = 'allowInternalJavadoc'
 
 final boolean allowInternalJavadoc = ext.has(propertyName) && ext.get(propertyName)
 
-if (allowInternalJavadoc) {
+if (!allowInternalJavadoc) {
     apply from: deps.scripts.filterInternalJavadocs
 }
 


### PR DESCRIPTION
In this PR we address an error introduced in #134. The internal Javadoc exclusion condition is inverted to fit the purpose of the condition check.