### PR TITLE
Use the correct Travis API when triggering publishing

### DIFF
--- a/scripts/trigger-publishing.sh
+++ b/scripts/trigger-publishing.sh
@@ -30,4 +30,4 @@ curl -s -X POST \
  -H "Travis-API-Version: 3"\
  -H "Authorization: token $TRAVIS_TOKEN"\
  -d "$body"\
- "https://api.travis-ci.org/repo/SpineEventEngine%2Fpublishing/requests"
+ "https://api.travis-ci.com/repo/SpineEventEngine%2Fpublishing/requests"


### PR DESCRIPTION
This PR fixes the `trigger-publishing.sh` script to use the correct Travis URL.