### PR TITLE
Run the `CheckVersionIncrement` only during Pull Request builds

### DIFF
--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -28,10 +28,7 @@ repositories {
 }
 
 val jacksonVersion = "2.11.0"
-val floggerVersion = "0.5.1"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    implementation("com.google.flogger:flogger:$floggerVersion")
-    implementation("com.google.flogger:flogger-system-backend:$floggerVersion")
 }

--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -28,7 +28,10 @@ repositories {
 }
 
 val jacksonVersion = "2.11.0"
+val floggerVersion = "0.5.1"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+    implementation("com.google.flogger:flogger:$floggerVersion")
+    implementation("com.google.flogger:flogger-system-backend:$floggerVersion")
 }

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -20,6 +20,7 @@
 
 package io.spine.gradle.internal
 
+import com.google.common.flogger.FluentLogger
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -34,6 +35,8 @@ class IncrementGuard : Plugin<Project> {
         const val taskName = "checkVersionIncrement"
     }
 
+    private val logger: FluentLogger = FluentLogger.forEnclosingClass()
+
     /**
      * Adds the [CheckVersionIncrement] task to the project.
      *
@@ -45,6 +48,8 @@ class IncrementGuard : Plugin<Project> {
      */
     override fun apply(target: Project) {
         if (!isTravisPullRequest()) {
+            logger.atInfo().log("The build does not represent a Travis pull request job, " +
+                    "ignoring the `checkVersionIncrement` task.")
             return
         }
         val tasks = target.tasks

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -44,7 +44,9 @@ class IncrementGuard : Plugin<Project> {
      * tags, and in other cases that go outside of the "usual" development cycle.
      */
     override fun apply(target: Project) {
-        if (!isTravisPullRequest()) return
+        if (!isTravisPullRequest()) {
+            return
+        }
         val tasks = target.tasks
         tasks.register(taskName, CheckVersionIncrement::class.java) {
             repository = PublishingRepos.cloudRepo

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -61,6 +61,9 @@ class IncrementGuard : Plugin<Project> {
      *
      * Implementation note: the `TRAVIS_PULL_REQUEST` environment variable contains the pull
      * request number rather than `"true"` in positive case, hence the check.
+     *
+     * @see <a href="https://docs.travis-ci.com/user/environment-variables/#default-environment-variables">
+     *     List of default environment variables provided for Travis builds</a>
      */
     private fun isTravisPullRequest(): Boolean {
         val isPullRequest = System.getenv("TRAVIS_PULL_REQUEST")

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -20,7 +20,6 @@
 
 package io.spine.gradle.internal
 
-import com.google.common.flogger.FluentLogger
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -35,8 +34,6 @@ class IncrementGuard : Plugin<Project> {
         const val taskName = "checkVersionIncrement"
     }
 
-    private val logger: FluentLogger = FluentLogger.forEnclosingClass()
-
     /**
      * Adds the [CheckVersionIncrement] task to the project.
      *
@@ -47,17 +44,17 @@ class IncrementGuard : Plugin<Project> {
      * tags, and in other cases that go outside of the "usual" development cycle.
      */
     override fun apply(target: Project) {
-        if (!isTravisPullRequest()) {
-            logger.atInfo().log("The build does not represent a Travis pull request job, " +
-                    "ignoring the `checkVersionIncrement` task.")
-            return
-        }
         val tasks = target.tasks
         tasks.register(taskName, CheckVersionIncrement::class.java) {
             repository = PublishingRepos.cloudRepo
             tasks.getByName("check").dependsOn(this)
 
             shouldRunAfter("test")
+            if (!isTravisPullRequest()) {
+                logger.info("The build does not represent a Travis pull request job, the " +
+                        "`checkVersionIncrement` task is disabled.")
+                this.enabled = false
+            }
         }
     }
 


### PR DESCRIPTION
This PR modifies the `IncrementGuard` to run version increment check only during Travis Pull Request jobs.

The `checkVersionIncrement` task will no longer be executed:
1. during local builds;
2. for `merge` commits;
3. when building individual branches;
4. during any other CI checks rather than Travis build.

This change will allow CI checks to pass in situations outside of the "normal" build cycle, for example, when `master` should be re-built after artifacts are already published, or when a git tag is created.

Fixes #139.
