### PR TITLE
[2.x-jdk8] Absorb `config` at 1.6.0

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -98,6 +98,10 @@ object Versions {
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
     val javaxAnnotation  = "1.3.2"
+    val klaxon           = "5.4"
+    val ouathJwt         = "3.10.3"
+    val bouncyCastlePkcs = "1.66"
+    val assertK          = "0.22"
 
     /**
      * Version of the SLF4J library.
@@ -159,13 +163,20 @@ object Build {
 
     object AutoService {
         val annotations = "com.google.auto.service:auto-service-annotations:${Versions.autoService}"
-        val processor = "com.google.auto.service:auto-service:${Versions.autoService}"
+        val processor   = "com.google.auto.service:auto-service:${Versions.autoService}"
     }
 }
 
 object Gen {
     val javaPoet        = "com.squareup:javapoet:${Versions.javaPoet}"
     val javaxAnnotation = "javax.annotation:javax.annotation-api:${Versions.javaxAnnotation}"
+}
+
+object Publishing {
+    val klaxon           = "com.beust:klaxon:${Versions.klaxon}"
+    val oauthJwt         = "com.auth0:java-jwt:${Versions.ouathJwt}"
+    val bouncyCastlePkcs = "org.bouncycastle:bcpkix-jdk15on:${Versions.bouncyCastlePkcs}"
+    val assertK          = "com.willowtreeapps.assertk:assertk-jvm:${Versions.assertK}"
 }
 
 object Grpc {
@@ -275,6 +286,7 @@ object Deps {
     val test = Test
     val versions = Versions
     val scripts = Scripts
+    val publishing = Publishing
 }
 
 object DependencyResolution {

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -22,6 +22,8 @@
  * This script configures Gradle Checkstyle plugin.
  */
 
+apply plugin: 'checkstyle'
+
 checkstyle {
     toolVersion = "${deps.versions.checkstyle}"
     configFile = file("$rootDir/config/quality/checkstyle.xml")

--- a/quality/checkstyle.xml
+++ b/quality/checkstyle.xml
@@ -25,12 +25,15 @@
 
 <module name="Checker">
 
+    <module name="SuppressWarningsFilter"/>
+
     <module name="SuppressionFilter">
         <property name="file" value="config/quality/checkstyle-suppressions.xml"/>
         <property name="optional" value="false"/>
     </module>
 
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder"/>
         <module name="AvoidStarImport"/>
         <module name="EmptyCatchBlock"/>
         <module name="EmptyStatement"/>

--- a/scripts/trigger-publishing.sh
+++ b/scripts/trigger-publishing.sh
@@ -30,4 +30,4 @@ curl -s -X POST \
  -H "Travis-API-Version: 3"\
  -H "Authorization: token $TRAVIS_TOKEN"\
  -d "$body"\
- "https://api.travis-ci.org/repo/SpineEventEngine%2Fpublishing/requests"
+ "https://api.travis-ci.com/repo/SpineEventEngine%2Fpublishing/requests"


### PR DESCRIPTION
This changeset pulls the changes from the recent `master` branch (at its state after 1.6.0 release) to the `2.x-jdk8-master` branch.