### PR TITLE
[2.x-jdk8] Enable artifact publishing

### DIFF
--- a/scripts/publish-artifacts.sh
+++ b/scripts/publish-artifacts.sh
@@ -11,7 +11,7 @@
 
 echo " -- PUBLISHING: current branch is $TRAVIS_BRANCH."
 
-if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if { [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x-jdk8-master" ]; } && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_TEST_RESULT" == 0 ]; then
         echo " ------ Publishing the artifacts to the repository..."
         if ./gradlew publish -x test --stacktrace -Dorg.gradle.jvmargs="-Xmx4g -XX:+HeapDumpOnOutOfMemoryError"; then


### PR DESCRIPTION
This changeset enables the publishing for the `2.x-jdk8-master` branches.