### PR TITLE
[2.x-jdk8] Widen the definition of snapshot versions

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -114,7 +114,7 @@ projectsToPublish.each {
             currentProject.afterEvaluate(publishingAction)
         }
 
-        final boolean isSnapshots = currentProject.version.matches('.+-SNAPSHOT(\\+\\d+)?')
+        final boolean isSnapshots = currentProject.version.matches('.+[-\\.]SNAPSHOT([\\+\\.]\\d+)?')
 
         publishing {
             repositories {


### PR DESCRIPTION
When publishing an artifact, Spine's publishing routines determine the target repository basing on the version of the artifact.
The snapshot versions are published to the snapshot repository, the release versions go to the release repo.

Previously, only strings such as `1.6.10-SNAPSHOT+10` qualified as snapshot versions. This changeset updates the code to count versions like `2.0.0-jdk8.SNAPSHOT.4`  as snapshot versions as well.