### PR TITLE
[2.x-jdk8] Add a reference to the snapshot repo

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -351,6 +351,14 @@ object DependencyResolution {
                 includeGroup("io.spine.gcloud")
             }
         }
+        repositories.maven {
+            url = URI(Repos.spineSnapshots)
+            content {
+                includeGroup("io.spine")
+                includeGroup("io.spine.tools")
+                includeGroup("io.spine.gcloud")
+            }
+        }
         repositories.jcenter()
         repositories.maven {
             url = URI(Repos.gradlePlugins)


### PR DESCRIPTION
We have the `defaultRepositories()` clause which configures the Maven repositories to search for libraries in.

Previously, we referenced only our Spine releases (besides all the default repos, such as `jCenter()`). And we were not using the Spine's snapshot repository.

This changeset appends the Spine snapshot repo to the list of the sources which are configured with the `defaultRepositories()` clause.