### PR TITLE
Provide "y" as input to `pub publish`

### DIFF
--- a/gradle/dart/pub-publish-tasks.gradle
+++ b/gradle/dart/pub-publish-tasks.gradle
@@ -47,9 +47,11 @@ task stagePubPublication(type: Copy) {
 task publishToPub(type: Exec) {
     description = 'Publishes this package to Pub.'
 
-    commandLine PUB_EXECUTABLE, 'publish', '--trace'
-
     workingDir publicationDir
+    commandLine PUB_EXECUTABLE, 'publish', '--trace'
+    final sayYes = new ByteArrayInputStream('y'.getBytes())
+    standardInput(sayYes)
+
     dependsOn 'stagePubPublication'
 }
 


### PR DESCRIPTION
`pub publish` command requires manual user approval. In order for it to pass, we provide the line "y" (as in "yes") to the `pub publish` process via standard input.