### PR TITLE
Remove call to deleted method `columns`

### DIFF
--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -50,10 +50,6 @@ modelCompiler {
         applyFactory "io.spine.code.gen.java.UuidMethodFactory", messages().uuid()
     }
 
-    columns {
-        generate = true
-    }
-
     fields {
         generateFor messages().inFiles(suffix: "events.proto"), markAs("io.spine.base.EventMessageField")
         generateFor messages().inFiles(suffix: "rejections.proto"), markAs("io.spine.base.EventMessageField")


### PR DESCRIPTION
Since recent changes in Model Compiler, we no longer have to configure `columns { }` in Gradle. This PR removes the call to that deleted method from `model-compiler.gradle`.