### PR TITLE
Update year to 2021 in copyright notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcs.properties
+++ b/gcs.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/dart/build-tasks.gradle
+++ b/gradle/dart/build-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/dart/pub-publish-tasks.gradle
+++ b/gradle/dart/pub-publish-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/filter-internal-javadoc.gradle
+++ b/gradle/filter-internal-javadoc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/generate-pom.gradle
+++ b/gradle/generate-pom.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/javac-args.gradle
+++ b/gradle/javac-args.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/javadoc-options.gradle
+++ b/gradle/javadoc-options.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/js/build-tasks.gradle
+++ b/gradle/js/build-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/js/configure-proto.gradle
+++ b/gradle/js/configure-proto.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/js/npm-cli.gradle
+++ b/gradle/js/npm-cli.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/js/npm-publish-tasks.gradle
+++ b/gradle/js/npm-publish-tasks.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/js/update-package-version.gradle
+++ b/gradle/js/update-package-version.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/license-report-common.gradle
+++ b/gradle/license-report-common.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/license-report-project.gradle
+++ b/gradle/license-report-project.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/license-report-repo.gradle
+++ b/gradle/license-report-repo.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/pmd.gradle
+++ b/gradle/pmd.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/publish-proto.gradle
+++ b/gradle/publish-proto.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/run-build.gradle
+++ b/gradle/run-build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/slow-tests.gradle
+++ b/gradle/slow-tests.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/test-artifacts.gradle
+++ b/gradle/test-artifacts.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/test-output.gradle
+++ b/gradle/test-output.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2021, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pull
+++ b/pull
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/quality/checkstyle-suppressions.xml
+++ b/quality/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <!--
-  ~ Copyright 2020, TeamDev. All rights reserved.
+  ~ Copyright 2021, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/quality/checkstyle.xml
+++ b/quality/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <!--
-  ~ Copyright 2020, TeamDev. All rights reserved.
+  ~ Copyright 2021, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2020, TeamDev. All rights reserved.
+  ~ Copyright 2021, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scripts/publish-artifacts.sh
+++ b/scripts/publish-artifacts.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/register-ssh-key.sh
+++ b/scripts/register-ssh-key.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/trigger-publishing.sh
+++ b/scripts/trigger-publishing.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update-apt.sh
+++ b/scripts/update-apt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/upload-artifacts.sh
+++ b/scripts/upload-artifacts.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2020, TeamDev. All rights reserved.
+# Copyright 2021, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/util/remove_finals.py
+++ b/scripts/util/remove_finals.py
@@ -22,14 +22,6 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#  http://www.apache.org/licenses/LICENSE-2.0
-#
-#
 """Scans a directory with Java files recursively and removes the `final` modifier from all local
 variables in the Java code.
 

--- a/scripts/util/remove_finals.py
+++ b/scripts/util/remove_finals.py
@@ -1,4 +1,4 @@
-#  Copyright 2020, TeamDev. All rights reserved.
+#  Copyright 2021, TeamDev. All rights reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -22,6 +22,14 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#
 """Scans a directory with Java files recursively and removes the `final` modifier from all local
 variables in the Java code.
 


### PR DESCRIPTION
This PR updates the copyright notices to the year 2021.

An [equivalent PR](#166) also updates the `2.x-jdk8-master` branch.