### PR TITLE
Start preparing 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,13 @@ In Spine, dependencies and CI configurations are shared among the sub-projects.
 
 The code of this repository should be added to a target project as a Git sub-module.
 
-# This is 2.x `master` branch!
+## Adding a sub-module to your project
 
-This branch contains the configuration for the development-only 2.x branches of the Spine libraries.
-
-It must **NOT** be merged to the `master`, at least until the release of Spine 2.0.0.
-
-The configuration in this branch is **not production-ready**. 
-
-This branch must be treated as `master` for the configuration required during 
-the Spine 2.0.0 development. Any the changes to it must go through the PR review process.
- 
-## `config` submodule in 2.x branch
-
-The common configuration files are located in the [SpineEventEngine/config](https://github.com/SpineEventEngine/config)
-repository. In scope of 2.x development a special `2.x-jdk8-master` branch has been created 
-in the `config` repository as well. It has been connected to the current repository as a submodule.
+To add a sub-module:
+```bash
+git submodule add https://github.com/SpineEventEngine/config config
+``` 
+This will only add a sub-module with the reference to the repository.
 
 In order to get the actual code for the `config` submodule, run the following command:
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,14 +2,24 @@ In Spine, dependencies and CI configurations are shared among the sub-projects.
 
 The code of this repository should be added to a target project as a Git sub-module.
 
-## Adding a sub-module to your project
+# This is 2.x `master` branch!
 
-To add a sub-module:
-```bash
-git submodule add https://github.com/SpineEventEngine/config config
-``` 
-This will only add a sub-module with the reference to the repository. 
-In order to get the code, run the following command:
+This branch contains the configuration for the development-only 2.x branches of the Spine libraries.
+
+It must **NOT** be merged to the `master`, at least until the release of Spine 2.0.0.
+
+The configuration in this branch is **not production-ready**. 
+
+This branch must be treated as `master` for the configuration required during 
+the Spine 2.0.0 development. Any the changes to it must go through the PR review process.
+ 
+## `config` submodule in 2.x branch
+
+The common configuration files are located in the [SpineEventEngine/config](https://github.com/SpineEventEngine/config)
+repository. In scope of 2.x development a special `2.x-jdk8-master` branch has been created 
+in the `config` repository as well. It has been connected to the current repository as a submodule.
+
+In order to get the actual code for the `config` submodule, run the following command:
 ```bash
 git submodule update --init --recursive
 ```
@@ -28,12 +38,8 @@ project. The following files will be copied:
  * `.codecov.yml`
  * `.gitattributes`
  * `.gitignore`
- * `ext.gradle`
+ * `buildSrc` — a folder containing the common build-time code, in Kotlin.
  
-    This file will be copied only if it does not exist in your project. It defines the following:
-    1. the version of Spine Base which is used by the project (which uses `config`)
-    2. the version under which artifacts of the project will be published.
-
 ## Adding credentials to a new repository
 
 For details, see [this page](https://github.com/SpineEventEngine/config/wiki/Encrypting-Credential-Files-for-Travis).

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -76,8 +76,8 @@ open class RunBuild : DefaultTask() {
         val command = mutableListOf<String>()
         command.add("${project.rootDir}/$script")
         val shouldClean = project.gradle
-            .taskGraph
-            .hasTask(":clean")
+                                 .taskGraph
+                                 .hasTask(":clean")
         if (shouldClean) {
             command.add("clean")
         }

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -365,6 +365,14 @@ object DependencyResolution {
                 includeGroup("io.spine.gcloud")
             }
         }
+        repositories.maven {
+            url = URI(Repos.spineSnapshots)
+            content {
+                includeGroup("io.spine")
+                includeGroup("io.spine.tools")
+                includeGroup("io.spine.gcloud")
+            }
+        }
         repositories.jcenter()
         repositories.maven {
             url = URI(Repos.gradlePlugins)

--- a/gradle/model-compiler.gradle
+++ b/gradle/model-compiler.gradle
@@ -32,11 +32,20 @@
  * — all messages in Protobuf files ending with "events.proto" are marked as `EventMessage`;
  * — all messages in Protobuf files ending with "rejections.proto" are marked as `RejectionMessage`;
  * — all messages that qualify to be UUID messages are marked as `UuidValue`;
- * — all messages that represent the entity state are marked as `EntityState`.
+ * — all messages that represent an entity state are marked as `EntityState`.
  *
  * And the following method generations are applied:
  * — all messages that qualify to be UUID messages have helper `generate` and `of` methods
  *   generated using `UuidMethodFactory`;
+ *
+ * The generation of messages representing an entity state are appended with
+ * - entity columns for the fields marked as `column`;
+ * - entity query and entity query builder DSL.
+ *
+ * The fields of the messages are marked with certain interfaces:
+ * - `io.spine.base.EventMessageField` set to those in `*events.proto` and `*rejections.proto`;
+ * - `io.spine.query.EntityStateField` set to the fields of messages representing an entity state.
+ *
  *
  * Be aware that the root project `buildscript` should already have a classpath
  * `io.spine.tools:spine-model-compiler:<version>` classpath dependency.
@@ -56,13 +65,13 @@ modelCompiler {
         applyFactory "io.spine.code.gen.java.UuidMethodFactory", messages().uuid()
     }
 
-    columns {
+    entityQueries {
         generate = true
     }
 
     fields {
         generateFor messages().inFiles(suffix: "events.proto"), markAs("io.spine.base.EventMessageField")
         generateFor messages().inFiles(suffix: "rejections.proto"), markAs("io.spine.base.EventMessageField")
-        generateFor messages().entityState(), markAs("io.spine.base.EntityStateField")
+        generateFor messages().entityState(), markAs("io.spine.query.EntityStateField")
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -120,7 +120,7 @@ projectsToPublish.each {
             currentProject.afterEvaluate(publishingAction)
         }
 
-        final boolean isSnapshots = currentProject.version.matches('.+-SNAPSHOT(\\+\\d+)?')
+        final boolean isSnapshots = currentProject.version.matches('.+[-\\.]SNAPSHOT([\\+\\.]\\d+)?')
 
         publishing {
             repositories {

--- a/pull
+++ b/pull
@@ -44,8 +44,8 @@ git submodule update
 # Make the `config` dir current.
 cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
 
-# Set the current branch to `2.x-jdk8-master`.
-git checkout 2.x-jdk8-master
+# Set the current branch to `master`.
+git checkout master
 
 echo "Pulling changes from remote repo"
 git pull

--- a/pull
+++ b/pull
@@ -44,8 +44,8 @@ git submodule update
 # Make the `config` dir current.
 cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
 
-# Set the current branch to master.
-git checkout master
+# Set the current branch to `2.x-jdk8-master`.
+git checkout 2.x-jdk8-master
 
 echo "Pulling changes from remote repo"
 git pull

--- a/scripts/publish-artifacts.sh
+++ b/scripts/publish-artifacts.sh
@@ -37,7 +37,7 @@
 
 echo " -- PUBLISHING: current branch is $TRAVIS_BRANCH."
 
-if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if { [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x-jdk8-master" ]; } && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_TEST_RESULT" == 0 ]; then
         echo " ------ Publishing the artifacts to the repository..."
         if ./gradlew publish -x test --stacktrace -Dorg.gradle.jvmargs="-Xmx4g -XX:+HeapDumpOnOutOfMemoryError"; then


### PR DESCRIPTION
This PR merges the changes from `2.x-jdk8-master` to `master`.

With this, we prepare for Spine release 2.0.

Migration to Java 11 is planned for later.