### PR TITLE
Fix the POM generation.

### DIFF
--- a/gradle/generate-pom.gradle
+++ b/gradle/generate-pom.gradle
@@ -27,6 +27,8 @@
 import groovy.xml.MarkupBuilder
 import org.gradle.api.internal.artifacts.dependencies.AbstractExternalModuleDependency
 
+import java.util.function.Function
+
 import static java.util.stream.Collectors.toSet
 
 /**
@@ -472,17 +474,12 @@ class DependencyWithScope implements Comparable<DependencyWithScope> {
 
     @Override
     int compareTo(DependencyWithScope o) {
-        if (this.scope().equals(o.scope())) {
-            Dependency thatDependency = o.dependency()
-            if (this.dependency().group.equals(thatDependency.group)) {
-                if (this.dependency().name.equals(thatDependency.name)) {
-                    return this.dependency().version.compareTo(thatDependency.version)
-                }
-                return this.dependency().name.compareTo(thatDependency.name)
-            }
-            return this.dependency().group.compareTo(thatDependency.group)
-        }
-        return dependencyPriority() - o.dependencyPriority()
+        return Comparator
+                .comparingInt { it.dependencyPriority() }
+                .thenComparing((Function<DependencyWithScope, String>) { it.dependency().group })
+                .thenComparing((Function<DependencyWithScope, String>) { it.dependency().name })
+                .thenComparing((Function<DependencyWithScope, String>) { it.dependency().version })
+                .compare(this, o)
     }
 
     /**

--- a/gradle/generate-pom.gradle
+++ b/gradle/generate-pom.gradle
@@ -350,6 +350,26 @@ class DependencyWithScope implements Comparable<DependencyWithScope> {
      */
     private static Map<String, DependencyScope> CONFIG_TO_SCOPE
 
+
+    /**
+     * Performs comparison of {@code DependencyWithScope} instances based on the following rules:
+     *
+     * <ul>
+     *     <li>Compares the scope of the dependency first. Dependencies with lower scope
+     *     {@linkplain #dependencyPriority priority} number goes first.
+     *     <li>For dependencies with same scope does the lexicographical group name comparison.
+     *     <li>For dependencies within the same group does the lexicographical artifact
+     *     name comparison.
+     *     <li>For dependencies with the same artifact name does the lexicographical artifact
+     *     version comparison.
+     * </ul>
+     */
+    private static final Comparator<DependencyWithScope> COMPARATOR = Comparator
+            .comparingInt { it.dependencyPriority() }
+            .thenComparing((Function<DependencyWithScope, String>) { it.dependency().group })
+            .thenComparing((Function<DependencyWithScope, String>) { it.dependency().name })
+            .thenComparing((Function<DependencyWithScope, String>) { it.dependency().version })
+
     static {
         DependencyScope compile = DependencyScope.compile
         DependencyScope runtime = DependencyScope.runtime
@@ -474,12 +494,7 @@ class DependencyWithScope implements Comparable<DependencyWithScope> {
 
     @Override
     int compareTo(DependencyWithScope o) {
-        return Comparator
-                .comparingInt { it.dependencyPriority() }
-                .thenComparing((Function<DependencyWithScope, String>) { it.dependency().group })
-                .thenComparing((Function<DependencyWithScope, String>) { it.dependency().name })
-                .thenComparing((Function<DependencyWithScope, String>) { it.dependency().version })
-                .compare(this, o)
+        return COMPARATOR.compare(this, o)
     }
 
     /**

--- a/gradle/generate-pom.gradle
+++ b/gradle/generate-pom.gradle
@@ -475,8 +475,8 @@ class DependencyWithScope implements Comparable<DependencyWithScope> {
         if (this.scope().equals(o.scope())) {
             Dependency thatDependency = o.dependency()
             if (this.dependency().group.equals(thatDependency.group)) {
-                if (this.dependency().name.equals(thatDependency)) {
-                    return this.dependency().version.compareTo(thatDependency.name)
+                if (this.dependency().name.equals(thatDependency.name)) {
+                    return this.dependency().version.compareTo(thatDependency.version)
                 }
                 return this.dependency().name.compareTo(thatDependency.name)
             }


### PR DESCRIPTION
Fixes #170. This PR is a copy of the #168 PR that brings the fix to the `master` branch.

This PR fixes the POM generation process when there's a dependency with the same name and version.

This usually should not happen if the dependencies are forced and duplicates are excluded, but if not we may have such a situation when we're comparing the name and the version.