### PR TITLE
Allow empty commits to `gh-pages`

### DIFF
--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -235,7 +235,7 @@ Host github.com-publish
     execute repoBaseDir, "git", "config", "user.name", "\"UpdateGitHubPages Plugin\""
     execute repoBaseDir, "git", "config", "user.email", System.env.FORMAL_GIT_HUB_PAGES_AUTHOR
 
-    execute repoBaseDir, "git", "commit", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
+    execute repoBaseDir, "git", "commit", "--allow-empty", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
     execute repoBaseDir, "git", "push"
     logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` sucessfully")
 }


### PR DESCRIPTION
In this PR we allow the script which automatically updates the generated docs on GitHub Pages to make empty commits to the `gh-pages` branch.

Unless allowed explicitly, empty commits are an error in Git. However, for the purposes of our automatic system, we might want to make such commits. If, for example, nothing but infrastructural files are changed in a PR, or a successful `master` build is restarted, we don't want the build to fail just because the generated reference documentation has not changed.