### PR TITLE
Ignore a Flogger-related warning

### DIFF
--- a/gradle/javac-args.gradle
+++ b/gradle/javac-args.gradle
@@ -63,5 +63,6 @@ tasks.withType(JavaCompile) {
                                              '-Xep:ClassCanBeStatic:OFF',
                                              '-Xep:UnusedMethod:OFF',
                                              '-Xep:UnusedVariable:OFF',
-                                             '-Xep:CheckReturnValue:OFF')
+                                             '-Xep:CheckReturnValue:OFF',
+                                             '-Xep:FloggerSplitLogStatement:OFF')
 }


### PR DESCRIPTION
In this PR we disable the new `FloggerSplitLogStatement` ErrorProne warning.

Splitting Flogger statements is a conscious decision we've made for the sake of simpler logging API with `Logging`. This check will not prevent us from making a mistake. Instead, it is a nuisance.