### PR TITLE
Phase out `jcenter()`

### DIFF
--- a/gradle/buildSrc/build.gradle.kts
+++ b/gradle/buildSrc/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
 }
 
 val jacksonVersion = "2.11.0"

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -461,7 +461,7 @@ object DependencyResolution {
                 includeGroup("io.spine.gcloud")
             }
         }
-        repositories.jcenter()
+        repositories.mavenCentral()
         repositories.maven {
             url = URI(Repos.gradlePlugins)
         }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -292,7 +292,7 @@ ext.defaultRepositories = { final repositoryContainer ->
                 releasesOnly()
             }
         }
-        jcenter()
+        mavenCentral()
         maven { url = repos.gradlePlugins }
     }
 }

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -33,7 +33,7 @@
 
 // Required to grab dependencies for `jacocoRootReport` task.
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 import groovy.io.FileType

--- a/gradle/publish-proto.gradle
+++ b/gradle/publish-proto.gradle
@@ -53,8 +53,8 @@ import com.google.common.collect.Lists
 
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
+        mavenCentral()
     }
 
     dependencies {

--- a/gradle/update-gh-pages.gradle
+++ b/gradle/update-gh-pages.gradle
@@ -54,7 +54,7 @@ buildscript {
     apply from: "$rootDir/config/gradle/dependencies.gradle"
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
We're phasing out the usage of the JCenter Maven repository, replacing it with the conventional Maven Central. JCenter is announced to be shut down soon and is already experiencing deteriorated performance.