### PR TITLE
Maven repo credentials without a file

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -46,10 +46,17 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 data class Repository(
     val releases: String,
     val snapshots: String,
-    val credentialsFile: String? = null,
-    val credentials: Credentials? = null
+    private val credentialsFile: String? = null,
+    private val credentials: Credentials? = null
 ) {
 
+    /**
+     * Obtains the publishing password credentials to this repository.
+     *
+     * If the credentials are represented by a `.properties` file, reads the file and parses
+     * the credentials. The file must have properties `user.name` and `user.password`, which store
+     * the username and the password for the Maven repository auth.
+     */
     fun credentials(project: Project): Credentials {
         if (credentials != null) {
             return credentials

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -47,10 +47,10 @@ data class Repository(
     val releases: String,
     val snapshots: String,
     val credentialsFile: String? = null,
-    val credentials: Credentals? = null
+    val credentials: Credentials? = null
 ) {
 
-    fun credentials(project: Project): Credentals {
+    fun credentials(project: Project): Credentials {
         if (credentials != null) {
             return credentials
         } else {
@@ -64,7 +64,7 @@ data class Repository(
                 val username = properties.getProperty("user.name")
                 val password = properties.getProperty("user.password")
                 log.info("Publishing build as `${username}`.")
-                return Credentals(username, password)
+                return Credentials(username, password)
             } else {
                 throw InvalidUserDataException(
                     "Please set up valid credentials." +
@@ -79,7 +79,7 @@ data class Repository(
 /**
  * Password credentials for a Maven repository.
  */
-data class Credentals(
+data class Credentials(
     val username: String,
     val password: String
 )
@@ -104,7 +104,7 @@ object PublishingRepos {
         return Repository(
             releases = "https://maven.pkg.github.com/SpineEventEngine/$repoName",
             snapshots = "https://maven.pkg.github.com/SpineEventEngine/$repoName",
-            credentials = Credentals(
+            credentials = Credentials(
                 username = System.getenv("GITHUB_ACTOR"),
                 // This is a trick. Gradle only supports password or AWS credentials. Thus,
                 // we pass the GitHub token as a "password".

--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -90,6 +90,7 @@ data class Credentials(
  * See `publish.gradle` for details of the publishing process.
  */
 object PublishingRepos {
+
     val mavenTeamDev = Repository(
         releases = "http://maven.teamdev.com/repository/spine",
         snapshots = "http://maven.teamdev.com/repository/spine-snapshots",
@@ -100,6 +101,7 @@ object PublishingRepos {
         snapshots = "https://spine.mycloudrepo.io/public/repositories/snapshots",
         credentialsFile = "cloudrepo.properties"
     )
+
     fun gitHub(repoName: String) {
         return Repository(
             releases = "https://maven.pkg.github.com/SpineEventEngine/$repoName",

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -35,36 +35,6 @@
   ```
  */
 
-// See `dependencies.gradle` for the selection of the target repository.
-final String credentialsPropertyFile = publishToRepository.credentials
-
-String repositoryUserName = null
-String repositoryUserPassword = null
-
-final Properties properties = new Properties()
-final File credentialsFile = project.file(credentialsPropertyFile)
-if (credentialsFile.exists()) {
-    logger.info("Using credentials from $credentialsFile.")
-    properties.load(credentialsFile.newDataInputStream())
-    repositoryUserName = properties.getProperty("user.name")
-    repositoryUserPassword = properties.getProperty("user.password")
-}
-
-task checkPublishingCredentials {
-    doLast {
-        if (repositoryUserName == null || repositoryUserPassword == null) {
-            logger.error("Credentials file `$credentialsFile` does not exist.")
-
-            throw new InvalidUserDataException(
-                    "Please set up valid credentials." +
-                            " Credentials must be set in `${credentialsPropertyFile}` file in" +
-                            " the project root."
-            )
-        }
-        println "Publishing build as ${repositoryUserName}"
-    }
-}
-
 task publish {
     doLast {
         // Keep the task for dynamic generation while publishing.
@@ -91,13 +61,18 @@ projectsToPublish.each {
             archives javadocJar
         }
 
+        final boolean spinePrefix = rootProject.ext["spinePrefix"] ?: true
+
         // Artifact IDs are composed as "spine-<project.name>". Example:
         //
         //      "spine-model-compiler"
         //
         // That helps to distinguish resulting JARs in the final assembly, such as WAR package.
         //
-        final String artifactIdForPublishing = "spine-${currentProject.name}"
+        final String artifactIdForPublishing =
+                spinePrefix ?
+                "spine-${currentProject.name}" :
+                currentProject.name
 
         final def publishingAction = {
             currentProject.publishing {
@@ -138,9 +113,11 @@ projectsToPublish.each {
                     // Assign URL to the plugin property.
                     url = urlToPublish
 
+                    final credentials = rootProject.publishToRepository.credentials(project)
+
                     credentials {
-                        username = "${repositoryUserName}"
-                        password = "${repositoryUserPassword}"
+                        username = credentials.username
+                        password = credentials.password
                     }
                 }
             }


### PR DESCRIPTION
In this PR we allow to specify publishing credentials for a Maven repository via arguments, instead of a properties file.

We also define a preset for GitHub Packages publishing.