### PR TITLE
Fix error in JaCoCo script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,5 +55,6 @@ pull text eol=lf
 *.scpt binary
 *.scssc binary
 
-# Encoded files
+# Encrypted files
 *.enc binary
+*.gpg binary

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -194,7 +194,7 @@ class CodebaseFilter {
                 .stream()
                 .flatMap { it.getClassesDirs().files.stream() }
                 .map { final srcFile ->
-                    log("Filtering out the generated classes for ${srcFile)}")
+                    log("Filtering out the generated classes for ${srcFile}")
 
                     // Return the filtered `fileTree`s as a collected result.
                     return project.fileTree(dir: srcFile, exclude: { final details ->


### PR DESCRIPTION
In this PR we fix a compilation error in `jacoco.gradle`.

We also update `.gitattributes` file with a new encryption file extension.