### PR TITLE
Allow extra artifacts

### DIFF
--- a/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/Publish.kt
+++ b/gradle/buildSrc/src/main/kotlin/io/spine/gradle/internal/Publish.kt
@@ -120,10 +120,10 @@ class Publish : Plugin<Project> {
                         publishingExtension.setUpRepositories(p, extension)
                         p.prepareTasks(publish, checkCredentials)
                     }
-                    if (state.executed) {
+                    if (p.state.executed) {
                         action()
                     } else {
-                        afterEvaluate { action() }
+                        p.afterEvaluate { action() }
                     }
                 }
         }
@@ -199,7 +199,7 @@ class Publish : Plugin<Project> {
 
     private fun PublishingExtension.createMavenPublication(project: Project,
                                                            extension: PublishExtension) {
-        val artifactIdForPublishing = if(extension.spinePrefix.get()) {
+        val artifactIdForPublishing = if (extension.spinePrefix.get()) {
             "spine-${project.name}"
         } else {
             project.name


### PR DESCRIPTION
In this PR we allow adding extra artifacts to the Maven publication. Previously, this ability was broken by a configuration error.