### PR TITLE
Address PMD warnings

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/Repositories.kt
@@ -27,8 +27,10 @@
 package io.spine.gradle.internal
 
 import java.io.File
+import java.net.URI
 import java.util.*
 import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
 
 /**
  * A Maven repository.
@@ -122,7 +124,11 @@ object PublishingRepos {
     }
 }
 
-// Specific repositories.
+/**
+ * Defines names of the commonly used repositories.
+ *
+ * @see [applyStandard]
+ */
 @Suppress("unused")
 object Repos {
     val oldSpine: String = PublishingRepos.mavenTeamDev.releases
@@ -132,5 +138,35 @@ object Repos {
     val spineSnapshots: String = PublishingRepos.cloudRepo.snapshots
 
     const val sonatypeSnapshots: String = "https://oss.sonatype.org/content/repositories/snapshots"
+
+    @Deprecated("Please use `gradlePluginPortal()` call instead of the hard-coded URL.")
     const val gradlePlugins = "https://plugins.gradle.org/m2/"
+}
+
+/**
+ * Applies repositories commonly used by Spine Event Engine projects.
+ */
+@Suppress("unused")
+fun applyStandard(repositories: RepositoryHandler) {
+    repositories.apply {
+        gradlePluginPortal()
+        mavenLocal()
+        maven {
+            url = URI(Repos.spine)
+            content {
+                includeGroup("io.spine")
+                includeGroup("io.spine.tools")
+                includeGroup("io.spine.gcloud")
+            }
+        }
+        maven {
+            url = URI(Repos.spineSnapshots)
+            content {
+                includeGroup("io.spine")
+                includeGroup("io.spine.tools")
+                includeGroup("io.spine.gcloud")
+            }
+        }
+        mavenCentral()
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -26,7 +26,6 @@
 
 package io.spine.gradle.internal
 
-import java.net.URI
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 
@@ -424,6 +423,7 @@ object Build {
 }
 
 object Gen {
+    @Suppress("unused")
     const val javaPoet = JavaPoet.lib
     @Suppress("unused")
     const val javaxAnnotation = JavaX.annotations
@@ -459,10 +459,11 @@ object Test {
         "Use Flogger over SLF4J.",
         replaceWith = ReplaceWith("Flogger.Runtime.systemBackend")
     )
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "unused")
     const val slf4j = Slf4J.jdk14
 }
 
+@Suppress("unused")
 object Deps {
     val build = Build
     val grpc = Grpc
@@ -541,27 +542,11 @@ object DependencyResolution {
     }
 
     @Suppress("unused")
+    @Deprecated(
+        "Please use `applyStandard(repositories)` instead.",
+        replaceWith = ReplaceWith("applyStandard(repositories)")
+    )
     fun defaultRepositories(repositories: RepositoryHandler) {
-        repositories.mavenLocal()
-        repositories.maven {
-            url = URI(Repos.spine)
-            content {
-                includeGroup("io.spine")
-                includeGroup("io.spine.tools")
-                includeGroup("io.spine.gcloud")
-            }
-        }
-        repositories.maven {
-            url = URI(Repos.spineSnapshots)
-            content {
-                includeGroup("io.spine")
-                includeGroup("io.spine.tools")
-                includeGroup("io.spine.gcloud")
-            }
-        }
-        repositories.mavenCentral()
-        repositories.maven {
-            url = URI(Repos.gradlePlugins)
-        }
+        applyStandard(repositories)
     }
 }

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -108,7 +108,7 @@
     <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
     <rule ref="category/java/errorprone.xml/CheckSkipResult"/>
     <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
-    <rule ref="category/java/errorprone.xml/DoNotCallSystemExit"/>
+    <rule ref="category/java/errorprone.xml/DoNotTerminateVM"/>
     <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard"/>
     <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
     <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
@@ -145,7 +145,6 @@
     <rule ref="category/java/performance.xml/IntegerInstantiation"/>
     <rule ref="category/java/performance.xml/LongInstantiation"/>
     <rule ref="category/java/performance.xml/ShortInstantiation"/>
-    <rule ref="category/java/performance.xml/SimplifyStartsWith"/>
     <rule ref="category/java/performance.xml/StringInstantiation"/>
     <rule ref="category/java/performance.xml/StringToString"/>
     <rule ref="category/java/performance.xml/UseArraysAsList"/>

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -35,47 +35,16 @@
     <!-- Always exclude the Protobuf-generated files, as they generate a lot of warnings. -->
     <exclude-pattern>.*/generated/.*</exclude-pattern>
 
-    <rule ref="category/java/errorprone.xml/NonCaseLabelInSwitchStatement"/>
-    <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
-    <rule ref="category/java/codestyle.xml/NoPackage"/>
-    <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
-    <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause"/>
-    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
-
-    <!-- Will become deprecated in Java 9 onwards. -->
-    <rule ref="category/java/errorprone.xml/AvoidCallingFinalize"/>
-
-    <rule ref="category/java/performance.xml/StringToString"/>
-    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
-    <rule ref="category/java/errorprone.xml/EmptyIfStmt"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementBlock"/>
-
-    <!-- Will become deprecated in Java 9 onwards. -->
-    <rule ref="category/java/errorprone.xml/EmptyFinalizer"/>
-
-    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptySwitchStatements"/>
-    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyTryBlock"/>
-    <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
-    <rule ref="category/java/performance.xml/BooleanInstantiation"/>
-    <rule ref="category/java/performance.xml/ByteInstantiation"/>
-    <rule ref="category/java/performance.xml/IntegerInstantiation"/>
-    <rule ref="category/java/performance.xml/LongInstantiation"/>
-    <rule ref="category/java/performance.xml/ShortInstantiation"/>
-    <rule ref="category/java/performance.xml/StringInstantiation"/>
-    <rule ref="category/java/design.xml/ExcessiveParameterList"/>
-    <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
-    <rule ref="category/java/design.xml/ExcessiveClassLength"/>
-    <rule ref="category/java/design.xml/ExcessiveMethodLength"/>
+    <!-- Best Practices       -->
     <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
-    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock"/>
-    <rule ref="category/java/design.xml/AvoidThrowingNullPointerException"/>
-    <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes"/>
-    <rule ref="category/java/design.xml/SimplifyBooleanExpressions"/>
-    <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
-    <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
+    <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>
+    <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
+    <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
+    <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap"/>
+    <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList"/>
+    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
     <rule ref="category/java/bestpractices.xml/UnusedImports"/>
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
@@ -85,70 +54,104 @@
                       value="io.spine.server.aggregate.Apply|java.lang.Deprecated"/>
         </properties>
     </rule>
-    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
-    <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop"/>
-    <rule ref="category/java/errorprone.xml/EqualsNull"/>
-    <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
-    <rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
-    <rule ref="category/java/errorprone.xml/CheckSkipResult"/>
-    <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
+
+    <!-- Code Style -->
+    <rule ref="category/java/codestyle.xml/CallSuperInConstructor"/>
     <rule ref="category/java/codestyle.xml/ClassNamingConventions">
         <properties>
             <!-- Override the default "[A-Z][a-zA-Z0-9]+(Utils?|Helper)" value. -->
             <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]*"/>
         </properties>
     </rule>
-    <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass"/>
-    <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap"/>
-    <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList"/>
-    <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard"/>
-    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
-    <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
-    <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
-    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
-    <rule ref="category/java/errorprone.xml/EmptyInitializer"/>
+    <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
+    <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
+    <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
     <rule ref="category/java/codestyle.xml/GenericsNaming"/>
-    <rule ref="category/java/codestyle.xml/CallSuperInConstructor"/>
-
-    <!-- Do we need that at all, given Google Truth? -->
-    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>
-
-    <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
     <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
-    <rule ref="category/java/codestyle.xml/ExtendsObject"/>
-    <rule ref="category/java/errorprone.xml/NonStaticInitializer"/>
+    <rule ref="category/java/codestyle.xml/NoPackage"/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
-    <rule ref="category/java/design.xml/SingularField"/>
-    <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
-    <rule ref="category/java/errorprone.xml/AssignmentToNonFinalStatic"/>
-    <rule ref="category/java/performance.xml/UseStringBufferForStringAppends"/>
-    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
-    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
-    <rule ref="category/java/errorprone.xml/DoNotCallSystemExit"/>
-    <rule ref="category/java/design.xml/NPathComplexity"/>
-    <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
-    <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
-    <rule ref="category/java/performance.xml/SimplifyStartsWith"/>
-    <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
-    <rule ref="category/java/performance.xml/UseStringBufferLength"/>
-    <rule ref="category/java/design.xml/TooManyFields"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+    <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
 
+    <!--  Design -->
+    <rule ref="category/java/design.xml/AvoidThrowingNullPointerException"/>
+    <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes"/>
+    <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
+    <rule ref="category/java/design.xml/ExcessiveClassLength"/>
+    <rule ref="category/java/design.xml/ExcessiveMethodLength"/>
+    <rule ref="category/java/design.xml/ExcessiveParameterList"/>
+    <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
+    <rule ref="category/java/design.xml/LogicInversion"/>
+    <rule ref="category/java/design.xml/NPathComplexity"/>
+    <rule ref="category/java/design.xml/SimplifyBooleanAssertion"/>
+    <rule ref="category/java/design.xml/SimplifyBooleanExpressions"/>
+    <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
+    <rule ref="category/java/design.xml/SingularField"/>
+    <rule ref="category/java/design.xml/TooManyFields"/>
+
+    <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
+
+    <!-- Error Prone -->
+
+    <!-- Will become deprecated in Java 9 onwards. -->
+    <rule ref="category/java/errorprone.xml/AvoidCallingFinalize"/>
+
+    <!-- Will become deprecated in Java 9 onwards. -->
+    <rule ref="category/java/errorprone.xml/EmptyFinalizer"/>
+
+    <rule ref="category/java/errorprone.xml/AssignmentToNonFinalStatic"/>
+    <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop"/>
+    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+    <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause"/>
+    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
+    <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
+    <rule ref="category/java/errorprone.xml/CheckSkipResult"/>
+    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
+    <rule ref="category/java/errorprone.xml/DoNotCallSystemExit"/>
+    <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard"/>
+    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
+    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyIfStmt"/>
+    <rule ref="category/java/errorprone.xml/EmptyInitializer"/>
+    <rule ref="category/java/errorprone.xml/EmptyStatementBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
+    <rule ref="category/java/errorprone.xml/EmptySwitchStatements"/>
+    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyTryBlock"/>
+    <rule ref="category/java/errorprone.xml/EqualsNull"/>
+    <rule ref="category/java/errorprone.xml/JUnitSpelling"/>
+    <rule ref="category/java/errorprone.xml/JUnitStaticSuite"/>
+    <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
+    <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass"/>
+    <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
+    <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
+    <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
+    <rule ref="category/java/errorprone.xml/NonCaseLabelInSwitchStatement"/>
+    <rule ref="category/java/errorprone.xml/NonStaticInitializer"/>
+    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock"/>
+    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
+    <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion"/>
+    <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange"/>
+    <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings"/>
+    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
+
+    <rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
+    <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
+    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
+
+    <rule ref="category/java/performance.xml/BooleanInstantiation"/>
+    <rule ref="category/java/performance.xml/ByteInstantiation"/>
+    <rule ref="category/java/performance.xml/IntegerInstantiation"/>
+    <rule ref="category/java/performance.xml/LongInstantiation"/>
+    <rule ref="category/java/performance.xml/ShortInstantiation"/>
+    <rule ref="category/java/performance.xml/SimplifyStartsWith"/>
+    <rule ref="category/java/performance.xml/StringInstantiation"/>
+    <rule ref="category/java/performance.xml/StringToString"/>
+    <rule ref="category/java/performance.xml/UseArraysAsList"/>
+    <rule ref="category/java/performance.xml/UseStringBufferForStringAppends"/>
     <!-- Possible duplication with `ReplaceVectorWithList` -->
     <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector"/>
-
-    <rule ref="category/java/performance.xml/UseArraysAsList"/>
-    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
-    <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings"/>
-    <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
-    <rule ref="category/java/design.xml/LogicInversion"/>
-    <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange"/>
-    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
-
-    <rule ref="category/java/errorprone.xml/JUnitStaticSuite"/>
-    <rule ref="category/java/errorprone.xml/JUnitSpelling"/>
-    <rule ref="category/java/design.xml/SimplifyBooleanAssertion"/>
-    <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion"/>
+    <rule ref="category/java/performance.xml/UseStringBufferLength"/>
 
 </ruleset>


### PR DESCRIPTION
This PR:
  * Addresses warnings PMD emits on the rules that are going to be discontinued in the version 7.0. Rules were also sorted alphabetically for easier navigation.
  * Deprecates `DependencyResolution.defaultRepositories()` method in favour of `applyStandard()` function (which now belongs to `Repositories.kt` file). The list of repositories stays the same.
