### PR TITLE
Use only Kotlin-defined dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,20 +24,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import io.spine.internal.dependency.LicenseReport
+import io.spine.internal.dependency.Jackson
+
 buildscript {
     repositories {
         gradlePluginPortal()
     }
 
     dependencies {
-        classpath("com.github.jk1:gradle-license-report:1.16")
+        classpath(io.spine.internal.dependency.LicenseReport.lib)
     }
 }
 
 plugins {
     java
     `kotlin-dsl`
-    id("com.github.jk1.dependency-license-report") version "1.16"
+    @Suppress("RemoveRedundantQualifierName")
+    io.spine.internal.dependency.LicenseReport.GradlePlugin.apply {
+        id(id).version(version)
+    }
 }
 
 kotlinDslPluginOptions {
@@ -50,10 +56,7 @@ repositories {
     mavenCentral()
 }
 
-val jacksonVersion = "2.11.0"
-val licenseReportVersion = "1.16"
-
 dependencies {
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
+    implementation(Jackson.dataformatXml)
+    api(LicenseReport.lib)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
@@ -27,10 +27,13 @@
 package io.spine.internal.dependency
 
 // https://cloud.google.com/java/docs/reference
+@Suppress("unused")
 object AppEngine {
     private const val version = "1.9.82"
-    private const val gradlePluginVersion = "2.2.0"
-
     const val sdk          = "com.google.appengine:appengine-api-1.0-sdk:${version}"
-    const val gradlePlugin = "com.google.cloud.tools:appengine-gradle-plugin:${gradlePluginVersion}"
+
+    object GradlePlugin {
+        private const val version = "2.2.0"
+        const val lib = "com.google.cloud.tools:appengine-gradle-plugin:$version"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
@@ -34,6 +34,6 @@ object AppEngine {
 
     object GradlePlugin {
         private const val version = "2.2.0"
-        const val lib = "com.google.cloud.tools:appengine-gradle-plugin:$version"
+        const val lib = "com.google.cloud.tools:appengine-gradle-plugin:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.0-M2"
+    const val version      = "1.5.0-RC"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
@@ -26,11 +26,15 @@
 
 package io.spine.internal.dependency
 
+// https://github.com/jk1/Gradle-License-Report
 @Suppress("unused")
-object Jackson {
-    private const val version = "2.12.3"
-    // https://github.com/FasterXML/jackson-databind
-    const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
-    // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
+object LicenseReport {
+    private const val version = "1.16"
+    const val lib = "com.github.jk1:gradle-license-report:${version}"
+
+    object GradlePlugin {
+        const val version = LicenseReport.version
+        const val id = "com.github.jk1.dependency-license-report"
+        const val lib = LicenseReport.lib
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -125,7 +125,7 @@ object PublishingRepos {
 }
 
 /**
- * Defines names of the commonly used repositories.
+ * Defines names of additional repositories commonly used in the framework projects.
  *
  * @see [applyStandard]
  */
@@ -137,15 +137,14 @@ object Repos {
     val spine: String = PublishingRepos.cloudRepo.releases
     val spineSnapshots: String = PublishingRepos.cloudRepo.snapshots
 
+    const val sonatypeReleases: String = "https://oss.sonatype.org/content/repositories/snapshots"
     const val sonatypeSnapshots: String = "https://oss.sonatype.org/content/repositories/snapshots"
-
-    @Deprecated("Please use `gradlePluginPortal()` call instead of the hard-coded URL.")
-    const val gradlePlugins = "https://plugins.gradle.org/m2/"
 }
 
 /**
  * The function to be used in `buildscript` clauses when fully-qualified call must be made.
  */
+@Suppress("unused")
 fun doApplyStandard(repositories: RepositoryHandler) {
     repositories.applyStandard()
 }
@@ -181,5 +180,11 @@ fun RepositoryHandler.applyStandard() {
             }
         }
         mavenCentral()
+        maven {
+            url = URI(Repos.sonatypeReleases)
+        }
+        maven {
+            url = URI(Repos.sonatypeSnapshots)
+        }
     }
 }

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -28,10 +28,12 @@
  * This script configures Gradle Checkstyle plugin.
  */
 
+import io.spine.internal.dependency.CheckStyle
+
 apply plugin: 'checkstyle'
 
 checkstyle {
-    toolVersion = "${deps.versions.checkstyle}"
+    toolVersion = "${CheckStyle.version}"
     configFile = file("$rootDir/config/quality/checkstyle.xml")
 
     // Disable checking the test sources.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,6 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+//file:noinspection GrDeprecatedAPIUsage
+
+import io.spine.internal.dependency.*
+
 /*
  * This file describes shared dependencies of Spine sub-projects.
  *
@@ -31,133 +35,84 @@
  *  https://github.com/uber/NullAway/blob/master/gradle/dependencies.gradle
  */
 
-// Repositories to which we may publish. Normally, only one repository will be used.
-// See `publish.gradle` for details of the publishing process.
-
 // Specific repositories.
 ext.repos = [
         // Snapshots of Error Prone and Guava.
         sonatypeSnapshots : 'https://oss.sonatype.org/content/repositories/snapshots',
-
         gradlePlugins     : 'https://plugins.gradle.org/m2/'
 ]
 
-final def versions = [
-        slf4j            : '1.7.29', // deprecated, remove after full migration.
-        checkerFramework : '3.3.0',
-        errorProne       : '2.3.4',
-        errorProneJavac  : '9+181-r4173-1', // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
-        errorPronePlugin : '1.2.1',
-        pmd              : '6.24.0',
-        checkstyle       : '8.29',
-        protobufPlugin   : '0.8.12',
-        appengineApi     : '1.9.79',
-        appenginePlugin  : '2.2.0',
-        findBugs         : '3.0.2',
-        guava            : '29.0-jre',
-        protobuf         : '3.11.4',
-        grpc             : '1.28.1',
-        flogger          : '0.5.1',
-        junit4           : '4.12',
-        junit5           : '5.6.2',
-        junitPlatform    : '1.6.2',
-        junitPioneer     : '0.4.2',
-        truth            : '1.0.1',
-        httpClient       : '1.34.2',
-        apacheHttpClient : '2.1.2',
-        firebaseAdmin    : '6.12.2',
-        roaster          : '2.21.2.Final',
-        licensePlugin    : '1.13',
-        javaPoet         : '1.12.1',
-        autoService      : '1.0-rc6',
-        autoCommon       : '0.10',
-        jackson          : '2.9.10.4',
-        animalSniffer    : '1.18'
-]
-
 final def build = [
-        errorProneJavac        : "com.google.errorprone:javac:$versions.errorProneJavac",
-        errorProneAnnotations: [
-                "com.google.errorprone:error_prone_annotations:$versions.errorProne",
-                "com.google.errorprone:error_prone_type_annotations:$versions.errorProne"
-        ],
-        errorProneCheckApi     : "com.google.errorprone:error_prone_check_api:$versions.errorProne",
-        errorProneCore         : "com.google.errorprone:error_prone_core:$versions.errorProne",
-        errorProneTestHelpers  : "com.google.errorprone:error_prone_test_helpers:$versions.errorProne",
+        errorProneJavac        : "${ErrorProne.javacPlugin}",
+        errorProneAnnotations  : ErrorProne.INSTANCE.annotations.toArray(),
+        errorProneCheckApi     : ErrorProne.INSTANCE.checkApi,
+        errorProneCore         : ErrorProne.INSTANCE.core,
+        errorProneTestHelpers  : ErrorProne.INSTANCE.testHelpers,
 
-        checkerAnnotations     : "org.checkerframework:checker-qual:$versions.checkerFramework",
-        checkerDataflow        : ["org.checkerframework:dataflow:$versions.checkerFramework",
-                                  "org.checkerframework:javacutil:$versions.checkerFramework"],
-
-        autoCommon             : "com.google.auto:auto-common:$versions.autoCommon",
+        checkerAnnotations     : CheckerFramework.INSTANCE.annotations,
+        checkerDataflow        : CheckerFramework.INSTANCE.dataflow.toArray(),
+        autoCommon             : AutoCommon.lib,
         autoService            : [
-                annotations : "com.google.auto.service:auto-service-annotations:$versions.autoService",
-                processor   : "com.google.auto.service:auto-service:$versions.autoService"
+                annotations: AutoService.INSTANCE.annotations,
+                processor  : AutoService.processor
         ],
 
-        jsr305Annotations      : "com.google.code.findbugs:jsr305:$versions.findBugs",
+        jsr305Annotations      : FindBugs.INSTANCE.annotations,
 
-        guava                  : "com.google.guava:guava:$versions.guava",
-        flogger                : "com.google.flogger:flogger:$versions.flogger",
-        slf4j                  : "org.slf4j:slf4j-api:$versions.slf4j",
-        protobuf               : ["com.google.protobuf:protobuf-java:$versions.protobuf",
-                                  "com.google.protobuf:protobuf-java-util:$versions.protobuf"],
-        protoc                 : "com.google.protobuf:protoc:$versions.protobuf",
-        googleHttpClient       : "com.google.http-client:google-http-client:$versions.httpClient",
-        googleHttpClientApache : "com.google.http-client:google-http-client-apache:$versions.apacheHttpClient",
-        appengineApi           : "com.google.appengine:appengine-api-1.0-sdk:$versions.appengineApi",
+        guava                  : Guava.lib,
+        flogger                : Flogger.lib,
+        slf4j                  : Slf4J.lib,
+        protobuf               : Protobuf.INSTANCE.libs.toArray(),
+        protoc                 : Protobuf.compiler,
+        googleHttpClient       : HttpClient.google,
+        googleHttpClientApache : HttpClient.apache,
+        appengineApi           : AppEngine.sdk,
 
-        firebaseAdmin          : "com.google.firebase:firebase-admin:$versions.firebaseAdmin",
-        jacksonDatabind        : "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
+        firebaseAdmin          : Firebase.admin,
+        jacksonDatabind        : Jackson.databind,
 
-        roasterApi             : "org.jboss.forge.roaster:roaster-api:$versions.roaster",
-        roasterJdt             : "org.jboss.forge.roaster:roaster-jdt:$versions.roaster",
-        animalSniffer          : "org.codehaus.mojo:animal-sniffer-annotations:$versions.animalSniffer",
+        roasterApi             : Roaster.api,
+        roasterJdt             : Roaster.jdt,
+        animalSniffer          : AnimalSniffer.lib,
 
         ci: 'true' == System.getenv('CI'),
 
         gradlePlugins: [
-                errorProne      : "net.ltgt.gradle:gradle-errorprone-plugin:$versions.errorPronePlugin",
-                protobuf        : "com.google.protobuf:protobuf-gradle-plugin:$versions.protobufPlugin",
-                appengine       : "com.google.cloud.tools:appengine-gradle-plugin:$versions.appenginePlugin",
-                licenseReport   : "com.github.jk1:gradle-license-report:$versions.licensePlugin"
+                errorProne      : ErrorProne.GradlePlugin.lib,
+                protobuf        : Protobuf.GradlePlugin.lib,
+                appengine       : AppEngine.GradlePlugin.lib,
+                licenseReport   : LicenseReport.GradlePlugin.lib
         ]
 ]
 
 final def gen = [
-        javaPoet : "com.squareup:javapoet:$versions.javaPoet"
+        javaPoet : JavaPoet.lib
 ]
 
 final def grpc = [
-        grpcCore               : "io.grpc:grpc-core:$versions.grpc",
-        grpcStub               : "io.grpc:grpc-stub:$versions.grpc",
-        grpcOkHttp             : "io.grpc:grpc-okhttp:$versions.grpc",
-        grpcProtobuf           : "io.grpc:grpc-protobuf:$versions.grpc",
-        grpcNetty              : "io.grpc:grpc-netty:$versions.grpc",
-        grpcNettyShaded        : "io.grpc:grpc-netty-shaded:$versions.grpc",
-        grpcContext            : "io.grpc:grpc-context:$versions.grpc"
+        grpcCore       : Grpc.core,
+        grpcStub       : Grpc.stub,
+        grpcOkHttp     : Grpc.okHttp,
+        grpcProtobuf   : Grpc.protobuf,
+        grpcNetty      : Grpc.netty,
+        grpcNettyShaded: Grpc.nettyShaded,
+        grpcContext    : Grpc.context
 ]
 
 final def runtime = [
-        floggerSystemBackend : "com.google.flogger:flogger-system-backend:$versions.flogger",
-        floggerLog4J         : "com.google.flogger:flogger-log4j:$versions.flogger",
-        floggerSlf4J         : "com.google.flogger:slf4j-backend-factory:$versions.flogger"
+        floggerSystemBackend: Flogger.Runtime.systemBackend,
+        floggerLog4J        : Flogger.Runtime.log4J,
+        floggerSlf4J        : Flogger.Runtime.slf4J
 ]
 
 final def test = [
-        junit4        : "junit:junit:$versions.junit4",
-        junit5Api     : ["org.junit.jupiter:junit-jupiter-api:$versions.junit5",
-                         "org.junit.jupiter:junit-jupiter-params:$versions.junit5",
-                         'org.apiguardian:apiguardian-api:1.1.0'],
-        junit5Runner  : "org.junit.jupiter:junit-jupiter-engine:$versions.junit5",
-        junitPioneer  : "org.junit-pioneer:junit-pioneer:$versions.junitPioneer",
-        slf4j         : "org.slf4j:slf4j-jdk14:$versions.slf4j",
-        guavaTestlib  : "com.google.guava:guava-testlib:$versions.guava",
-        mockito       : "org.mockito:mockito-core:2.12.0",
-        hamcrest      : "org.hamcrest:hamcrest-all:1.3",
-        truth         : ["com.google.truth:truth:$versions.truth",
-                         "com.google.truth.extensions:truth-java8-extension:$versions.truth",
-                         "com.google.truth.extensions:truth-proto-extension:$versions.truth"]
+        junit4        : JUnit.legacy,
+        junit5Api     : JUnit.INSTANCE.api.toArray(),
+        junit5Runner  : JUnit.runner,
+        junitPioneer  : JUnit.pioneer,
+        slf4j         : Slf4J.lib,
+        guavaTestlib  : Guava.testLib,
+        truth         : Truth.INSTANCE.libs.toArray()
 ]
 
 final def scripts = [
@@ -194,7 +149,6 @@ ext.deps = [
         'gen'      : gen,
         'runtime'  : runtime,
         'test'     : test,
-        'versions' : versions,
         'scripts'  : scripts,
 ]
 
@@ -210,34 +164,36 @@ ext.forceConfiguration = { final configurationContainer ->
         resolutionStrategy {
             failOnVersionConflict()
             cacheChangingModulesFor(0, 'seconds')
+
+            // Force deprecated dependencies.
+            force (Slf4J.lib)
+
+            // Force dependencies internally used by the framework.
+            //noinspection UnnecessaryQualifiedReference
             force(
-                    deps.build.slf4j,
-                    deps.build.errorProneAnnotations,
-                    deps.build.jsr305Annotations,
-                    deps.build.checkerAnnotations,
-                    deps.build.autoCommon,
-                    deps.build.guava,
-                    deps.build.animalSniffer,
-                    deps.build.protobuf,
-                    deps.test.guavaTestlib,
-                    deps.test.truth,
-                    deps.test.junit5Api,
-                    deps.test.junit4,
+                    ErrorProne.annotations,
+                    JavaX.annotations,
+                    CheckerFramework.annotations,
+                    AutoCommon.lib,
+                    Guava.lib,
+                    AnimalSniffer.lib,
+                    Protobuf.lib,
+                    Guava.testLib,
+                    Truth.lib,
+                    JUnit.INSTANCE.api,
+                    JUnit.legacy,
+                    Protobuf.GradlePlugins.lib,
+            )
 
-                    // Transitive dependencies of 3rd party components that we don't use directly.
-                    'com.google.code.gson:gson:2.8.6',
-                    'com.google.j2objc:j2objc-annotations:1.3',
-                    'org.codehaus.plexus:plexus-utils:3.3.0',
-                    'com.squareup.okio:okio:1.17.5', // Last version before next major.
-                    'commons-cli:commons-cli:1.4',
-
-                    // Force discontinued transitive dependency until everybody migrates off it.
-                    'org.checkerframework:checker-compat-qual:2.5.5',
-
-                    'commons-logging:commons-logging:1.2',
-
-                    // Force the Gradle Protobuf plugin version.
-                    deps.build.gradlePlugins.protobuf
+            // Force transitive dependencies of 3rd party components that we don't use directly.
+            force(
+                Gson.lib,
+                J2ObjC.lib,
+                Plexus.utils,
+                Okio.lib,
+                CommonsCli.lib,
+                CheckerFramework.compatQual,
+                CommonsLogging.lib
             )
         }
     }
@@ -265,6 +221,6 @@ ext.defaultRepositories = { final repositoryContainer ->
             }
         }
         mavenCentral()
-        maven { url = repos.gradlePlugins }
+        gradlePluginPortal()
     }
 }

--- a/gradle/license-report-project.gradle
+++ b/gradle/license-report-project.gradle
@@ -23,6 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+//file:noinspection UnnecessaryQualifiedReference
 
 import com.github.jk1.license.*
 import com.github.jk1.license.render.ReportRenderer
@@ -37,15 +38,15 @@ import com.github.jk1.license.render.ReportRenderer
 
 buildscript {
     repositories {
-        maven { url = 'https://plugins.gradle.org/m2/'}
+        gradlePluginPortal()
     }
 
     dependencies {
-        classpath 'com.github.jk1:gradle-license-report:1.16'
+        classpath io.spine.internal.dependency.LicenseReport.lib
     }
 }
 
-apply plugin: 'com.github.jk1.dependency-license-report'
+apply plugin: io.spine.internal.dependency.LicenseReport.GradlePlugin.id
 
 apply from: "${rootDir}/config/gradle/license-report-common.gradle"
 
@@ -92,8 +93,8 @@ class MarkdownReportRenderer implements ReportRenderer {
 
     private void printDependencies(final ProjectData data) {
 
-        final runtimeDependencies = new HashSet();
-        final compileToolingDependencies = new HashSet();
+        final runtimeDependencies = new HashSet()
+        final compileToolingDependencies = new HashSet()
 
         data.configurations.each { final ConfigurationData config ->
 
@@ -107,12 +108,12 @@ class MarkdownReportRenderer implements ReportRenderer {
 
         output << "\n## Runtime"
         runtimeDependencies.toArray().sort().each {
-            printModuleDependency(it);
+            printModuleDependency(it)
         }
 
         output << "\n## Compile, tests and tooling"
         compileToolingDependencies.toArray().sort().each {
-            printModuleDependency(it);
+            printModuleDependency(it)
         }
     }
 


### PR DESCRIPTION
This PR eliminates remaining string-based dependency usage in favor of those defined in Kotlin objects under `io.spine.internal.dependency` package.

The `version` property of the `deps` was removed to encourage using Maven coordinates declared in corresponding Kotlin objects.

Kotlin version was bumped to `1.5.0-RC`.

