### PR TITLE
Open common path

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
@@ -30,7 +30,7 @@ import org.gradle.api.Project
 
 @Suppress("unused")
 object Scripts {
-    private const val commonPath = "/buildSrc/src/main/groovy/"
+    const val commonPath = "/buildSrc/src/main/groovy/"
 
     fun testArtifacts(p: Project)          = p.script("test-artifacts.gradle")
     fun testOutput(p: Project)             = p.script("test-output.gradle")

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Scripts.kt
@@ -30,6 +30,7 @@ import org.gradle.api.Project
 
 @Suppress("unused")
 object Scripts {
+    @Suppress("MemberVisibilityCanBePrivate") // is used from Groovy-based scripts.
     const val commonPath = "/buildSrc/src/main/groovy/"
 
     fun testArtifacts(p: Project)          = p.script("test-artifacts.gradle")


### PR DESCRIPTION
This PR opens `Scripts.commonPath` property to be used from Groovy-based scripts.