### PR TITLE
Add JUnit params dependency

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -49,5 +49,5 @@ object JUnit {
     const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"
     const val platformLauncher = "org.junit.platform:junit-platform-launcher:${platformVersion}"
     @Suppress("unused")
-    const val params = "org.junit.platform:junit-jupiter-params:${platformVersion}"
+    const val params = "org.junit.jupiter:junit-jupiter-params:${platformVersion}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -49,5 +49,5 @@ object JUnit {
     const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"
     const val platformLauncher = "org.junit.platform:junit-platform-launcher:${platformVersion}"
     @Suppress("unused")
-    const val params = "org.junit.jupiter:junit-jupiter-params:${platformVersion}"
+    const val params = "org.junit.jupiter:junit-jupiter-params:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -48,4 +48,6 @@ object JUnit {
     const val pioneer = "org.junit-pioneer:junit-pioneer:${pioneerVersion}"
     const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"
     const val platformLauncher = "org.junit.platform:junit-platform-launcher:${platformVersion}"
+    @Suppress("unused")
+    const val params = "org.junit.platform:junit-jupiter-params:${platformVersion}"
 }


### PR DESCRIPTION
In this PR we add the `org.junit.jupiter:junit-jupiter-params` artifact to be used as a dependency.