### PR TITLE
Remove packages in Gradle scripts

### DIFF
--- a/buildSrc/src/main/groovy/dart/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/build-tasks.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package dart
 
 import org.apache.tools.ant.taskdefs.condition.Os
 

--- a/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package dart
 
 import org.apache.tools.ant.taskdefs.condition.Os
 


### PR DESCRIPTION
In Groovy Gradle scripts, declaring a package is a compile-time error.