### PR TITLE
Update versions and add gRPC plugin

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.35.1"
+    const val version        = "1.38.0"
     const val core           = "io.grpc:grpc-core:${version}"
     const val stub           = "io.grpc:grpc-stub:${version}"
     const val okHttp         = "io.grpc:grpc-okhttp:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,12 +30,13 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version     = "1.35.1"
-    const val core        = "io.grpc:grpc-core:${version}"
-    const val stub        = "io.grpc:grpc-stub:${version}"
-    const val okHttp      = "io.grpc:grpc-okhttp:${version}"
-    const val protobuf    = "io.grpc:grpc-protobuf:${version}"
-    const val netty       = "io.grpc:grpc-netty:${version}"
-    const val nettyShaded = "io.grpc:grpc-netty-shaded:${version}"
-    const val context     = "io.grpc:grpc-context:${version}"
+    const val version        = "1.35.1"
+    const val core           = "io.grpc:grpc-core:${version}"
+    const val stub           = "io.grpc:grpc-stub:${version}"
+    const val okHttp         = "io.grpc:grpc-okhttp:${version}"
+    const val protobuf       = "io.grpc:grpc-protobuf:${version}"
+    const val netty          = "io.grpc:grpc-netty:${version}"
+    const val nettyShaded    = "io.grpc:grpc-netty-shaded:${version}"
+    const val context        = "io.grpc:grpc-context:${version}"
+    const val protobufPlugin = "io.grpc:protoc-gen-grpc-java:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.15.7"
+    const val version    = "3.17.0"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"
@@ -37,7 +37,7 @@ object Protobuf {
     const val compiler = "com.google.protobuf:protoc:${version}"
 
     object GradlePlugin {
-        const val version = "0.8.13"
+        const val version = "0.8.16"
         const val id = "com.google.protobuf"
         const val lib = "com.google.protobuf:protobuf-gradle-plugin:${version}"
     }


### PR DESCRIPTION
This PR adds the gRPC Protobuf plugin artifact to the `Grpc` object.

Also, updates the versions of Protobuf, gPRC, and the Protobuf Gradle plugin.