### PR TITLE
Disable publishing Javadocs to GitHub Pages for snapshots

### DIFF
--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -58,7 +58,7 @@ ext {
 /**
  * Prints a message telling those who read build logs about what happened.
  */
-if(isSnapshot()) {
+if (isSnapshot()) {
     println("GitHub Pages update will be skipped since this project" +
             " is a snapshot: `$project.name-$project.version`.")
 }

--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -65,7 +65,6 @@ if(isSnapshot()) {
 
 /**
  * Tells whether this project is a snapshot.
- * @return
  */
 def isSnapshot() {
     return project.version.toLowerCase().contains("snapshot")

--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -55,6 +55,22 @@ ext {
     repositoryTempDir = Files.createTempDirectory("repoTemp")
 }
 
+/**
+ * Prints a message telling those who read build logs about what happened.
+ */
+if(isSnapshot()) {
+    println("GitHub Pages update will be skipped since this project" +
+            " is a snapshot: `$project.name-$project.version`.")
+}
+
+/**
+ * Tells whether this project is a snapshot.
+ * @return
+ */
+def isSnapshot() {
+    return project.version.toLowerCase().contains("snapshot")
+}
+
 final String propertyName = 'allowInternalJavadoc'
 
 final boolean allowInternalJavadoc = ext.has(propertyName) && ext.get(propertyName)
@@ -87,6 +103,13 @@ task copyJavadoc(type: Copy) {
 task updateGitHubPages {
     description "Updates the Javadoc published to GitHub Pages website."
     dependsOn copyJavadoc
+}
+
+/**
+ * Prevents this task from execution in case this project is in its `SNAPSHOT` version.
+ */
+updateGitHubPages.onlyIf {
+    !isSnapshot()
 }
 
 /**
@@ -128,7 +151,7 @@ static String execute(final File baseDir, final String... command) {
     } else {
         final String errorMsg = "Command `$command` finished with exit code $result.exitCode:" +
                 " ${System.lineSeparator()}${result.error}" +
-                " ${System.lineSeparator()}${result.out}"
+                " ${System.lineSeparator()}${result.out}."
         throw new IllegalStateException(errorMsg)
     }
 }
@@ -194,7 +217,7 @@ Host github.com-publish
 
     execute 'git', 'clone', GIT_HOST, "$repoBaseDir"
     execute repoBaseDir, "git", "checkout", GH_PAGES_BRANCH
-    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`")
+    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`.")
     docDir.mkdir()
 
     copy {
@@ -202,7 +225,7 @@ Host github.com-publish
         into docDir
     }
 
-    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`")
+    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`.")
     versionedDocDir.mkdir()
     copy {
         from generatedDocs
@@ -224,5 +247,5 @@ Host github.com-publish
 
     execute repoBaseDir, "git", "commit", "--allow-empty", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
     execute repoBaseDir, "git", "push"
-    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` sucessfully")
+    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` successfully.")
 }


### PR DESCRIPTION
Before this changeset, each build from `master` published its updates to the Javadoc-only branch called `gh-pages`.

As a result, [spine.io](https://spine.io) readers would see the Javadocs of some `...-SNAPSHOT.42` instead of the documentation for the latest release.

This PR disables the corresponding Gradle task for snapshots.