### PR TITLE
Update Google Truth version

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/truth
 object Truth {
-    private const val version = "1.1.2"
+    private const val version = "1.1.3"
     val libs = listOf(
         "com.google.truth:truth:${version}",
         "com.google.truth.extensions:truth-java8-extension:${version}",


### PR DESCRIPTION
Updates Google Truth so that the issue with required fields and `comparingExpectedFieldsOnly()` is resolved.

In past versions, this assertion mode failed if a Proto 2 required field was not set. This was a problem for us as we use the same validation sites for Spine validation as does Proto 2 for their inbuilt validation.