### PR TITLE
Dokka plugin dependency

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
@@ -26,14 +26,6 @@
 
 package io.spine.internal.dependency
 
-/**
- * Versions of one-line dependencies.
- *
- * For versions of other dependencies please see `version` properties of objects declared below.
- *
- * See also: https://github.com/SpineEventEngine/config/issues/171
- */
-
 // https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/
 object AnimalSniffer {
     private const val version = "1.19"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -35,4 +35,11 @@ object Kotlin {
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
     const val stdLibJdk8   = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
+
+    // https://github.com/Kotlin/dokka
+    object Dokka {
+
+        const val version = "1.4.32"
+        const val pluginId = "org.jetbrains.dokka"
+    }
 }


### PR DESCRIPTION
In this PR we add the Dokka Gradle plugin artifact coordinates.
Note that Dokka uses a different version from Kotlin.

We also remove a doc copied by error in `AnimalSniffer.kt`.