### PR TITLE
Copy properties in `RunBuild`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -51,6 +51,9 @@ open class RunBuild : DefaultTask() {
     @Internal
     lateinit var directory: String
 
+    @Internal
+    var includeGradleProperties: MutableSet<String> = mutableSetOf()
+
     @TaskAction
     private fun execute() {
         val runsOnWindows = OperatingSystem.current().isWindows()
@@ -86,6 +89,11 @@ open class RunBuild : DefaultTask() {
         command.add("--console=plain")
         command.add("--debug")
         command.add("--stacktrace")
+        val rootProject = project.rootProject
+        includeGradleProperties
+            .filter { rootProject.hasProperty(it) }
+            .map { name -> name to rootProject.property(name).toString() }
+            .forEach { (name, value) -> command.add("-P$name=$value") }
         return command
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -51,6 +51,14 @@ open class RunBuild : DefaultTask() {
     @Internal
     lateinit var directory: String
 
+    /**
+     * Names of Gradle properties to copy into the launched build.
+     *
+     * The properties are looked up in the root project. If a property is not found, it is ignored.
+     *
+     * See [Gradle doc](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties)
+     * for more info about Gradle properties.
+     */
     @Internal
     var includeGradleProperties: MutableSet<String> = mutableSetOf()
 


### PR DESCRIPTION
In this PR we introduce the ability for the `RunBuild` task to copy Gradle properties from the current build into the build launched by `RunBuild`.