### PR TITLE
Print error message if an included build fails

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -80,6 +80,9 @@ open class RunBuild : DefaultTask() {
 
         val process = buildProcess(command, errorOut, debugOut)
         if (process.waitFor() != 0) {
+            if (errorOut.exists()) {
+                logger.error(errorOut.readText())
+            }
             throw GradleException("Build FAILED. See $errorOut for details.")
         }
     }


### PR DESCRIPTION
Now we print the error output of a Gradle build that was launched via `RunBuild` instead of just giving the file name.