### PR TITLE
Allow seemingly redundant type qualifiers in Gradle

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -638,6 +638,9 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RemoveRedundantQualifierName" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="non-gradle-files" level="WARNING" enabled="true" />
+    </inspection_tool>
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>

--- a/.idea/scopes/non_gradle_files.xml
+++ b/.idea/scopes/non_gradle_files.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="non-gradle-files" pattern="!file:*.gradle.kts||!file:*.gradle" />
+</component>


### PR DESCRIPTION
In some parts of a Gradle script, usage of imports is prohibited.

This is related to how Gradle resolves dependencies for its scripts.
This applies to `buildscript { }` and `plugins { }` blocks.

In this PR, specifically for Gradle files, we turn off the IDEA's inspection which warns us about a redundant use of an FQN where an import could be used.
Unfortunately, we cannot turn off this inspection for a section of a file.