### PR TITLE
Make `@Input` public

### DIFF
--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -74,7 +74,7 @@ class MarkdownReportRenderer implements ReportRenderer {
     }
 
     @Input
-    private String getFileNameCache() { return this.fileName }
+    String getFileNameCache() { return this.fileName }
 
     void render(final ProjectData data) {
         project = data.project


### PR DESCRIPTION
This PR makes the method `getFileNameCache()` of `MarkdownReportRenderer` `public` because this is a requirement of Gradle 7.x for getters annotated with `@Input`.