### PR TITLE
Jackson YAML parsing and version bumps

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,9 +28,11 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.12.3"
+    private const val version = "2.12.4"
     // https://github.com/FasterXML/jackson-databind
     const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
     // https://github.com/FasterXML/jackson-dataformat-xml/releases
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
+    // https://github.com/FasterXML/jackson-dataformats-text/releases
+    const val dataformatsText = "com.fasterxml.jackson.dataformat:jackson-dataformats-text:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -34,5 +34,5 @@ object Jackson {
     // https://github.com/FasterXML/jackson-dataformat-xml/releases
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
     // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatsText = "com.fasterxml.jackson.dataformat:jackson-dataformats-text:${version}"
+    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.0"
+    const val version      = "1.5.20"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
@@ -39,7 +39,7 @@ object Kotlin {
     // https://github.com/Kotlin/dokka
     object Dokka {
 
-        const val version = "1.4.32"
+        const val version = "1.5.0"
         const val pluginId = "org.jetbrains.dokka"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,13 +29,14 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.17.0"
+    const val version    = "3.17.3"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"
     )
     const val compiler = "com.google.protobuf:protoc:${version}"
 
+    // https://github.com/google/protobuf-gradle-plugin/releases
     object GradlePlugin {
         const val version = "0.8.16"
         const val id = "com.google.protobuf"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/forge/roaster
 object Roaster {
-    private const val version = "2.22.2.Final"
+    private const val version = "2.23.0.Final"
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"
 }


### PR DESCRIPTION
In this PR we
 1. Add a dependency for Jackson YAML parsing components.
 2. Update versions:
    - Jackson: `2.12.3` to `2.12.4`;
    - Kotlin: `1.5.0` to `1.5.20`;
    - Dokka: `1.4.32` to `1.5.0`;
    - Protobuf: `3.17.0` to `3.17.3`;
    - Roaster: `2.22.0.Final` to `2.23.0.Final`.