### PR TITLE
Add Jackson Kotlin module

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -35,4 +35,6 @@ object Jackson {
     const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
     // https://github.com/FasterXML/jackson-dataformats-text/releases
     const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
+    // https://github.com/FasterXML/jackson-module-kotlin/releases
+    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
 }


### PR DESCRIPTION
In this PR we add the Jackson module for Kotlin interop.

The module enables Jackson to work with Kotlin data classes.