### PR TITLE
Roll back Roaster to the version compatible with Java 8

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -28,7 +28,16 @@ package io.spine.internal.dependency
 
 // https://github.com/forge/roaster
 object Roaster {
-    private const val version = "2.23.0.Final"
+
+    /**
+     * Do not advance this version further because it would break compatibility with Java 8
+     * projects. Starting from the following version Roaster has a shaded version of Eclipse JFace
+     * built with Java 11.
+     *
+     * Please see [this issue][https://github.com/SpineEventEngine/config/issues/220] for details.
+     */
+    private const val version = "2.22.2.Final"
+
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"
 }


### PR DESCRIPTION
This PR rolls the version of Roaster back to `2.22.2.Final` to restore compatibility with Java 8.

Please see #220 for details.
