### PR TITLE
Allow timeouts for processed initiated from Gradle under Windows

### DIFF
--- a/buildSrc/src/main/groovy/run-build.gradle
+++ b/buildSrc/src/main/groovy/run-build.gradle
@@ -39,7 +39,7 @@ configure(project.rootProject) {
          * 
          * @param directory the project root directory in which to execute the build
          */
-        runBuild = { final GString directory ->
+        runBuild = { final String directory ->
             final boolean shouldClean = gradle.getTaskGraph().hasTask(':clean')
             final def command = []
             final def runsOnWindows = org.gradle.internal.os.OperatingSystem.current().isWindows()
@@ -69,7 +69,13 @@ configure(project.rootProject) {
                     .redirectError(errorOut)
                     .redirectOutput(debugOut)
                     .start()
-            if (process.waitFor() != 0) {
+            if (!process.waitFor(10, TimeUnit.MINUTES)) {
+                /* The timeout is set because of Gradle process execution under Windows.
+                   See the following locations for details:
+                    https://github.com/gradle/gradle/pull/8467#issuecomment-498374289
+                    https://github.com/gradle/gradle/issues/3987
+                    https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
+                 */
                 throw new GradleException("Build FAILED. See $errorOut for details.")
             }
         }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -78,7 +78,7 @@ open class RunBuild : DefaultTask() {
         val errorOut = File(buildDir, "error-out.txt")
         val debugOut = File(buildDir, "debug-out.txt")
 
-        val process = buildProcess(command, errorOut, debugOut)
+        val process = startProcess(command, errorOut, debugOut)
         if (process.waitFor() != 0) {
             if (errorOut.exists()) {
                 logger.error(errorOut.readText())
@@ -108,7 +108,7 @@ open class RunBuild : DefaultTask() {
         return command
     }
 
-    private fun buildProcess(command: List<String>, errorOut: File, debugOut: File) =
+    private fun startProcess(command: List<String>, errorOut: File, debugOut: File) =
         ProcessBuilder()
             .command(command)
             .directory(project.file(directory))

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.gradle
 
 import java.io.File
+import java.util.concurrent.TimeUnit
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Internal
@@ -79,7 +80,14 @@ open class RunBuild : DefaultTask() {
         val debugOut = File(buildDir, "debug-out.txt")
 
         val process = startProcess(command, errorOut, debugOut)
-        if (process.waitFor() != 0) {
+
+        if (!process.waitFor(10, TimeUnit.MINUTES)) {
+            /*  The timeout is set because of Gradle process execution under Windows.
+                See the following locations for details:
+                  https://github.com/gradle/gradle/pull/8467#issuecomment-498374289
+                  https://github.com/gradle/gradle/issues/3987
+                  https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
+             */
             if (errorOut.exists()) {
                 logger.error(errorOut.readText())
             }


### PR DESCRIPTION
This PR allows reasonably long (10 minutes) timeout for waiting for a build process initiated by a Gradle script.

This is done to overcome the issue with stalled child processes under Windows.  See the following locations for details:
 * https://github.com/gradle/gradle/pull/8467#issuecomment-498374289
 * https://github.com/gradle/gradle/issues/3987
 * https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
