### PR TITLE
Allow publishing of single-module projects

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
@@ -340,7 +340,7 @@ private constructor(
  * Configures the `spinePublishing` extension.
  *
  * As `Publish` is a class-plugin in `buildSrc`, we don't get strongly typed generated helper
- * methods for the `spinePublishing` configuration. Thus, we proviude this helper function for use
+ * methods for the `spinePublishing` configuration. Thus, we provide this helper function for use
  * in Kotlin build scripts.
  */
 @Suppress("unused")

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
@@ -52,8 +52,23 @@ import org.gradle.kotlin.dsl.setProperty
 /**
  * This plugin allows publishing artifacts to remote Maven repositories.
  *
- * Apply this plugin to the root project. Specify the projects which produce publishable artifacts
- * and the target Maven repositories via the `publishing` DSL:
+ * The plugin can be used with single- and multi-module projects.
+ *
+ * When applied to a single-module project, the reference to the project is passed to the plugin:
+ * ```
+ * import io.spine.gradle.internal.PublishingRepos
+ * import io.spine.gradle.internal.spinePublishing
+ *
+ * spinePublishing {
+ *     publish(project)
+ *     targetRepositories.addAll(
+ *         PublishingRepos.cloudRepo,
+ *         PublishingRepos.gitHub("LibraryName")
+ *     )
+ * }
+ * ```
+ * When applied to a multi-module project, the plugin should be applied to the root project.
+ * The sub-projects to be published are specified by their names:
  * ```
  * import io.spine.gradle.internal.PublishingRepos
  * import io.spine.gradle.internal.spinePublishing
@@ -99,32 +114,53 @@ class Publish : Plugin<Project> {
         val extension = PublishExtension.create(project)
         project.extensions.add(PublishExtension::class.java, extensionName, extension)
 
-        val publish = project.createPublishTask()
-        val checkCredentials = project.createCheckTask(extension)
-
         project.afterEvaluate {
-            extension.projectsToPublish
-                .get()
-                .map { project.project(it) }
-                .forEach { p ->
-                    p.logger.debug("Applying `maven-publish` plugin to ${name}.")
+            val soloMode = extension.soloProject != null
+            val rootPublish: Task? =
+                if (soloMode) null
+                else project.createPublishTask()
+            val checkCredentials = project.createCheckTask(extension)
 
-                    p.apply(plugin = "maven-publish")
+            if (soloMode) {
+                project.applyMavenPublish(extension, null, checkCredentials)
+            } else {
+                extension.projectsToPublish
+                    .get()
+                    .map { project.project(it) }
+                    .forEach { it.applyMavenPublish(extension, rootPublish, checkCredentials) }
+            }
+        }
+    }
 
-                    p.setUpDefaultArtifacts()
+    private fun Project.applyMavenPublish(
+        extension: PublishExtension,
+        rootPublish: Task?,
+        checkCredentials: Task
+    ) {
+        logger.debug("Applying `maven-publish` plugin to ${name}.")
 
-                    val action = {
-                        val publishingExtension = p.extensions.getByType(PublishingExtension::class)
-                        publishingExtension.createMavenPublication(p, extension)
-                        publishingExtension.setUpRepositories(p, extension)
-                        p.prepareTasks(publish, checkCredentials)
-                    }
-                    if (p.state.executed) {
-                        action()
-                    } else {
-                        p.afterEvaluate { action() }
-                    }
-                }
+        apply(plugin = "maven-publish")
+
+        setUpDefaultArtifacts()
+
+        val action = {
+            val publishingExtension = extensions.getByType(PublishingExtension::class)
+            with(publishingExtension) {
+                val project = this@applyMavenPublish
+                createMavenPublication(project, extension)
+                setUpRepositories(project, extension)
+            }
+
+            if (rootPublish != null) {
+                prepareTasks(rootPublish, checkCredentials)
+            } else {
+                tasks.getByPath(taskName).dependsOn(checkCredentials)
+            }
+        }
+        if (state.executed) {
+            action()
+        } else {
+            afterEvaluate { action() }
         }
     }
 
@@ -275,8 +311,22 @@ private constructor(
         }
     }
 
+    /**
+     * The project to be published _instead_ of [projectsToPublish].
+     *
+     * If set, [projectsToPublish] will be ignored.
+     */
+    var soloProject: Project? = null
+
     init {
         spinePrefix.convention(true)
+    }
+
+    /**
+     * Instructs to publish the passed project _instead_ of [projectsToPublish].
+     */
+    fun publish(project: Project) {
+        soloProject = project
     }
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
@@ -111,13 +111,13 @@ class Publish : Plugin<Project> {
         val extension = PublishExtension.create(project)
         project.extensions.add(PublishExtension::class.java, extensionName, extension)
 
-        project.afterEvaluate {
-            val soloMode = extension.soloProject != null
-            val rootPublish: Task? =
-                if (soloMode) null
-                else project.createPublishTask()
-            val checkCredentials = project.createCheckTask(extension)
+        val soloMode = extension.singleProject()
+        val rootPublish: Task? =
+            if (soloMode) null
+            else project.createPublishTask()
+        val checkCredentials: Task = project.createCheckTask(extension)
 
+        project.afterEvaluate {
             if (soloMode) {
                 project.applyMavenPublish(extension, null, checkCredentials)
             } else {
@@ -322,7 +322,7 @@ private constructor(
      *
      * If set, [projectsToPublish] will be ignored.
      */
-    var soloProject: Project? = null
+    private var soloProject: Project? = null
 
     init {
         spinePrefix.convention(true)
@@ -334,6 +334,8 @@ private constructor(
     fun publish(project: Project) {
         soloProject = project
     }
+
+    fun singleProject(): Boolean = soloProject != null
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunBuild.kt
@@ -26,112 +26,12 @@
 
 package io.spine.internal.gradle
 
-import java.io.File
-import java.util.concurrent.TimeUnit
-import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.os.OperatingSystem
-
 /**
- * A Gradle task which runs another Gradle build.
- *
- * Launches Gradle wrapper under a given [directory] with the `build` task. The `clean` task is also
- * run if current build includes a `clean` task.
- *
- * The build writes verbose log into `$directory/build/debug-out.txt`. The error output is written
- * into `$directory/build/error-out.txt`.
+ * Runs the `build` task via Gradle Wrapper.
  */
-@Suppress("unused")
-open class RunBuild : DefaultTask() {
+open class RunBuild : RunGradle() {
 
-    /**
-     * Path to the directory which contains a Gradle wrapper script.
-     */
-    @Internal
-    lateinit var directory: String
-
-    /**
-     * Names of Gradle properties to copy into the launched build.
-     *
-     * The properties are looked up in the root project. If a property is not found, it is ignored.
-     *
-     * See [Gradle doc](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties)
-     * for more info about Gradle properties.
-     */
-    @Internal
-    var includeGradleProperties: MutableSet<String> = mutableSetOf()
-
-    @TaskAction
-    private fun execute() {
-        // Ensure build error output log.
-        // Since we're executing this task in another process, we redirect error output to
-        // the file under the `build` directory.
-        val buildDir = File(directory, "build")
-        if (!buildDir.exists()) {
-            buildDir.mkdir()
-        }
-        val errorOut = File(buildDir, "error-out.txt")
-        val debugOut = File(buildDir, "debug-out.txt")
-
-        val command = buildCommand()
-        val process = startProcess(command, errorOut, debugOut)
-
-        /*  The timeout is set because of Gradle process execution under Windows.
-            See the following locations for details:
-              https://github.com/gradle/gradle/pull/8467#issuecomment-498374289
-              https://github.com/gradle/gradle/issues/3987
-              https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
-         */
-        val completed = process.waitFor(10, TimeUnit.MINUTES)
-        val exitCode = process.exitValue()
-        if (!completed || exitCode != 0) {
-            val errorOutExists = errorOut.exists()
-            if (errorOutExists) {
-                logger.error(errorOut.readText())
-            }
-            throw GradleException("Child build process FAILED." +
-                    " Exit code: $exitCode." +
-                    if (errorOutExists) " See $errorOut for details."
-                    else " $errorOut file was not created."
-            )
-        }
+    init {
+        task("build")
     }
-
-    private fun buildCommand(): List<String> {
-        val script = buildScript()
-        val command = mutableListOf<String>()
-        command.add("${project.rootDir}/$script")
-        val shouldClean = project.gradle
-            .taskGraph
-            .hasTask(":clean")
-        if (shouldClean) {
-            command.add("clean")
-        }
-        command.add("build")
-        command.add("--console=plain")
-        command.add("--debug")
-        command.add("--stacktrace")
-        command.add("--no-daemon")
-        val rootProject = project.rootProject
-        includeGradleProperties
-            .filter { rootProject.hasProperty(it) }
-            .map { name -> name to rootProject.property(name).toString() }
-            .forEach { (name, value) -> command.add("-P$name=$value") }
-        return command
-    }
-
-    private fun buildScript(): String {
-        val runsOnWindows = OperatingSystem.current().isWindows()
-        return if (runsOnWindows) "gradlew.bat" else "gradlew"
-    }
-
-    private fun startProcess(command: List<String>, errorOut: File, debugOut: File) =
-        ProcessBuilder()
-            .command(command)
-            .directory(project.file(directory))
-            .redirectError(errorOut)
-            .redirectOutput(debugOut)
-            .start()
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.os.OperatingSystem
+
+/**
+ * A Gradle task which runs another Gradle build.
+ *
+ * Launches Gradle wrapper under a given [directory] with the specified [taskNames] names.
+ * The `clean` task is also run if current build includes a `clean` task.
+ *
+ * The build writes verbose log into `$directory/build/debug-out.txt`.
+ * The error output is written into `$directory/build/error-out.txt`.
+ */
+@Suppress("unused")
+open class RunGradle : DefaultTask() {
+
+    /**
+     * Path to the directory which contains a Gradle wrapper script.
+     */
+    @Internal
+    lateinit var directory: String
+
+    /**
+     * The names of the tasks to be passed to the Gradle Wrapper script.
+     */
+    private lateinit var taskNames: List<String>
+
+    /**
+     * Names of Gradle properties to copy into the launched build.
+     *
+     * The properties are looked up in the root project. If a property is not found, it is ignored.
+     *
+     * See [Gradle doc](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties)
+     * for more info about Gradle properties.
+     */
+    @Internal
+    var includeGradleProperties: MutableSet<String> = mutableSetOf()
+
+    /**
+     * Specifies task names to be passed to the Gradle Wrapper script.
+     */
+    fun task(vararg tasks: String) {
+        taskNames = tasks.asList()
+    }
+
+    @TaskAction
+    private fun execute() {
+        // Ensure build error output log.
+        // Since we're executing this task in another process, we redirect error output to
+        // the file under the `build` directory.
+        val buildDir = File(directory, "build")
+        if (!buildDir.exists()) {
+            buildDir.mkdir()
+        }
+        val errorOut = File(buildDir, "error-out.txt")
+        val debugOut = File(buildDir, "debug-out.txt")
+
+        val command = buildCommand()
+        val process = startProcess(command, errorOut, debugOut)
+
+        /*  The timeout is set because of Gradle process execution under Windows.
+            See the following locations for details:
+              https://github.com/gradle/gradle/pull/8467#issuecomment-498374289
+              https://github.com/gradle/gradle/issues/3987
+              https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
+         */
+        val completed = process.waitFor(10, TimeUnit.MINUTES)
+        val exitCode = process.exitValue()
+        if (!completed || exitCode != 0) {
+            val errorOutExists = errorOut.exists()
+            if (errorOutExists) {
+                logger.error(errorOut.readText())
+            }
+            throw GradleException("Child build process FAILED." +
+                    " Exit code: $exitCode." +
+                    if (errorOutExists) " See $errorOut for details."
+                    else " $errorOut file was not created."
+            )
+        }
+    }
+
+    private fun buildCommand(): List<String> {
+        val script = buildScript()
+        val command = mutableListOf<String>()
+        command.add("${project.rootDir}/$script")
+        val shouldClean = project.gradle
+            .taskGraph
+            .hasTask(":clean")
+        if (shouldClean) {
+            command.add("clean")
+        }
+        command.addAll(taskNames)
+        command.add("--console=plain")
+        command.add("--debug")
+        command.add("--stacktrace")
+        command.add("--no-daemon")
+        addProperties(command)
+        return command
+    }
+
+    private fun addProperties(command: MutableList<String>) {
+        val rootProject = project.rootProject
+        includeGradleProperties
+            .filter { rootProject.hasProperty(it) }
+            .map { name -> name to rootProject.property(name).toString() }
+            .forEach { (name, value) -> command.add("-P$name=$value") }
+    }
+
+    private fun buildScript(): String {
+        val runsOnWindows = OperatingSystem.current().isWindows()
+        return if (runsOnWindows) "gradlew.bat" else "gradlew"
+    }
+
+    private fun startProcess(command: List<String>, errorOut: File, debugOut: File) =
+        ProcessBuilder()
+            .command(command)
+            .directory(project.file(directory))
+            .redirectError(errorOut)
+            .redirectOutput(debugOut)
+            .start()
+}


### PR DESCRIPTION
This PR extends the `Publish` (aka `spinePublishing`) with the ability to publish a single-module project.

The changes look vast because private extension functions were pushed to the file level to reduce code nesting.