### PR TITLE
Force `ErrorProne.core`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -79,6 +79,7 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         AutoService.annotations,
         CheckerFramework.annotations,
         ErrorProne.annotations,
+        ErrorProne.core,
         Guava.lib,
         FindBugs.annotations,
         Kotlin.reflect,


### PR DESCRIPTION
This PR forces the version of `ErrorProne.core` dependency.