### PR TITLE
Google Cloud Artifact Registry publishing

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -58,9 +58,11 @@ repositories {
 }
 
 val jacksonVersion = "2.11.0"
+val googleAuthToolVersion = "2.1.1"
 val licenseReportVersion = "1.16"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion")
     api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
 }

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -27,6 +27,7 @@
 
 import com.github.jk1.license.*
 import com.github.jk1.license.render.ReportRenderer
+import io.spine.internal.gradle.PublishExtension
 
 /**
  * This script plugin generates the license report for all dependencies used in a project.
@@ -80,8 +81,10 @@ class MarkdownReportRenderer implements ReportRenderer {
         project = data.project
         config = project.licenseReport
         output = new File(config.outputDir, fileName)
+        final publishExtension = project.extensions.findByType(PublishExtension.class)
+        final prefix = (publishExtension?.spinePrefix?.getOrElse(false) ?: false) ? "spine-" : ""
         output.text = """
-    \n# Dependencies of `$project.group:spine-$project.name:$project.version`
+    \n# Dependencies of `${project.group}:$prefix${project.name}:${project.version}`
 """
         printDependencies(data)
         output << """

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -81,7 +81,7 @@ class MarkdownReportRenderer implements ReportRenderer {
         project = data.project
         config = project.licenseReport
         output = new File(config.outputDir, fileName)
-        final publishExtension = project.extensions.findByType(PublishExtension.class)
+        final publishExtension = project.rootProject.extensions.findByType(PublishExtension.class)
         final prefix = (publishExtension?.spinePrefix?.getOrElse(false) ?: false) ? "spine-" : ""
         output.text = """
     \n# Dependencies of `${project.group}:$prefix${project.name}:${project.version}`

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -207,6 +207,11 @@ object Repos {
     val cloudArchive = PublishingRepos.cloudArtifactRegistry.releases
     val cloudArchiveSnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
 
+    @Deprecated(
+        message = "Sonatype release repository redirects to the Maven Central",
+        replaceWith = ReplaceWith("sonatypeSnapshots"),
+        level = DeprecationLevel.ERROR
+    )
     const val sonatypeReleases = "https://oss.sonatype.org/content/repositories/snapshots"
     const val sonatypeSnapshots = "https://oss.sonatype.org/content/repositories/snapshots"
 }
@@ -259,25 +264,28 @@ fun RepositoryHandler.applyGitHubPackages(project: Project) {
 @Suppress("unused")
 fun RepositoryHandler.applyStandard() {
 
-    apply {
-        gradlePluginPortal()
-        mavenLocal()
+    gradlePluginPortal()
+    mavenLocal()
 
-        maven {
-            url = URI(Repos.spine)
-            includeSpineOnly()
+    val spineRepos = listOf(
+        Repos.spine,
+        Repos.spineSnapshots,
+        Repos.cloudArchive,
+        Repos.cloudArchiveSnapshots
+    )
+
+    spineRepos
+        .map { URI(it) }
+        .forEach {
+            maven {
+                url = it
+                includeSpineOnly()
+            }
         }
-        maven {
-            url = URI(Repos.spineSnapshots)
-            includeSpineOnly()
-        }
-        mavenCentral()
-        maven {
-            url = URI(Repos.sonatypeReleases)
-        }
-        maven {
-            url = URI(Repos.sonatypeSnapshots)
-        }
+
+    mavenCentral()
+    maven {
+        url = URI(Repos.sonatypeSnapshots)
     }
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -120,16 +120,16 @@ object PublishingRepos {
      * In order to successfully publish into this repository, a service account key is needed.
      * The published must create a service account, grant it the permission to write into
      * Artifact Registry, and generate a JSON key.
-     * Then, the key must be placed somewhere on the file system.
-     * Env variable `GOOGLE_APPLICATION_CREDENTIALS` must point at the key file.
-     * Once, these preconditions are met, publishing becomes possible.
+     * Then, the key must be placed somewhere on the file system and the environment variable
+     * `GOOGLE_APPLICATION_CREDENTIALS` must be set to point at the key file.
+     * Once these preconditions are met, publishing becomes possible.
      *
-     * Implementation note. Google provides [tools](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools)
+     * ## Implementation note
+     * Google provides [tools](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools)
      * for configuring authentication for the Maven repositories, including a Gradle plugin.
-     * However, the plugin is incompatible with Gradle 7.x at the moment. For now, we reproduce what
-     * plugin does manually. This makes the whole `buildSrc` depend on
-     * the `artifactregistry-auth-common` artifact.
-     * Track [this issue](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/52)
+     * However, the plugin is incompatible with Gradle 7.x at the moment.
+     * For now, we reproduce what the plugin does manually. This makes the whole `buildSrc`
+     * depend on the `artifactregistry-auth-common` artifact. Track [this issue](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/52)
      * for the progress on Gradle 7.x support.
      */
     val cloudArtifactRegistry = Repository(

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -98,7 +98,7 @@ data class Credentials(
  */
 object PublishingRepos {
 
-    private const val CLOUD_ARTIFACT_REGISTRY = "https://europe-central2-maven.pkg.dev/spine-dev"
+    private const val CLOUD_ARTIFACT_REGISTRY = "https://europe-maven.pkg.dev/spine-event-engine"
 
     @Suppress("HttpUrlsUsage") // HTTPS is not supported by this repository.
     val mavenTeamDev = Repository(

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -26,6 +26,8 @@
 
 package io.spine.internal.gradle
 
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.artifactregistry.auth.DefaultCredentialProvider
 import io.spine.internal.gradle.PublishingRepos.gitHub
 import java.io.File
 import java.net.URI
@@ -96,6 +98,8 @@ data class Credentials(
  */
 object PublishingRepos {
 
+    private const val CLOUD_ARTIFACT_REGISTRY = "https://europe-central2-maven.pkg.dev/spine-dev"
+
     @Suppress("HttpUrlsUsage") // HTTPS is not supported by this repository.
     val mavenTeamDev = Repository(
         name = "maven.teamdev.com",
@@ -108,6 +112,16 @@ object PublishingRepos {
         releases = "https://spine.mycloudrepo.io/public/repositories/releases",
         snapshots = "https://spine.mycloudrepo.io/public/repositories/snapshots",
         credentialsFile = "cloudrepo.properties"
+    )
+    val cloudArtifactRegistry = Repository(
+        releases = "$CLOUD_ARTIFACT_REGISTRY/releases",
+        snapshots = "$CLOUD_ARTIFACT_REGISTRY/snapshots",
+        credentialValues = {
+            val googleCreds = DefaultCredentialProvider()
+            val creds = googleCreds.credential as GoogleCredentials
+            creds.refreshIfExpired()
+            return@Repository Credentials("oauth2accesstoken", creds.accessToken.tokenValue)
+        }
     )
 
     fun gitHub(repoName: String): Repository {
@@ -165,14 +179,17 @@ object PublishingRepos {
  */
 @Suppress("unused")
 object Repos {
-    val oldSpine: String = PublishingRepos.mavenTeamDev.releases
-    val oldSpineSnapshots: String = PublishingRepos.mavenTeamDev.snapshots
+    val oldSpine = PublishingRepos.mavenTeamDev.releases
+    val oldSpineSnapshots = PublishingRepos.mavenTeamDev.snapshots
 
-    val spine: String = PublishingRepos.cloudRepo.releases
-    val spineSnapshots: String = PublishingRepos.cloudRepo.snapshots
+    val spine = PublishingRepos.cloudRepo.releases
+    val spineSnapshots = PublishingRepos.cloudRepo.snapshots
 
-    const val sonatypeReleases: String = "https://oss.sonatype.org/content/repositories/snapshots"
-    const val sonatypeSnapshots: String = "https://oss.sonatype.org/content/repositories/snapshots"
+    val cloudArchive = PublishingRepos.cloudArtifactRegistry.releases
+    val cloudArchiveSnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
+
+    const val sonatypeReleases = "https://oss.sonatype.org/content/repositories/snapshots"
+    const val sonatypeSnapshots = "https://oss.sonatype.org/content/repositories/snapshots"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -113,6 +113,25 @@ object PublishingRepos {
         snapshots = "https://spine.mycloudrepo.io/public/repositories/snapshots",
         credentialsFile = "cloudrepo.properties"
     )
+
+    /**
+     * The experimental Google Cloud Artifact Registry repository.
+     *
+     * In order to successfully publish into this repository, a service account key is needed.
+     * The published must create a service account, grant it the permission to write into
+     * Artifact Registry, and generate a JSON key.
+     * Then, the key must be placed somewhere on the file system.
+     * Env variable `GOOGLE_APPLICATION_CREDENTIALS` must point at the key file.
+     * Once, these preconditions are met, publishing becomes possible.
+     *
+     * Implementation note. Google provides [tools](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools)
+     * for configuring authentication for the Maven repositories, including a Gradle plugin.
+     * However, the plugin is incompatible with Gradle 7.x at the moment. For now, we reproduce what
+     * plugin does manually. This makes the whole `buildSrc` depend on
+     * the `artifactregistry-auth-common` artifact.
+     * Track [this issue](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/52)
+     * for the progress on Gradle 7.x support.
+     */
     val cloudArtifactRegistry = Repository(
         releases = "$CLOUD_ARTIFACT_REGISTRY/releases",
         snapshots = "$CLOUD_ARTIFACT_REGISTRY/snapshots",

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -312,13 +312,7 @@ private fun RepositoryHandler.spineMavenRepo(
  * Narrows down the search for this repository to Spine-related artifact groups.
  */
 private fun MavenArtifactRepository.includeSpineOnly() {
-    val libraryGroup = "io.spine"
-    val toolsGroup = "io.spine.tools"
-    val gcloudGroup = "io.spine.gcloud"
-
     content {
-        includeGroup(libraryGroup)
-        includeGroup(toolsGroup)
-        includeGroup(gcloudGroup)
+        includeGroupByRegex("io\\.spine.*")
     }
 }


### PR DESCRIPTION
### New repositories

In this PR we configure publishing artifacts to and fetching artifacts from the Google Cloud Artifact Registry.
The registry hosts a Maven repo which serves Java artifacts.

Unlike GitHub Packages, Google CAR allows public auth-free access to the artifacts.

Right now, two repositories are created, one for releases and one for snapshots.
In order to fetch the artifacts, consumers would only need to plack the right URL into their build script:
```kotlin
repositories {
    maven {
        url = uri("https://europe-maven.pkg.dev/spine-event-engine/releases")
    }

    maven {
        url = uri("https://europe-maven.pkg.dev/spine-event-engine/snapshots")
    }
}
```

Alternatively, just use `applyStandard()` to use the standard Spine repositories, which include the Google CAR repositories.

In order to publish artifacts, the developers would have to:
 1. Download a service account key. The service account for publishing Maven artifacts has been created in the `spine-event-engine` GCP project.
 2. Place the key file somewhere on the file system and point the `GOOGLE_APPLICATION_CREDENTIALS` env variable to that location.
 3. Add the repository to the publishing repositories:
```kotlin
spinePublishing {
    // ...
    targetRepositories.add(PublishingRepos.cloudArtifactRegistry)
}
```

Note. In order to publish artifacts, one might need to install the Google Cloud CLI tools (`gcloud`) first.

As of now, both repositories are publicly available. Google recommends capping request thoughput. Right now, the quota is set to 100 requests per minute, we can set it higher at any time.

### Also, in this PR...
...we generate more precise artifact names in the license report. Previously, all the artifact IDs contained the `spine-` name prefix. Now, we only include one if the modules are published with the prefix.