### PR TITLE
Explicitly specify Guava for `buildSrc`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,7 +30,7 @@
  * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
  *
  * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
- * changed in the Kotlin object _and_ in this file below thrice. 
+ * changed in the Kotlin object _and_ in this file below thrice.
  */
 buildscript {
     repositories {
@@ -60,9 +60,13 @@ repositories {
 val jacksonVersion = "2.11.0"
 val googleAuthToolVersion = "2.1.1"
 val licenseReportVersion = "1.16"
+val guavaVersion = "30.1.1-jre"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion")
-    api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
+    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
+        exclude(group = "com.google.guava")
+    }
+    implementation("com.google.guava:guava:$guavaVersion")
+    api("com.github.jk1:gradle-license-report:$licenseReportVersion")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -60,6 +60,13 @@ repositories {
 val jacksonVersion = "2.11.0"
 val googleAuthToolVersion = "2.1.1"
 val licenseReportVersion = "1.16"
+
+/**
+ * The version of Guava used in `buildSrc`.
+ *
+ * Always use the same version as the one specified in `io.spine.internal.dependency.Guava`.
+ * Otherwise, when testing Gradle plugins, clashes may occur.
+ */
 val guavaVersion = "30.1.1-jre"
 
 dependencies {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -26,6 +26,13 @@
 
 package io.spine.internal.dependency
 
+/**
+ * The dependencies for Guava.
+ *
+ * When changing the version, also change the version used in the `build.gradle.kts`. We need
+ * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
+ * Gradle plugins, errors may occur due to version clashes.
+ */
 // https://github.com/google/guava
 object Guava {
     private const val version = "30.1.1-jre"


### PR DESCRIPTION
When testing Gradle plugins, we copy `buildSrc` into the test project. This may lead to version clashes.
One such clash occurred after we've added the Google Cloud Artifact Registry tools as a dependency to `buildSrc`. The versions of Guava used in the tool and in our plugins differed.

In this PR we force the newer version of Guava in `buildSrc`.