### PR TITLE
Allow to test `config` and `config/buildSrc` with local modifications with existing Spine repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ val tempFolder = File("./tmp")
 ConfigTester(config, tasks, tempFolder)
     .addRepo(SpineRepos.baseTypes)  // Builds `base-types` at `master`.
     .addRepo(SpineRepos.base)       // Builds `base` at `master`.
-    .addRepo(SpineRepos.coreJava)   // Builds `base` at `master`.
+    .addRepo(SpineRepos.coreJava)   // Builds `core-java` at `master`.
 
     // This is how one builds a specific branch of some repository:
     // .addRepo(SpineRepos.coreJava, Branch("grpc-concurrency-fixes"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,9 @@
+import io.spine.internal.gradle.SpineRepos
+import io.spine.internal.gradle.cleanFolder
+import io.spine.internal.gradle.BuildSrcTester
+import io.spine.internal.gradle.Branch
+import java.nio.file.Paths
+
 /*
  * Copyright 2021, TeamDev. All rights reserved.
  *
@@ -24,4 +30,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// This empty file is needed to make `buildSrc` buildable.
+// A reference to `buildSrc` to use along with the `BuildSrcTester`.
+// See `BuildSrcTester` below.
+val buildSrc = Paths.get("./buildSrc")
+
+// A temp folder to use to checkout the sources of other repositories.
+// See `BuildSrcTester` down below.
+val tempFolder = File("./tmp")
+
+// Creates a Gradle task which checks out and builds the selected Spine repositories
+// with the local version of `config/buildSrc`.
+BuildSrcTester(buildSrc, tasks, tempFolder)
+    .addRepo(SpineRepos.baseTypes)  // Builds `base-types` at `master`.
+    .addRepo(SpineRepos.base)       // Builds `base` at `master`.
+    .addRepo(SpineRepos.coreJava)   // Builds `base` at `master`.
+
+    // This is how one builds a specific branch of some repository:
+    // .addRepo(SpineRepos.coreJava, Branch("grpc-concurrency-fixes"))
+
+    // Register the produced task under the selected name to invoke manually upon need.
+    .registerUnder("buildDependants")
+
+// Cleans the temp folder used to checkout the sources from Git.
+tasks.register("clean") {
+    doLast {
+        cleanFolder(tempFolder)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import io.spine.internal.gradle.SpineRepos
 import io.spine.internal.gradle.cleanFolder
-import io.spine.internal.gradle.BuildSrcTester
-import io.spine.internal.gradle.Branch
+import io.spine.internal.gradle.ConfigTester
 import java.nio.file.Paths
 
 /*
@@ -30,17 +29,15 @@ import java.nio.file.Paths
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// A reference to `buildSrc` to use along with the `BuildSrcTester`.
-// See `BuildSrcTester` below.
-val buildSrc = Paths.get("./buildSrc")
+// A reference to `buildSrc` to use along with the `ConfigTester`.
+val config = Paths.get("./")
 
-// A temp folder to use to checkout the sources of other repositories.
-// See `BuildSrcTester` down below.
+// A temp folder to use to checkout the sources of other repositories with the `ConfigTester`.
 val tempFolder = File("./tmp")
 
 // Creates a Gradle task which checks out and builds the selected Spine repositories
-// with the local version of `config/buildSrc`.
-BuildSrcTester(buildSrc, tasks, tempFolder)
+// with the local version of `config` and `config/buildSrc`.
+ConfigTester(config, tasks, tempFolder)
     .addRepo(SpineRepos.baseTypes)  // Builds `base-types` at `master`.
     .addRepo(SpineRepos.base)       // Builds `base` at `master`.
     .addRepo(SpineRepos.coreJava)   // Builds `base` at `master`.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -55,12 +55,17 @@ repositories {
     mavenLocal()
     gradlePluginPortal()
     mavenCentral()
+    maven {
+        url = uri("https://repo.spring.io/libs-release")
+    }
 }
 
 val jacksonVersion = "2.11.0"
 val licenseReportVersion = "1.16"
+val grGitVersion = "3.1.1"
 
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
     api("com.github.jk1:gradle-license-report:${licenseReportVersion}")
+    implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Clean.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Clean.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import java.io.File
+import java.lang.IllegalArgumentException
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Cleans the folder and all of its content.
+ */
+fun cleanFolder(folder: File) {
+    if(!folder.exists()) {
+        return
+    }
+    if(!folder.isDirectory) {
+        throw IllegalArgumentException("A folder to clean " +
+                "must be supplied: `${folder.absolutePath}`.")
+    }
+    Files.walk(folder.toPath())
+        .sorted(Comparator.reverseOrder())
+        .map(Path::toFile)
+        .forEach(File::delete);
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/ConfigTester.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/ConfigTester.kt
@@ -36,7 +36,7 @@ import org.ajoberstar.grgit.Grgit
 import org.gradle.api.tasks.TaskContainer
 
 /**
- * A tool to execute the Gradle `build` task in selected Git repositories,
+ * A tool to execute the Gradle `build` task in selected Git repositories
  * with the local version of [config] contents.
  *
  * Checks out the content of selected repositories into the specified [tempFolder]. The folder
@@ -86,7 +86,7 @@ class ConfigTester(
     }
 
     fun registerUnder(taskName: String) {
-        val tasksPerRepo = repos.map { testWithBuildSrc(it) }
+        val tasksPerRepo = repos.map { testWithConfig(it) }
 
         tasks.register(taskName) {
             for (repoTaskName in tasksPerRepo) {
@@ -95,7 +95,7 @@ class ConfigTester(
         }
     }
 
-    private fun testWithBuildSrc(gitRepo: GitRepository): String {
+    private fun testWithConfig(gitRepo: GitRepository): String {
         val runGradleName = runGradleTask(gitRepo)
         doRegisterRunBuild(runGradleName, gitRepo)
 
@@ -285,18 +285,18 @@ class ClonedRepo(
     }
 
     private fun replaceFolder(folderName: String, source: Path, ignoredFolder: Path?) {
-        val buildSrc = location.resolve(folderName)
-        val buildSrcFolder = buildSrc.toFile()
-        if (buildSrcFolder.exists() && buildSrcFolder.isDirectory) {
+        val folder = location.resolve(folderName)
+        val rawFolder = folder.toFile()
+        if (rawFolder.exists() && rawFolder.isDirectory) {
             val toRenameInto = location.resolve(folderName + "-original")
-            println("Renaming ${buildSrc.toAbsolutePath()} into ${toRenameInto.toAbsolutePath()}.")
-            buildSrcFolder.renameTo(toRenameInto.toFile())
+            println("Renaming ${folder.toAbsolutePath()} into ${toRenameInto.toAbsolutePath()}.")
+            rawFolder.renameTo(toRenameInto.toFile())
         }
         println(
             "Copying the files from ${source.toAbsolutePath()} " +
-                    "into ${buildSrc.toAbsolutePath()}."
+                    "into ${folder.toAbsolutePath()}."
         )
-        copyFolder(source, ignoredFolder, buildSrc)
+        copyFolder(source, ignoredFolder, folder)
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -325,7 +325,6 @@ class ClonedRepo(
             throw IllegalStateException(
                 "Error copying folder `$sourceFolder` to `$destinationFolder`.", e
             )
-
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/GitCheckout.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/GitCheckout.kt
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("unused")    /* Some constants may be used throughout the Spine repos. */
+
+package io.spine.internal.gradle
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import org.ajoberstar.grgit.Grgit
+import org.gradle.api.tasks.TaskContainer
+
+/**
+ * A tool to execute the Gradle `build` task in selected Git repositories,
+ * with the specific version of [buildSrc] contents.
+ *
+ * Uses Gradle's [tasks] container to register itself as a Gradle task.
+ *
+ * Checks out the content of selected repositories into the specified [tempFolder]. The folder
+ * is created if it does not exist. By default, uses `./tmp` as a temp folder.
+ *
+ * This tool uses `println`s to print out its state. This is done to simplify the configuration
+ * and dependencies.
+ *
+ * When running the Gradle build for each repository, a [RunBuild] task is used. Error and debug
+ * logs of each Gradle test build are written according to this task's implementation.
+ *
+ * If the selected repository already contains its own `buildSrc` folder, it is NOT overwritten,
+ * but rather renamed into `buildSrc-original`. This allows further tracing if the build fails.
+ */
+class BuildSrcTester(
+    private val buildSrc: Path,
+    private val tasks: TaskContainer,
+    private val tempFolder: File = File("./tmp")
+) {
+    /**
+     * Git repositories to test.
+     */
+    private val repos: MutableList<GitRepository> = ArrayList()
+
+    /**
+     * Adds a Git [repo] into the test build by its URI.
+     *
+     * The `master` branch is used as the one to checkout.
+     */
+    fun addRepo(repo: URI): BuildSrcTester {
+        repos.add(GitRepository(repo))
+        return this
+    }
+
+    /**
+     * Adds a test
+     */
+    fun addRepo(repo: URI, branch: Branch): BuildSrcTester {
+        repos.add(GitRepository(repo, branch))
+        return this
+    }
+
+    fun registerUnder(taskName: String) {
+        val tasksPerRepo = repos.map { testWithBuildSrc(it, buildSrc, tasks, tempFolder) }
+
+        tasks.register(taskName) {
+            for (repoTaskName in tasksPerRepo) {
+                dependsOn(repoTaskName)
+            }
+        }
+    }
+}
+
+private fun testWithBuildSrc(gitRepo: GitRepository,
+                             buildSrc: Path,
+                             tasks: TaskContainer,
+                             tempFolder: File): String {
+    val runGradleName = runGradleTask(gitRepo)
+    tasks.register(runGradleName, RunBuild::class.java) {
+        doFirst {
+            println("`${gitRepo.name}`: starting Gradle build...")
+        }
+        doLast {
+            println("*** `${gitRepo.name}`: Gradle build completed. ***")
+        }
+        directory = gitRepo.prepareCheckout(tempFolder).absolutePath
+    }
+
+    val executeBuildName = executeBuildTask(gitRepo)
+    tasks.register(executeBuildName) {
+        doLast {
+            println(" *** Testing `config/buildSrc` with `${gitRepo.name}`. ***")
+            val localRepo = gitRepo.checkout(tempFolder)
+            localRepo.replaceBuildSrc(buildSrc)
+        }
+        finalizedBy(runGradleName)
+    }
+    return executeBuildName
+}
+
+private fun runGradleTask(repo: GitRepository): String {
+    return "run-gradle-${repo.name}"
+}
+
+private fun executeBuildTask(repo: GitRepository): String {
+    return "execute-build-${repo.name}"
+}
+
+/**
+ * A repository of source code hosted using Git.
+ */
+class GitRepository(
+
+    /**
+     * URI pointing to the location of the repository.
+     */
+    private val uri: URI,
+
+    /**
+     * A branch to checkout.
+     *
+     * By default, points to `master`.
+     */
+    private val branch: Branch = Branch("master"),
+) {
+    /**
+     * The name of this repository.
+     */
+    val name: String
+
+    init {
+        name = repoName(uri)
+    }
+
+    fun prepareCheckout(destinationFolder: File): File {
+        if (!destinationFolder.exists()) {
+            destinationFolder.mkdirs();
+        }
+
+        val result = destinationFolder.toPath().resolve(name)
+        Files.createDirectories(result)
+        return result.toFile()
+    }
+
+    /**
+     * Performs the checkout of the source code for this repository
+     * to the specified [destinationFolder].
+     *
+     * The source code is put to the sub-folder named after the repository.
+     * E.g. for `https://github.com/acme-org/foobar` the code is placed under
+     * the `destinationFolder/foobar` folder.
+     *
+     * If the supplied folder does not exist, it is created.
+     */
+    fun checkout(destinationFolder: File): ClonedRepo {
+        val preparedFolder = prepareCheckout(destinationFolder).toPath()
+        println(
+            "Checking out the `$uri` repository at `${branch.name}` " +
+                    "to `${preparedFolder.toAbsolutePath()}`."
+        )
+
+        Grgit.clone(
+            mapOf(
+                "dir" to preparedFolder,
+                "uri" to uri
+            )
+        ).checkout(
+            mapOf(
+                "branch" to branch.name
+            )
+        )
+        return ClonedRepo(this, preparedFolder)
+    }
+
+    private fun repoName(resourceLocation: URI): String {
+        var path = resourceLocation.path
+        if (path.endsWith('/')) {
+            path = path.substring(0, path.length - 1)
+        }
+        val fromLastSlash = path.lastIndexOf('/') + 1
+        val repoName = path.substring(fromLastSlash)
+        return repoName
+    }
+
+    /**
+     * Returns a new Git repository pointing to some particular Git [branch].
+     */
+    fun at(branch: Branch): GitRepository {
+        return GitRepository(uri, branch)
+    }
+}
+
+/**
+ * The cloned Git repository.
+ */
+class ClonedRepo(
+
+    /**
+     * Origin Git repository which is cloned.
+     */
+    private val repo: GitRepository,
+
+    /**
+     * The location into which the [repo] is cloned.
+     */
+    private val location: Path
+) {
+
+    /**
+     * Replaces the `buildSrc` folder in this cloned repository by the contents
+     * of the folder defined by the [source].
+     *
+     * [source] is expected to be another `buildSrc` folder.
+     *
+     * The original `buildSrc` folder, if it exists in this cloned repo, is renamed
+     * to `buildSrc-original`.
+     *
+     * Returns this instance of `ClonedRepo`, for call chaining.
+     */
+    fun replaceBuildSrc(source: Path): ClonedRepo {
+        val buildSrc = location.resolve("buildSrc")
+        val buildSrcFolder = buildSrc.toFile()
+        if (buildSrcFolder.exists() && buildSrcFolder.isDirectory) {
+            val toRenameInto = location.resolve("buildSrc-original")
+            println("Renaming ${buildSrc.toAbsolutePath()} into ${toRenameInto.toAbsolutePath()}.")
+            buildSrcFolder.renameTo(toRenameInto.toFile())
+        }
+        println("Copying the files from ${source.toAbsolutePath()} into ${buildSrc.toAbsolutePath()}.")
+        copyFolder(source, buildSrc)
+        return this
+    }
+
+    private fun copyFolder(sourceFolder: Path, destinationFolder: Path) {
+        try {
+            Files.walk(sourceFolder).forEach { file: Path ->
+                try {
+                    val destination = destinationFolder.resolve(sourceFolder.relativize(file))
+                    if (Files.isDirectory(file)) {
+                        if (!Files.exists(destination)) Files.createDirectory(destination)
+                        return@forEach
+                    }
+                    Files.copy(file, destination)
+                } catch (e: Exception) {
+                    throw IllegalStateException(
+                        "Error copying folder `$sourceFolder` to `$destinationFolder`.", e
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            throw IllegalStateException(
+                "Error copying folder `$sourceFolder` to `$destinationFolder`.", e
+            )
+
+        }
+    }
+}
+
+/**
+ * Spine repositories at GitHub.
+ *
+ * The list is expected to grow over time.
+ */
+object SpineRepos {
+
+    const val libsOrg: String = "https://github.com/SpineEventEngine/"
+    const val examplesOrg: String = "https://github.com/spine-examples/"
+
+    val base: URI = library("base")
+    val baseTypes: URI = library("base-types")
+    val coreJava: URI = library("core-java")
+    val web: URI = library("web")
+
+    private fun library(repo: String) = URI(libsOrg + repo)
+}
+
+/**
+ * A name of a Git branch.
+ */
+data class Branch(val name: String)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/GitCheckout.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/GitCheckout.kt
@@ -264,6 +264,7 @@ class ClonedRepo(
         return this
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun copyFolder(sourceFolder: Path, destinationFolder: Path) {
         try {
             Files.walk(sourceFolder).forEach { file: Path ->

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -58,6 +58,12 @@ open class RunGradle : DefaultTask() {
     private lateinit var taskNames: List<String>
 
     /**
+     * For how many minutes to wait for the Gradle build to complete.
+     */
+    @Internal
+    var maxDurationMins: Long = 10
+
+    /**
      * Names of Gradle properties to copy into the launched build.
      *
      * The properties are looked up in the root project. If a property is not found, it is ignored.
@@ -73,6 +79,15 @@ open class RunGradle : DefaultTask() {
      */
     fun task(vararg tasks: String) {
         taskNames = tasks.asList()
+    }
+
+    /**
+     * Sets the maximum time to wait until the build completion in minutes
+     * and specifies task names to be passed to the Gradle Wrapper script.
+     */
+    fun task(maxDurationMins: Long, vararg tasks: String) {
+        taskNames = tasks.asList()
+        this.maxDurationMins = maxDurationMins
     }
 
     @TaskAction
@@ -96,7 +111,7 @@ open class RunGradle : DefaultTask() {
               https://github.com/gradle/gradle/issues/3987
               https://discuss.gradle.org/t/weirdness-in-gradle-exec-on-windows/13660/6
          */
-        val completed = process.waitFor(10, TimeUnit.MINUTES)
+        val completed = process.waitFor(maxDurationMins, TimeUnit.MINUTES)
         val exitCode = process.exitValue()
         if (!completed || exitCode != 0) {
             val errorOutExists = errorOut.exists()

--- a/scripts/update-apt.sh
+++ b/scripts/update-apt.sh
@@ -26,7 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-# Standard update precedure.
+# Standard update procedure.
 sudo apt-get install -y libxml2-dev
 sudo apt-get update
 


### PR DESCRIPTION
Previously, any changes made to `config` may turn out to be breaking for some of Spine repositories. The main reason for that was the cost of testing, which required manual checkout of all repos, copying the `config` and `buildSrc` over to them, and launching builds.

This changeset adds a `ConfigTester` to automate all that. This tool serves to probe the Spine repositories for compatibility with the local changes in the `config` repository. Long story short, that's how one uses it (copied from `config/build.gradle.kts`):

```kotlin
// A reference to `config` to use along with the `ConfigTester`.
val config = Paths.get("./")

// A temp folder to use to checkout the sources of other repositories with the `ConfigTester`.
val tempFolder = File("./tmp")

// Creates a Gradle task which checks out and builds the selected Spine repositories
// with the local version of `config` and `config/buildSrc`.
ConfigTester(config, tasks, tempFolder)
    .addRepo(SpineRepos.baseTypes)  // Builds `base-types` at `master`.
    .addRepo(SpineRepos.base)       // Builds `base` at `master`.
    .addRepo(SpineRepos.coreJava)   // Builds `core-java` at `master`.

    // This is how one builds a specific branch of some repository:
    // .addRepo(SpineRepos.coreJava, Branch("grpc-concurrency-fixes"))

    // Register the produced task under the selected name to invoke manually upon need.
    .registerUnder("buildDependants")
```

and then:

```bash
./gradlew buildDependants
```

Another helpful tool is a `cleanFolder` utility:

``` Kotlin
// Cleans the temp folder used to checkout the sources from Git.
tasks.register("clean") {
    doLast {
        cleanFolder(tempFolder)
    }
}
```
making the bash command look like this:

```bash
./gradlew clean buildDependants 
```

Sidenote: a time to build `base`, `base-types` and `core-java` locally is around 32-35 minutes.