### PR TITLE
Run `checkVersionIncrement` for both `releases` and `snapshots`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -45,7 +45,7 @@ open class CheckVersionIncrement : DefaultTask() {
     /**
      * The Maven repository in which to look for published artifacts.
      *
-     * We check both the `releases` and `snapshots` repository. Artifacts in either of these repos
+     * We check both the `releases` and `snapshots` repositories. Artifacts in either of these repos
      * may not be overwritten.
      */
     @Input

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -57,7 +57,11 @@ open class CheckVersionIncrement : DefaultTask() {
     @TaskAction
     private fun fetchAndCheck() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
-        val repoUrl = repository.releases
+        checkInRepo(repository.snapshots, artifact)
+        checkInRepo(repository.releases, artifact)
+    }
+
+    private fun checkInRepo(repoUrl: String, artifact: String) {
         val metadata = fetch(repoUrl, artifact)
         val versions = metadata?.versioning?.versions
         val versionExists = versions?.contains(version) ?: false

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -45,8 +45,8 @@ open class CheckVersionIncrement : DefaultTask() {
     /**
      * The Maven repository in which to look for published artifacts.
      *
-     * We only check the `releases` repository. Artifacts in `snapshots` repository still may be
-     * overridden.
+     * We check both the `releases` and `snapshots` repository. Artifacts in either of these repos
+     * may not be overwritten.
      */
     @Input
     lateinit var repository: Repository

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/CheckVersionIncrement.kt
@@ -28,13 +28,13 @@ package io.spine.internal.gradle
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import java.io.FileNotFoundException
+import java.net.URL
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import java.io.FileNotFoundException
-import java.net.URL
 
 /**
  * A task which verifies that the current version of the library has not been published to the given
@@ -58,7 +58,10 @@ open class CheckVersionIncrement : DefaultTask() {
     private fun fetchAndCheck() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
         checkInRepo(repository.snapshots, artifact)
-        checkInRepo(repository.releases, artifact)
+
+        if (repository.releases != repository.snapshots) {
+            checkInRepo(repository.releases, artifact)
+        }
     }
 
     private fun checkInRepo(repoUrl: String, artifact: String) {


### PR DESCRIPTION
Previously, `checkVersionIncrement` task has been targeting only `releases`. So, release versions could not be overwritten once they had been published. It was still possible to overwrite snapshots.

However, as we started publishing to GitHub Packages, any overwrites became impossible. An attempt to do so now resolves in a HTTP response 409 "Conflict".

This changeset now forces the check to ensure neither of `snapshots` and `releases` repositories contains the version which is to be published.

Please note, that for local builds AND for the CI runs in `master` branches this task will still NOT run. It is a precautious measure, partially explained by the comment in `IncrementGuard`:

```kotlin
    /**
     * Adds the [CheckVersionIncrement] task to the project.
     *
     * Only adds the check if the project is built on Travis CI and the job is a pull request.
     *
     * The task only runs on non-master branches on GitHub Actions. This is done
     * to prevent unexpected CI fails when re-building `master` multiple times, creating git
     * tags, and in other cases that go outside of the "usual" development cycle.
     */
    override fun apply(target: Project) { ... }
```
For now, we still may encounter a need to re-trigger builds in `master` branch if they fail for some unfortunate reason. Therefore, such behaviour is left intact within this PR.