### PR TITLE
Tune copying

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,8 +10,6 @@ coverage:
   - generated/*
   - examples/*
   - test/*
-  status:
-    patch: false
 
 comment:
   layout: "header, diff, changes, uncovered"

--- a/pull
+++ b/pull
@@ -59,15 +59,18 @@ cp -R CONTRIBUTING.md ..
 echo "Updating Contributor Covenant"
 cp -R CODE_OF_CONDUCT.md ..
 
-echo "Updating CI config files"
-cp .codecov.yml ..
-cp .gitattributes ..
+# Copies the file passes as the first parameter to the upper directory,
+# only if such a file does not exist there.
+function initialize() {
+  if [ ! -f ../"$1" ]; then
+      echo "Creating $1"
+      cp "$1" ..
+  fi
+}
 
-# Copy `.gitignore` only if it's not yet created.
-if [ ! -f ../.gitignore ]; then
-    echo "Creating .gitignore"
-    cp .gitignore ..
-fi
+initialize .gitattributes
+initialize .gitignore
+initialize .codecov.yml
 
 echo "Updating Gradle buildSrc scripts"
 cp -R buildSrc ..


### PR DESCRIPTION
This PR:
  * Enables Codecov patch statuses in the default configuration (to avoid the confusion when initialized in a new repo).
  * Tunes the `pull` script to not overwrite already present configuration files in the root directory of the project.
