### PR TITLE
Remove redundant semicolon

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Clean.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Clean.kt
@@ -27,7 +27,6 @@
 package io.spine.internal.gradle
 
 import java.io.File
-import java.lang.IllegalArgumentException
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -45,5 +44,5 @@ fun cleanFolder(folder: File) {
     Files.walk(folder.toPath())
         .sorted(Comparator.reverseOrder())
         .map(Path::toFile)
-        .forEach(File::delete);
+        .forEach(File::delete)
 }


### PR DESCRIPTION
This PR cleans the `Clean.kt` from a redundant semicolon and unused import.