### PR TITLE
Fix a typo

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -214,8 +214,8 @@ object Repos {
     val spine = PublishingRepos.cloudRepo.releases
     val spineSnapshots = PublishingRepos.cloudRepo.snapshots
 
-    val cloudArtifactRegistry = PublishingRepos.cloudArtifactRegistry.releases
-    val cloudArtifactRegistrySnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
+    val artifactRegistry = PublishingRepos.cloudArtifactRegistry.releases
+    val artifactRegistrySnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
 
     @Deprecated(
         message = "Sonatype release repository redirects to the Maven Central",
@@ -280,8 +280,8 @@ fun RepositoryHandler.applyStandard() {
     val spineRepos = listOf(
         Repos.spine,
         Repos.spineSnapshots,
-        Repos.cloudArtifactRegistry,
-        Repos.cloudArtifactRegistrySnapshots
+        Repos.artifactRegistry,
+        Repos.artifactRegistrySnapshots
     )
 
     spineRepos

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -214,8 +214,8 @@ object Repos {
     val spine = PublishingRepos.cloudRepo.releases
     val spineSnapshots = PublishingRepos.cloudRepo.snapshots
 
-    val cloudArchive = PublishingRepos.cloudArtifactRegistry.releases
-    val cloudArchiveSnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
+    val cloudArtifactRegistry = PublishingRepos.cloudArtifactRegistry.releases
+    val cloudArtifactRegistrySnapshots = PublishingRepos.cloudArtifactRegistry.snapshots
 
     @Deprecated(
         message = "Sonatype release repository redirects to the Maven Central",
@@ -280,8 +280,8 @@ fun RepositoryHandler.applyStandard() {
     val spineRepos = listOf(
         Repos.spine,
         Repos.spineSnapshots,
-        Repos.cloudArchive,
-        Repos.cloudArchiveSnapshots
+        Repos.cloudArtifactRegistry,
+        Repos.cloudArtifactRegistrySnapshots
     )
 
     spineRepos


### PR DESCRIPTION
Somehow, we called the properties that store GCAR URLs `cloudArchive` and `cloudArchiveSnapshots`.
Google Cloud Artifact Registry is not a cloud archive. Indeed, Cloud Archive is a name of an Azure service.
In this PR we correct that mistake.