### PR TITLE
Travis-specific Javadoc task log configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ project. The following files will be copied:
  
 ## Adding credentials to a new repository
 
-For details, see [this page](https://github.com/SpineEventEngine/config/wiki/Encrypting-Credential-Files-for-Travis).
+For details, please see [this page][travis-creds].
 
 ## Checking updated configuration
 
@@ -87,4 +87,5 @@ These scripts are copied by the `pull` script when `config` is applied to a new 
   
 [base]: https://github.com/SpineEventEngine/base
 [base-types]: https://github.com/SpineEventEngine/base-types
-[core-java]: https://github.com/SpineEventEngine/core-java 
+[core-java]: https://github.com/SpineEventEngine/core-java
+[travis-creds]: https://github.com/SpineEventEngine/config/wiki/Encrypting-Credential-Files-for-Travis 

--- a/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
+++ b/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
@@ -41,7 +41,6 @@ object TravisLogs {
         val isTravis = System.getenv("TRAVIS") == "true"
         if (isTravis) {
             // Set the maximum number of Javadoc warnings to print.
-            //
             // If the parameter value is zero, all warnings will be printed.
             p.tasks.named<Javadoc>("javadoc") {
                 val opt = options

--- a/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
+++ b/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
@@ -33,8 +33,10 @@ import org.gradle.kotlin.dsl.named
 object TravisLogs {
 
     /**
-     * Specific setup for a Travis build, which prevents appearing of warning messages
-     * in build logs. It is expected that warnings are viewed and analyzed in the local build logs.
+     * Specific setup for a Travis build, which prevents warning messages related to
+     * `javadoc` tasks in build logs.
+     *
+     * It is expected that warnings are viewed and analyzed during local builds.
      */
     fun configure(p: Project) {
         //

--- a/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
+++ b/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
@@ -38,7 +38,7 @@ object TravisLogs {
      *
      * It is expected that warnings are viewed and analyzed during local builds.
      */
-    fun configure(p: Project) {
+    fun hideJavadocWarnings(p: Project) {
         //
         val isTravis = System.getenv("TRAVIS") == "true"
         if (isTravis) {

--- a/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
+++ b/buildSrc/src/main/kotlin/travis-warnings.gradle.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.external.javadoc.CoreJavadocOptions
+import org.gradle.kotlin.dsl.named
+
+@Suppress("unused")
+object TravisLogs {
+
+    /**
+     * Specific setup for a Travis build, which prevents appearing of warning messages
+     * in build logs. It is expected that warnings are viewed and analyzed in the local build logs.
+     */
+    fun configure(p: Project) {
+        //
+        val isTravis = System.getenv("TRAVIS") == "true"
+        if (isTravis) {
+            // Set the maximum number of Javadoc warnings to print.
+            //
+            // If the parameter value is zero, all warnings will be printed.
+            p.tasks.named<Javadoc>("javadoc") {
+                val opt = options
+                if (opt is CoreJavadocOptions) {
+                    opt.addStringOption("Xmaxwarns", "1")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a Gradle script plugin for configuring logging of `javadoc` tasks when running under Travis. 

Even though, we're stopping using Travis, this piece of knowledge is valuable, and should be preserved before we remove it from build scripts.