### PR TITLE
Pull Dokka to the package level

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -26,13 +26,9 @@
 
 package io.spine.internal.dependency
 
-// https://github.com/JetBrains/kotlin
-// https://github.com/Kotlin
-object Kotlin {
-    @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.30"
-    const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
-    const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
-    const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
-    const val stdLibJdk8   = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
+// https://github.com/Kotlin/dokka
+@Suppress("unused")
+object Dokka {
+    const val version = "1.5.0"
+    const val pluginId = "org.jetbrains.dokka"
 }


### PR DESCRIPTION
This PR moves the `Dokka` dependency object to the package level. Previously, it was under `Kotlin`. 

Since Dokka is versioned differently than Kotlin, having it as a top level dependency object makes more sense.