### PR TITLE
Clean up a workflow file

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Upload code coverage report
         uses: codecov/codecov-action@v2
         with:
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
We remove the `# optional (default = false)` comments from the `build-on-ubuntu.yml`. This comment was copied from the action usage example and has no value for us.