### PR TITLE
Fix `VersionWriter`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/ProjectExtensions.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.getByType
+
+/**
+ * This file contains extension methods and properties for the Gradle `Project`.
+ */
+
+/**
+ * Obtains the Java plugin extension of the project.
+ */
+val Project.javaPluginExtension: JavaPluginExtension
+    get() = extensions.getByType()
+
+/**
+ * Obtains source set container of the Java project.
+ */
+val Project.sourceSets: SourceSetContainer
+    get() = javaPluginExtension.sourceSets

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Publish.kt
@@ -192,10 +192,7 @@ private fun Project.prepareTasks(publish: Task, checkCredentials: Task) {
 }
 
 private fun Project.setUpDefaultArtifacts() {
-    val javaExtension: JavaPluginExtension =
-        project.extensions.getByType(JavaPluginExtension::class.java)
-    val sourceSets = javaExtension.sourceSets
-
+    val sourceSets = this.sourceSets
     val sourceJar = tasks.createIfAbsent(
         artifactTask = sourceJar,
         from = sourceSets["main"].allSource,

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -126,11 +126,8 @@ class VersionWriter : Plugin<Project> {
         val task = register("writeVersions", WriteVersions::class.java) {
             versionsFileLocation.convention(project.layout.buildDirectory.dir(name))
             includeOwnVersion()
-            @Suppress("SimpleRedundantLet")
-                // Decrease the number of null-safe calls (`?.`).
-            extensions.findByType<JavaPluginExtension>()?.let {
-                it.sourceSets
-                    .getByName("main")
+            project.extensions.findByType<JavaPluginExtension>()!!.apply {
+                sourceSets.getByName("main")
                     .resources
                     .srcDir(versionsFileLocation)
             }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -132,6 +132,6 @@ class VersionWriter : Plugin<Project> {
                     .srcDir(versionsFileLocation)
             }
         }
-        findByName("processResources")?.dependsOn(task)
+        getByName("processResources").dependsOn(task)
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -126,11 +126,10 @@ class VersionWriter : Plugin<Project> {
         val task = register("writeVersions", WriteVersions::class.java) {
             versionsFileLocation.convention(project.layout.buildDirectory.dir(name))
             includeOwnVersion()
-            project.extensions.findByType<JavaPluginExtension>()!!.apply {
-                sourceSets.getByName("main")
-                    .resources
-                    .srcDir(versionsFileLocation)
-            }
+            project.sourceSets
+                .getByName("main")
+                .resources
+                .srcDir(versionsFileLocation)
         }
         getByName("processResources").dependsOn(task)
     }


### PR DESCRIPTION
In this PR we fix the `VersionWriter` so that the generated file is added automatically to the resources.