### PR TITLE
Add `buildSrc/src`  to Git after `pull`

### DIFF
--- a/pull
+++ b/pull
@@ -85,4 +85,7 @@ cp -R buildSrc ..
 
 cd ..
 
+echo "Adding buildSrc sources to Git..."
+git add ./buildSrc/src
+
 echo "Done."

--- a/pull
+++ b/pull
@@ -80,12 +80,12 @@ echo "Updating GitHub workflows"
 cp -a .github/workflows/. ../.github/workflows
 cp -a .github-workflows/. ../.github/workflows
 
-echo "Updating Gradle buildSrc scripts"
+echo "Updating Gradle 'buildSrc' scripts"
 cp -R buildSrc ..
 
 cd ..
 
-echo "Adding buildSrc sources to Git..."
+echo "Adding 'buildSrc' sources to Git..."
 git add ./buildSrc/src
 
 echo "Done."


### PR DESCRIPTION
When pulling changes from `config`, sometimes, new files are added to the `buildSrc` Gradle project.
The users have to add those files to Git manually.

In this PR we make the `pull` script add new source files of the `buildSrc` Gradle project to Git automatically.