### PR TITLE
Fix import in `license-report-project.gradle`

### DIFF
--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -27,7 +27,7 @@
 
 import com.github.jk1.license.*
 import com.github.jk1.license.render.ReportRenderer
-import io.spine.internal.gradle.PublishExtension
+import io.spine.internal.gradle.publish.PublishExtension
 
 /**
  * This script plugin generates the license report for all dependencies used in a project.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProjectExtensions.kt
@@ -112,7 +112,6 @@ private fun Project.prepareTasks(publish: Task, checkCredentials: Task) {
 }
 
 private fun Project.setUpDefaultArtifacts() {
-    val sourceSets = this.sourceSets
     val sourceJar = tasks.createIfAbsent(
         artifactTask = ArtifactTaskName.sourceJar,
         from = sourceSets["main"].allSource,
@@ -131,9 +130,10 @@ private fun Project.setUpDefaultArtifacts() {
     )
 
     artifacts {
-        add(ConfigurationName.archives, sourceJar)
-        add(ConfigurationName.archives, testOutputJar)
-        add(ConfigurationName.archives, javadocJar)
+        val archives = ConfigurationName.archives
+        add(archives, sourceJar)
+        add(archives, testOutputJar)
+        add(archives, javadocJar)
     }
 }
 


### PR DESCRIPTION
This PR fixes the reference to the new publishing API made from the `license-report-project.gradle` script.