### PR TITLE
Extend gRPC dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -31,12 +31,14 @@ package io.spine.internal.dependency
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
     const val version        = "1.38.0"
+    const val api            = "io.grpc:grpc-api:${version}"
     const val core           = "io.grpc:grpc-core:${version}"
+    const val context        = "io.grpc:grpc-context:${version}"
     const val stub           = "io.grpc:grpc-stub:${version}"
     const val okHttp         = "io.grpc:grpc-okhttp:${version}"
     const val protobuf       = "io.grpc:grpc-protobuf:${version}"
+    const val protobufLite   = "io.grpc:grpc-protobuf-lite:${version}"
+    const val protobufPlugin = "io.grpc:protoc-gen-grpc-java:${version}"
     const val netty          = "io.grpc:grpc-netty:${version}"
     const val nettyShaded    = "io.grpc:grpc-netty-shaded:${version}"
-    const val context        = "io.grpc:grpc-context:${version}"
-    const val protobufPlugin = "io.grpc:protoc-gen-grpc-java:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/JavadocConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/JavadocConfig.kt
@@ -51,6 +51,7 @@ object JavadocConfig {
 
     fun applyTo(project: Project) {
         val docletOptions = project.tasks.javadocTask().options as StandardJavadocDocletOptions
+        docletOptions.encoding = encoding.name
         reduceParamWarnings(docletOptions)
         registerCustomTags(docletOptions)
     }


### PR DESCRIPTION
This PR adds properties to the `Grpc` dependency object which are used in `gcloud-java`. Even though there's only one repository now, it would be better to have these properties to highlight their usage, and ease the search.

Also this PR enforces UTF-8 encoding when applying the `JavadocConfig` plugin to a Gradle project.

