### PR TITLE
Smarter `updateGitHubPages` task

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
@@ -146,12 +146,24 @@ class UpdateGitHubPages : Plugin<Project> {
             val projectVersion = project.version.toString()
             val isSnapshot = isSnapshot(projectVersion)
             if (isSnapshot) {
+                registerNoOpTask(project)
+            } else {
+                registerTasks(extension, project)
+            }
+        }
+    }
+
+    /**
+     * Registers `updateGitHubPages` task which performs no actual update, but prints the message
+     * telling the update is skipped, since the project is in its `SNAPSHOT` version.
+     */
+    private fun Project.registerNoOpTask(project: Project) {
+        tasks.register(taskName) {
+            doLast {
                 println(
                     "GitHub Pages update will be skipped since this project" +
                             " is a snapshot: `${project.name}-${project.version}`."
                 )
-            } else {
-                registerTasks(extension, project)
             }
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
@@ -146,7 +146,7 @@ class UpdateGitHubPages : Plugin<Project> {
             val projectVersion = project.version.toString()
             val isSnapshot = isSnapshot(projectVersion)
             if (isSnapshot) {
-                registerNoOpTask(project)
+                registerNoOpTask()
             } else {
                 registerTasks(extension, project)
             }
@@ -157,12 +157,13 @@ class UpdateGitHubPages : Plugin<Project> {
      * Registers `updateGitHubPages` task which performs no actual update, but prints the message
      * telling the update is skipped, since the project is in its `SNAPSHOT` version.
      */
-    private fun Project.registerNoOpTask(project: Project) {
+    private fun Project.registerNoOpTask() {
         tasks.register(taskName) {
             doLast {
+                val project = this@registerNoOpTask
                 println(
-                    "GitHub Pages update will be skipped since this project" +
-                            " is a snapshot: `${project.name}-${project.version}`."
+                    "GitHub Pages update will be skipped since this project is a snapshot: " +
+                            "`${project.name}-${project.version}`."
                 )
             }
         }


### PR DESCRIPTION
This changeset updates the `updateGitHubPages` Gradle task.

Previously, it was skipping all the actions in case the project was a `SNAPSHOT`. However, it led to some issues, as consuming Gradle projects may have had a dependency onto `updateGitHubPages` — whether it was actually registered or not.

Now, we always register `updateGitHubPages` as a Gradle task. But for `SNAPSHOT` projects, it just prints a diagnostic message telling that the actual update is going to be skipped for the `SNAPSHOT`-versioned project.