### PR TITLE
Allow external inputs for `UpdateGitHubPages`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
@@ -94,7 +94,12 @@ class UpdateGitHubPages : Plugin<Project> {
      */
     private lateinit var rootFolder: File
 
-    private lateinit var includeOutputOfTasks: Set<String>
+    /**
+     * The external inputs to include into the publishing.
+     *
+     * The inputs are evaluated according to [Copy.from] specification.
+     */
+    private lateinit var includedInputs: Set<Any>
 
     /**
      * Path to the temp folder used to gather the Javadoc output
@@ -174,7 +179,7 @@ class UpdateGitHubPages : Plugin<Project> {
     private fun registerTasks(extension: UpdateGitHubPagesExtension, project: Project) {
         val includeInternal = extension.allowInternalJavadoc()
         rootFolder = extension.rootFolder()
-        includeOutputOfTasks = extension.includeOutputOfTasks()
+        includedInputs = extension.includedInputs()
         val tasks = project.tasks
         if (!includeInternal) {
             InternalJavadocFilter.registerTask(project)
@@ -254,16 +259,12 @@ class UpdateGitHubPages : Plugin<Project> {
         allowInternalJavadoc: Boolean
     ): MutableList<Any> {
         val inputs = mutableListOf<Any>()
-
-        includeOutputOfTasks.forEach {
-            val toInclude = tasks.findByName(it)!!
-            inputs.add(toInclude)
-        }
         if (allowInternalJavadoc) {
             inputs.add(tasks.javadocTask(InternalJavadocFilter.taskName))
         } else {
             inputs.add(tasks.javadocTask(JavadocTask.name))
         }
+        inputs.addAll(includedInputs)
         return inputs
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPagesExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPagesExtension.kt
@@ -29,6 +29,7 @@ package io.spine.internal.gradle.github.pages
 import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.property
@@ -58,7 +59,15 @@ private constructor(
     /**
      * The root folder of the repository to which the updated `Project` belongs.
      */
-    var rootFolder: Property<File>
+    var rootFolder: Property<File>,
+
+    /**
+     * The names of other Gradle tasks, which output should be included
+     * into the GitHub Pages update.
+     *
+     * This property is optional.
+     */
+    var includeTaskOutput: SetProperty<String>
 ) {
 
     internal companion object {
@@ -66,7 +75,8 @@ private constructor(
             val factory = project.objects
             return UpdateGitHubPagesExtension(
                 allowInternalJavadoc = factory.property(Boolean::class),
-                rootFolder = factory.property(File::class)
+                rootFolder = factory.property(File::class),
+                includeTaskOutput = factory.setProperty(String::class.java)
             )
         }
     }
@@ -84,5 +94,13 @@ private constructor(
      */
     fun rootFolder(): File {
         return rootFolder.get()
+    }
+
+    /**
+     * Returns the name of Gradle tasks, which output should be included
+     * into the GitHub Pages update.
+     */
+    fun includeOutputOfTasks(): Set<String> {
+        return includeTaskOutput.get()
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPagesExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPagesExtension.kt
@@ -62,12 +62,14 @@ private constructor(
     var rootFolder: Property<File>,
 
     /**
-     * The names of other Gradle tasks, which output should be included
+     * The external inputs, which output should be included
      * into the GitHub Pages update.
+     *
+     * The values are interpreted according to [org.gradle.api.tasks.Copy.from] specification.
      *
      * This property is optional.
      */
-    var includeTaskOutput: SetProperty<String>
+    var includeInputs: SetProperty<Any>
 ) {
 
     internal companion object {
@@ -76,7 +78,7 @@ private constructor(
             return UpdateGitHubPagesExtension(
                 allowInternalJavadoc = factory.property(Boolean::class),
                 rootFolder = factory.property(File::class),
-                includeTaskOutput = factory.setProperty(String::class.java)
+                includeInputs = factory.setProperty(Any::class.java)
             )
         }
     }
@@ -97,10 +99,10 @@ private constructor(
     }
 
     /**
-     * Returns the name of Gradle tasks, which output should be included
+     * Returns the external inputs, which results should be included
      * into the GitHub Pages update.
      */
-    fun includeOutputOfTasks(): Set<String> {
-        return includeTaskOutput.get()
+    fun includedInputs(): Set<Any> {
+        return includeInputs.get()
     }
 }


### PR DESCRIPTION
This changeset introduces a way to include some external inputs into the GitHub Pages update.

```kotlin
updateGitHubPages {

        // ...

        // A directory, or a path to the directory.
        includeInputs.add(someDir)
        
        // Or, an output of some task.
        includeInputs.add(anotherTask)
    }

```

The values are treated according to the specification of [Copy.from](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/AbstractCopyTask.html#from-java.lang.Object...-), which, in turn, delegates the evaluation to [Project.files](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#files-java.lang.Object...-).