### PR TITLE
Improve dependency objects

### DIFF
--- a/buildSrc/src/main/groovy/js/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/build-tasks.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package js
 
 /**
  * This script declares common Gradle tasks required for JavaScript modules.

--- a/buildSrc/src/main/groovy/js/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/build-tasks.gradle
@@ -46,8 +46,8 @@ ext {
 }
 
 apply plugin: 'base'
-apply from: deps.scripts.npmCli
-apply from: deps.scripts.updatePackageVersion
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "/js/npm-cli.gradle"
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "/js/update-package-version.gradle"
 
 /**
  * Compiles Protobuf sources into JavaScript.

--- a/buildSrc/src/main/groovy/js/configure-proto.gradle
+++ b/buildSrc/src/main/groovy/js/configure-proto.gradle
@@ -49,7 +49,7 @@ ext {
     genProtoTest = "$genProtoBaseDir/test/js"
 }
 
-apply from: Scripts.npmPublishTasks
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/npm-publish-tasks.gradle"
 
 /**
  * Configures the JS code generation.
@@ -81,8 +81,8 @@ protobuf {
 }
 
 /**
- * Configures the generation of additional features for the Proto messages via Spine Proto JS
- * plugin.
+ * Configures the generation of additional features for the Proto messages via
+ * Spine Proto JS plugin.
  */
 protoJs {
     mainGenProtoDir = genProtoMain

--- a/buildSrc/src/main/groovy/js/configure-proto.gradle
+++ b/buildSrc/src/main/groovy/js/configure-proto.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package js
 
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.Scripts

--- a/buildSrc/src/main/groovy/js/js.gradle
+++ b/buildSrc/src/main/groovy/js/js.gradle
@@ -1,0 +1,217 @@
+package js
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * A script configuring the build of a JavaScript module, which is going to be published to NPM.
+ *
+ * <p>In particular, the script brings tasks to:
+ * <ol>
+ *     <li>Install NPM dependencies. 
+ *     <li>Compile Protobuf sources to JavaScript.
+ *     <li>Test and generate coverage reports for JavaScript sources. 
+ *     <li>Update the version in `package.json` depending on the `versionToPublishJs` property. 
+ *     <li>Clean up the build output of a JavaScript module. 
+ * </ol>
+ *
+ * <p>The script is based on other scripts from `config` submodule.
+ */
+
+ext {
+    srcDir = "$projectDir/main"
+    testSrcDir = "$projectDir/test"
+    genProtoBaseDir = projectDir
+    genProtoSubDir = "proto"
+    genProtoMain = "$genProtoBaseDir/main/$genProtoSubDir"
+    genProtoTest = "$genProtoBaseDir/test/$genProtoSubDir"
+    nycOutputDir = "$projectDir/.nyc_output"
+}
+
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "/js/npm-publish-tasks.gradle"
+
+/**
+ * Cleans old module dependencies and build outputs.
+ */
+task deleteCompiled {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Cleans old module dependencies and build outputs.'
+
+    clean.dependsOn deleteCompiled
+
+    doLast {
+        delete genProtoMain
+        delete genProtoTest
+        delete coverageJs.outputs
+    }
+}
+
+/**
+ * Customizes the task already defined in `config` module by running Webpack build.
+ */
+buildJs {
+
+    outputs.dir "$projectDir/dist"
+    
+    doLast {
+        npm 'run', 'build'
+        npm 'run', 'build-dev'
+    }
+}
+
+/**
+ * Customizes the task already defined in `config` module by running
+ * the JavaScript tests.
+ */
+testJs {
+
+    doLast {
+        npm 'run', 'test'
+    }
+}
+
+/**
+ * Copies bundled JS sources to the temporary NPM publication directory.
+ */
+task copyBundledJs(type: Copy) {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Copies assembled JavaScript sources to the NPM publication directory.'
+
+    from buildJs.outputs
+    into "$publicationDirectory/dist"
+
+    dependsOn buildJs
+}
+
+/**
+ * Transpiles JS sources before publishing them to NPM.
+ *
+ * Puts the resulting files to the temporary NPM publication directory.
+ */
+task transpileSources {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = "Transpiles sources before publishing."
+
+    doLast {
+        npm 'run', 'transpile-before-publish'
+    }
+}
+
+/**
+ * Defines files to copy by the task.
+ */
+prepareJsPublication {
+
+    doLast {
+        copy {
+            from (projectDir) {
+                include 'package.json'
+                include '.npmrc'
+            }
+            into publicationDirectory
+        }
+    }
+
+    //TODO:2019-02-05:dmytro.grankin: temporarily don't publish a bundle, see https://github.com/SpineEventEngine/web/issues/61
+    //dependsOn copyBundledJs
+    dependsOn transpileSources
+}
+
+/**
+ * Runs the JavaScript tests and collects the code coverage.
+ */
+task coverageJs {
+    group = JAVA_SCRIPT_TASK_GROUP
+    description = 'Runs the JS tests and collects the code coverage info.'
+
+    outputs.dir nycOutputDir
+
+    final def runsOnWindows = org.gradle.internal.os.OperatingSystem.current().isWindows()
+    final def coverageScript = runsOnWindows ? 'coverage:win' : 'coverage:unix'
+
+    doLast {
+        npm 'run', coverageScript
+    }
+
+    dependsOn buildJs
+    
+    rootProject.check.dependsOn coverageJs
+}
+
+/**
+ * Generates the report on NPM dependencies and their licenses.
+ */
+task npmLicenseReport {
+    
+    doLast {
+        npm 'run', 'license-report'
+    }
+}
+
+/**
+ * Runs NPM license report straight after the Gradle license report.
+ */
+//TODO:2021-09-22:alexander.yevsyukov: Resolve this dependency.
+//generateLicenseReport.finalizedBy npmLicenseReport
+
+apply plugin: 'io.spine.mc-js'
+
+protoJs {
+    generatedMainDir = genProtoMain
+    generatedTestDir = genProtoTest
+
+    generateParsersTask().dependsOn compileProtoToJs
+    buildJs.dependsOn generateParsersTask()
+    testJs.dependsOn buildJs
+}
+
+
+protobuf {
+    generatedFilesBaseDir = genProtoBaseDir
+    protoc {
+        artifact = io.spine.internal.dependency.Protobuf.compiler
+    }
+    generateProtoTasks {
+        all().each { final task ->
+            task.builtins {
+                // Do not use java builtin output in this project.
+                remove java
+
+                // For information on JavaScript code generation please see
+                // https://github.com/google/protobuf/blob/master/js/README.md
+                js {
+                    option "import_style=commonjs"
+                    outputSubDir = genProtoSubDir
+                }
+
+                task.generateDescriptorSet = true
+                final def testClassifier = task.sourceSet.name == "test" ? "_test" : ""
+                final def descriptorName = "${project.group}_${project.name}_${project.version}${testClassifier}.desc"
+                task.descriptorSetOptions.path = "${projectDir}/build/descriptors/${task.sourceSet.name}/${descriptorName}"
+            }
+            compileProtoToJs.dependsOn task
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/js/js.gradle
+++ b/buildSrc/src/main/groovy/js/js.gradle
@@ -1,4 +1,3 @@
-package js
 /*
  * Copyright 2021, TeamDev. All rights reserved.
  *

--- a/buildSrc/src/main/groovy/js/npm-cli.gradle
+++ b/buildSrc/src/main/groovy/js/npm-cli.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package js
 
 import org.apache.tools.ant.taskdefs.condition.Os
 

--- a/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package js
 
 /**
  * The script declares tasks for publishing to NPM.

--- a/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
@@ -32,7 +32,7 @@
  * the NPM execution process, which is sufficient for the local development.
  */
 
-apply from: deps.scripts.jsBuildTasks
+apply "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/build-tasks.gradle"
 
 ext {
     publicationDirectory = "$buildDir/npm-publication/"

--- a/buildSrc/src/main/groovy/js/update-package-version.gradle
+++ b/buildSrc/src/main/groovy/js/update-package-version.gradle
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package js
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleApis.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleApis.kt
@@ -26,17 +26,33 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
-object Jackson {
-    private const val version = "2.12.4"
-    // https://github.com/FasterXML/jackson-core
-    const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
-    // https://github.com/FasterXML/jackson-databind
-    const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
-    // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
-    // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
-    // https://github.com/FasterXML/jackson-module-kotlin/releases
-    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
+/**
+ * Provides dependencies on [GoogleApis projects](https://github.com/googleapis/).
+ */
+object GoogleApis {
+
+    // https://github.com/googleapis/google-api-java-client
+    const val client = "com.google.api-client:google-api-client:1.32.1"
+
+    // https://github.com/googleapis/api-common-java
+    const val common = "com.google.api:api-common:2.0.2"
+
+    // https://github.com/googleapis/java-common-protos
+    const val commonProtos = "com.google.api.grpc:proto-google-common-protos:2.5.1"
+
+    // https://github.com/googleapis/gax-java
+    const val gax = "com.google.api:gax:2.5.0"
+
+    // https://github.com/googleapis/java-iam
+    const val protoAim = "com.google.api.grpc:proto-google-iam-v1:1.1.3"
+
+    // https://github.com/googleapis/google-oauth-java-client
+    const val oAuthClient = "com.google.oauth-client:google-oauth-client:1.32.1"
+
+    // https://github.com/googleapis/google-auth-library-java
+    object AuthLibrary {
+        const val version = "1.1.0"
+        const val credentials = "com.google.auth:google-auth-library-credentials:${version}"
+        const val oAuth2Http = "com.google.auth:google-auth-library-oauth2-http:${version}"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
@@ -27,16 +27,17 @@
 package io.spine.internal.dependency
 
 @Suppress("unused")
-object Jackson {
-    private const val version = "2.12.4"
-    // https://github.com/FasterXML/jackson-core
-    const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
-    // https://github.com/FasterXML/jackson-databind
-    const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
-    // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
-    // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
-    // https://github.com/FasterXML/jackson-module-kotlin/releases
-    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
+object GoogleCloud {
+
+    // https://github.com/googleapis/java-core
+    const val core = "com.google.cloud:google-cloud-core:2.1.7"
+
+    // https://github.com/googleapis/java-pubsub
+    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.95.1"
+
+    // https://github.com/googleapis/java-trace
+    const val trace = "com.google.cloud:google-cloud-trace:1.4.1"
+
+    // https://github.com/googleapis/java-datastore
+    const val datastore = "com.google.cloud:google-cloud-datastore:1.106.5"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -27,9 +27,15 @@
 package io.spine.internal.dependency
 
 /**
- * Google implementations of HTTP client.
+ * Google implementations of [HTTP client](https://github.com/googleapis/google-http-java-client).
  */
+@Suppress("unused")
 object HttpClient {
-    const val google = "com.google.http-client:google-http-client:1.39.1"
-    const val apache = "com.google.http-client:google-http-client-apache:2.1.2"
+    // https://github.com/googleapis/google-http-java-client
+    const val version  = "1.40.0"
+    const val google   = "com.google.http-client:google-http-client:${version}"
+    const val jackson2 = "com.google.http-client:google-http-client-jackson2:${version}"
+    const val gson     = "com.google.http-client:google-http-client-gson:${version}"
+
+    const val apache   = "com.google.http-client:google-http-client-apache:2.1.2"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -27,12 +27,11 @@
 package io.spine.internal.dependency
 
 /**
- * J2ObjC is a transitive dependency which we don't use directly.
- * We `force` it in [DependencyResolution.forceConfiguration()].
- *
- * [J2ObjC](https://developers.google.com/j2objc)
+ * [J2ObjC](https://developers.google.com/j2objc) is a transitive dependency
+ * which we don't use directly. This object is used for forcing the version.
  */
 object J2ObjC {
+    // https://github.com/google/j2objc/releases
     private const val version = "1.3"
     const val lib = "com.google.j2objc:j2objc-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
@@ -26,8 +26,11 @@
 
 package io.spine.internal.dependency
 
-// This artifact which used to be a part of J2EE moved under Eclipse EE4J project.
-// https://github.com/eclipse-ee4j/common-annotations-api
+@Suppress("unused")
 object JavaX {
+    // This artifact which used to be a part of J2EE moved under Eclipse EE4J project.
+    // https://github.com/eclipse-ee4j/common-annotations-api
     const val annotations = "javax.annotation:javax.annotation-api:1.3.2"
+
+    const val servletApi = "javax.servlet:javax.servlet-api:3.1.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
@@ -27,16 +27,12 @@
 package io.spine.internal.dependency
 
 @Suppress("unused")
-object Jackson {
-    private const val version = "2.12.4"
-    // https://github.com/FasterXML/jackson-core
-    const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
-    // https://github.com/FasterXML/jackson-databind
-    const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
-    // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
-    // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
-    // https://github.com/FasterXML/jackson-module-kotlin/releases
-    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
+object Netty {
+    // https://github.com/netty/netty/releases
+    private const val version = "4.1.68.Final"
+    const val common = "io.netty:netty-common:${version}"
+    const val buffer = "io.netty:netty-buffer:${version}"
+    const val transport = "io.netty:netty-transport:${version}"
+    const val handler = "io.netty:netty-handler:${version}"
+    const val codecHttp = "io.netty:netty-codec-http:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
@@ -26,17 +26,10 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
-object Jackson {
-    private const val version = "2.12.4"
-    // https://github.com/FasterXML/jackson-core
-    const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
-    // https://github.com/FasterXML/jackson-databind
-    const val databind = "com.fasterxml.jackson.core:jackson-databind:${version}"
-    // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
-    // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
-    // https://github.com/FasterXML/jackson-module-kotlin/releases
-    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
+object OsDetector {
+    // https://github.com/google/osdetector-gradle-plugin
+    const val version = "1.7.0"
+    const val id = "com.google.osdetector"
+    const val lib = "com.google.gradle:osdetector-gradle-plugin:${version}"
+    const val classpath = lib
 }


### PR DESCRIPTION
This PR adds and improves dependency objects that are used in `web` and `gcloud` sub-projects.

Also, import statements in `js/*.gradle` scripts were inlined to remove the references to the `deps` property.
