### PR TITLE
Fix script plugin paths in `js`

### DIFF
--- a/buildSrc/src/main/groovy/js/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/build-tasks.gradle
@@ -46,8 +46,8 @@ ext {
 }
 
 apply plugin: 'base'
-apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "/js/npm-cli.gradle"
-apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "/js/update-package-version.gradle"
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/npm-cli.gradle"
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/update-package-version.gradle"
 
 /**
  * Compiles Protobuf sources into JavaScript.

--- a/buildSrc/src/main/groovy/js/js.gradle
+++ b/buildSrc/src/main/groovy/js/js.gradle
@@ -49,7 +49,7 @@ ext {
     nycOutputDir = "$projectDir/.nyc_output"
 }
 
-apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "/js/npm-publish-tasks.gradle"
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/npm-publish-tasks.gradle"
 
 /**
  * Cleans old module dependencies and build outputs.

--- a/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/js/npm-publish-tasks.gradle
@@ -32,7 +32,7 @@
  * the NPM execution process, which is sufficient for the local development.
  */
 
-apply "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/build-tasks.gradle"
+apply from: "$rootDir" + io.spine.internal.gradle.Scripts.commonPath + "js/build-tasks.gradle"
 
 ext {
     publicationDirectory = "$buildDir/npm-publication/"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
@@ -27,12 +27,11 @@
 package io.spine.internal.dependency
 
 /**
- * Commons Logging is a transitive dependency which we don't use directly.
- * We `force` it in [DependencyResolution.forceConfiguration].
- *
- * [Commons Logging](https://commons.apache.org/proper/commons-logging/)
+ * [Commons Logging](https://commons.apache.org/proper/commons-logging/) is a transitive
+ * dependency which we don't use directly. This object is used for forcing the version.
  */
 object CommonsLogging {
+    // https://commons.apache.org/proper/commons-logging/
     private const val version = "1.2"
     const val lib = "commons-logging:commons-logging:${version}"
 }


### PR DESCRIPTION
This PR fixes paths used in the `gradle/js` folder.

Also, documentation for `CommonsLogging` dependency object was improved.