### PR TITLE
Remove redundant plugin dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,20 +25,16 @@
  */
 
 /**
- * This script uses three declarations of the constant [licenseReportVersion] because
+ * This script uses two declarations of the constant [licenseReportVersion] because
  * currently there is no way to define a constant _before_ a build script of `buildSrc`.
  * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
  *
  * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
- * changed in the Kotlin object _and_ in this file below thrice.
+ * changed in the Kotlin object _and_ in this file below twice.
  */
 buildscript {
     repositories {
         gradlePluginPortal()
-    }
-    val licenseReportVersion = "1.16"
-    dependencies {
-        classpath("com.github.jk1:gradle-license-report:${licenseReportVersion}")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,11 +32,6 @@
  * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
  * changed in the Kotlin object _and_ in this file below twice.
  */
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-}
 
 plugins {
     java


### PR DESCRIPTION
For some reason, we declared the license report plugin twice: in `buildscript { }` and in `plugins { }`.
Now we only do that in `plugins { }`.