### PR TITLE
Set `NPM_TOKEN` value

### DIFF
--- a/.github-workflows/publish.yml
+++ b/.github-workflows/publish.yml
@@ -50,3 +50,4 @@ jobs:
           # https://docs.github.com/en/actions/reference/environment-variables
           REPO_SLUG: $GITHUB_REPOSITORY    # e.g. SpineEventEngine/core-java
           GOOGLE_APPLICATION_CREDENTIALS: ./maven-publisher.json
+          NPM_TOKEN: ${{ secrets.NPM_SECRET }}


### PR DESCRIPTION
This PR uses the GitHub `NPM_SECRET` value in the publishing workflow under `NPM_TOKEN` environment variable.

In particular, this is required in order to publish the JS artifacts from `web` repo.