### PR TITLE
Fix Javadoc filtering and `jacoco` forceful evaluation of child projects

### DIFF
--- a/buildSrc/src/main/groovy/jacoco.gradle
+++ b/buildSrc/src/main/groovy/jacoco.gradle
@@ -43,10 +43,6 @@ repositories {
 // Adds the `:check` task.
 apply plugin: 'base'
 
-// Evaluate this script only after all sub-projects were evaluated.
-// Only after that it is possible to say which of the sub-projects are Java projects.
-evaluationDependsOnChildren()
-
 final def javaProjects = subprojects.findAll { it.pluginManager.hasPlugin('jacoco') }
 final def jacocoReports = file("${rootProject.buildDir}/subreports/jacoco/")
 
@@ -77,9 +73,9 @@ task jacocoRootReport(dependsOn: ':copyReports', type: JacocoReport) {
     additionalClassDirs.from nonGeneratedFiles
 
     reports {
-        html.enabled = true
-        xml.enabled = true
-        csv.enabled = false
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
     }
     onlyIf = {
         true

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/UpdateGitHubPages.kt
@@ -130,14 +130,14 @@ class UpdateGitHubPages : Plugin<Project> {
     }
 
     private fun Project.registerTasks(extension: UpdateGitHubPagesExtension) {
-        val includeInternal = extension.allowInternalJavadoc()
+        val allowInternalJavadoc = extension.allowInternalJavadoc()
         rootFolder = extension.rootFolder()
         includedInputs = extension.includedInputs()
-        if (!includeInternal) {
+        if (!allowInternalJavadoc) {
             val doclet = ExcludeInternalDoclet(extension.excludeInternalDocletVersion)
             doclet.registerTaskIn(this)
         }
-        tasks.registerCopyJavadoc(includeInternal)
+        tasks.registerCopyJavadoc(allowInternalJavadoc)
         val updatePagesTask = tasks.registerUpdateTask()
         updatePagesTask.configure {
             dependsOn(copyJavadoc)
@@ -157,9 +157,9 @@ class UpdateGitHubPages : Plugin<Project> {
     private fun TaskContainer.composeInputs(allowInternalJavadoc: Boolean): MutableList<Any> {
         val inputs = mutableListOf<Any>()
         if (allowInternalJavadoc) {
-            inputs.add(javadocTask(ExcludeInternalDoclet.taskName))
-        } else {
             inputs.add(javadocTask())
+        } else {
+            inputs.add(javadocTask(ExcludeInternalDoclet.taskName))
         }
         inputs.addAll(includedInputs)
         return inputs
@@ -200,4 +200,3 @@ private fun Project.registerNoOpTask() {
         }
     }
 }
-


### PR DESCRIPTION
This PR:
  * Fixes `UpdateGitHubPages` so that it does not use `ExcludeInternalDoclet` when no Javadoc filtering of `@Internal` API is needed.
  * Removes `evaluationDependsOnChildren()` on children call in `jacoco.gradle` script because it conflicts with Maven publishing. See [this discussion](https://discuss.gradle.org/t/gradle-7-fails-with-cannot-run-project-afterevaluate-action-when-the-project-is-already-evaluated/40296) for details.
