### PR TITLE
Use Maven artifact ID for version files

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -27,7 +27,6 @@
       <option name="ignoreTransformationOfOriginalParameter" value="false" />
     </inspection_tool>
     <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BadExceptionCaught" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="exceptionsString" value="" />
       <option name="exceptions">
@@ -146,7 +145,6 @@
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConditionalExpressionWithIdenticalBranches" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="false" />
     </inspection_tool>
@@ -185,17 +183,10 @@
     <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DisjointPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="DoubleCheckedLocking" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreOnVolatileVariables" value="false" />
-    </inspection_tool>
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DuplicatePropertyInspection" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="CURRENT_FILE" value="true" />
-      <option name="MODULE_WITH_DEPENDENCIES" value="false" />
       <option name="CHECK_DUPLICATE_VALUES" value="false" />
-      <option name="CHECK_DUPLICATE_KEYS" value="true" />
-      <option name="CHECK_DUPLICATE_KEYS_WITH_DIFFERENT_VALUES" value="true" />
     </inspection_tool>
     <inspection_tool class="DuplicateStringLiteralInspection" enabled="true" level="TYPO" enabled_by_default="true">
       <scope name="Production" level="WARNING" enabled="true">
@@ -217,7 +208,6 @@
       <option name="commentsAreContent" value="true" />
     </inspection_tool>
     <inspection_tool class="EmptyDirectory" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="EmptySynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="TYPO" enabled="true">
         <option name="ignoreSwitchStatementsWithDefault" value="false" />
@@ -254,7 +244,6 @@
       <option name="m_limit" value="20" />
     </inspection_tool>
     <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FinalizeNotProtected" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FloatingPointEquality" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ForLoopReplaceableByWhile" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreLoopsWithoutConditions" value="false" />
@@ -480,6 +469,13 @@
     </inspection_tool>
     <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true">
+        <extension name="InstanceMethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+          <option name="m_maxLength" value="32" />
+        </extension>
+      </scope>
       <scope name="Tests" level="INFO" enabled="true">
         <extension name="InstanceMethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
@@ -490,13 +486,6 @@
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
           <option name="m_maxLength" value="64" />
-        </extension>
-      </scope>
-      <scope name="Production" level="WARNING" enabled="true">
-        <extension name="InstanceMethodNamingConvention" enabled="true">
-          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-          <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="32" />
         </extension>
       </scope>
       <extension name="InstanceMethodNamingConvention" enabled="true">
@@ -614,7 +603,6 @@
     </inspection_tool>
     <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ProtectedField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ProtectedMemberInFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PublicConstructorInNonPublicClass" enabled="true" level="INFO" enabled_by_default="true" />
     <inspection_tool class="PublicField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreEnums" value="false" />
@@ -659,10 +647,7 @@
     <inspection_tool class="SameParameterValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreAnonymousInnerClasses" value="false" />
-      <option name="superClassString" value="" />
-    </inspection_tool>
+    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
       <option name="superClassString" value="" />
@@ -719,7 +704,6 @@
     <inspection_tool class="SystemGetenv" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SystemOutErr" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SystemProperties" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SystemRunFinalizersOnExit" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SystemSetSecurityManager" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TailRecursion" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="TYPO" enabled_by_default="true" />
@@ -765,13 +749,13 @@
     <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
-      <scope name="Tests" level="INFO" enabled="true">
+      <scope name="Problems" level="INFO" enabled="true">
         <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
         <option name="useParameterizedTypeForCollectionMethods" value="true" />
         <option name="doNotWeakenToJavaLangObject" value="true" />
         <option name="onlyWeakentoInterface" value="true" />
       </scope>
-      <scope name="Problems" level="INFO" enabled="true">
+      <scope name="Tests" level="INFO" enabled="true">
         <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
         <option name="useParameterizedTypeForCollectionMethods" value="true" />
         <option name="doNotWeakenToJavaLangObject" value="true" />
@@ -782,7 +766,6 @@
       <option name="doNotWeakenToJavaLangObject" value="true" />
       <option name="onlyWeakentoInterface" value="true" />
     </inspection_tool>
-    <inspection_tool class="UnaryPlus" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnconditionalWait" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarilyQualifiedInnerClassAccess" enabled="true" level="INFO" enabled_by_default="true">
       <option name="ignoreReferencesNeedingImport" value="true" />
@@ -808,7 +791,7 @@
     </inspection_tool>
     <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarySuperQualifier" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UnnecessaryUnaryMinus" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryVariable" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />
@@ -820,6 +803,9 @@
     <inspection_tool class="UnusedReturnValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UseOfAWTPeerClass" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UseOfConcreteClass" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreAbstractClasses" value="true" />
+    </inspection_tool>
     <inspection_tool class="UseOfJDBCDriverClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UseOfProcessBuilder" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UseOfPropertiesAsHashtable" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -846,7 +832,6 @@
     <inspection_tool class="WaitNotInLoop" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WaitNotInSynchronizedContext" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WaitOrAwaitWithoutTimeout" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="WaitWhileHoldingTwoLocks" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WaitWithoutCorrespondingNotify" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WeakerAccess" enabled="true" level="INFO" enabled_by_default="true">
       <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/ProjectExtensions.kt
@@ -26,9 +26,8 @@
 
 package io.spine.internal.gradle
 
-import org.gradle.api.Plugin
+import io.spine.internal.gradle.publish.PublishExtension
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.getByType
@@ -50,22 +49,16 @@ val Project.sourceSets: SourceSetContainer
     get() = javaPluginExtension.sourceSets
 
 /**
- * Applies the specified Gradle plugin to this project by the plugin [class][cls].
- */
-fun Project.applyPlugin(cls: Class<out Plugin<*>>) {
-    this.apply {
-        plugin(cls)
-    }
-}
-
-/**
- * Finds the task of type `T` in this project by the task name.
+ * Obtains the Maven artifact ID of the project taking into account
+ * the value of the [PublishExtension.spinePrefix] property.
  *
- * The task must be present. Also, a caller is responsible for using the proper value of
- * the generic parameter `T`.
+ * If the project has a [PublishExtension] installed, then the extension is used for
+ * [obtaining][PublishExtension.artifactId] the artifact ID.
+ *
+ * Otherwise, the project name is returned.
  */
-@Suppress("UNCHECKED_CAST")     /* See the method docs. */
-fun <T : Task> Project.findTask(name: String): T {
-    val task = this.tasks.findByName(name)
-    return task!! as T
-}
+val Project.artifactId: String
+    get() {
+        val publishExtension = rootProject.extensions.findByType(PublishExtension::class.java)
+        return publishExtension?.artifactId(this) ?: name
+    }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -82,7 +82,7 @@ abstract class WriteVersions : DefaultTask() {
      */
     fun includeOwnVersion() {
         val groupId = project.group.toString()
-        val artifactId = artifactId()
+        val artifactId = project.artifactId
         val version = project.version.toString()
         versions.put("${groupId}_${artifactId}", version)
     }
@@ -119,11 +119,9 @@ abstract class WriteVersions : DefaultTask() {
     }
 
     private fun resourceFileName(): String {
-        val artifactId = artifactId()
+        val artifactId = project.artifactId
         return "versions-${artifactId}.properties"
     }
-
-    private fun artifactId() = PublishExtension.artifactIdIn(project)
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -82,9 +82,9 @@ abstract class WriteVersions : DefaultTask() {
      */
     fun includeOwnVersion() {
         val groupId = project.group.toString()
-        val name = project.name
+        val artifactId = artifactId()
         val version = project.version.toString()
-        versions.put("${groupId}_${name}", version)
+        versions.put("${groupId}_${artifactId}", version)
     }
 
     /**
@@ -119,9 +119,11 @@ abstract class WriteVersions : DefaultTask() {
     }
 
     private fun resourceFileName(): String {
-        val artifactId = PublishExtension.artifactIdIn(project)
-        return "versions-$artifactId.properties"
+        val artifactId = artifactId()
+        return "versions-${artifactId}.properties"
     }
+
+    private fun artifactId() = PublishExtension.artifactIdIn(project)
 }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publish.kt
@@ -29,9 +29,6 @@ package io.spine.internal.gradle.publish
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.PublishArtifact
-import org.gradle.api.artifacts.PublishArtifactSet
-import org.gradle.api.publish.PublishingExtension
 
 /**
  * This plugin allows publishing artifacts to remote Maven repositories.
@@ -71,10 +68,10 @@ import org.gradle.api.publish.PublishingExtension
  * ```
  *
  * By default, we publish artifacts produced by tasks `sourceJar`, `testOutputJar`,
- * and `javadocJar`, along with the default project compilation output. If any of these tasks is not
- * declared, it's created with sensible default settings by the plugin.
+ * and `javadocJar`, along with the default project compilation output.
+ * If any of these tasks is not declared, it's created with sensible default settings by the plugin.
  *
- * To publish more artifacts for a certain project, add them to the archives configuration:
+ * To publish more artifacts for a certain project, add them to the `archives` configuration:
  * ```
  * artifacts {
  *     archives(myCustomJarTask)
@@ -88,12 +85,10 @@ class Publish : Plugin<Project> {
 
     companion object {
         const val taskName = "publish"
-        const val extensionName = "spinePublishing"
     }
 
     override fun apply(project: Project) {
-        val extension = PublishExtension.create(project)
-        project.extensions.add(PublishExtension::class.java, extensionName, extension)
+        val extension = PublishExtension.createIn(project)
 
         project.afterEvaluate {
             val soloMode = extension.singleProject()

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
@@ -64,22 +64,6 @@ private constructor(
             project.extensions.add(PublishExtension::class.java, name, extension)
             return extension
         }
-
-        /**
-         * Obtains an artifact ID of the given project.
-         *
-         * If the project has a [PublishExtension] installed, then it is used for
-         * [obtaining][PublishExtension.artifactId] the artifact ID.
-         * Otherwise, the project name is returned.
-         *
-         * @see artifactId
-         */
-        fun artifactIdIn(project: Project): String {
-            val rootProject = project.rootProject
-            val publishExtension = rootProject.extensions.findByType(PublishExtension::class.java)
-            val result = publishExtension?.artifactId(project) ?: project.name
-            return result
-        }
     }
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
@@ -75,7 +75,8 @@ private constructor(
          * @see artifactId
          */
         fun artifactIdIn(project: Project): String {
-            val publishExtension = project.extensions.findByType(PublishExtension::class.java)
+            val rootProject = project.rootProject
+            val publishExtension = rootProject.extensions.findByType(PublishExtension::class.java)
             val result = publishExtension?.artifactId(project) ?: project.name
             return result
         }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingExtensions.kt
@@ -42,11 +42,7 @@ internal fun PublishingExtension.createMavenPublication(
     project: Project,
     extension: PublishExtension
 ) {
-    val artifactIdForPublishing = if (extension.spinePrefix.get()) {
-        "spine-${project.name}"
-    } else {
-        project.name
-    }
+    val artifactIdForPublishing = extension.artifactId(project)
     publications {
         create("mavenJava", MavenPublication::class.java) {
             groupId = project.group.toString()
@@ -123,4 +119,3 @@ private fun MavenArtifactRepository.initialize(
         password = creds?.password
     }
 }
-


### PR DESCRIPTION
This PR standardizes the way we treat module names when writing `versions-*.properties` files. Previously, these files were composed using module names of a Gradle project. 

In most of the sub-projects, we also add `spine-` prefix when publishing to Maven (using `spinePublishing/spinePrefix` property). Not taking in account the prefix resulted in the confusion:
  * When adding dependencies in a project, we need to take the prefix into account.
  * But whey they are loaded from the code (when reading `.properties`) we had to “remember” somehow if the artifact had the `spine-` prefix or not.

After this PR, we always Maven artifact ID.
