### PR TITLE
Restore lost `Project` extensions

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/ProjectExtensions.kt
@@ -85,5 +85,3 @@ val Project.artifactId: String
         val publishExtension = rootProject.extensions.findByType(PublishExtension::class.java)
         return publishExtension?.artifactId(this) ?: name
     }
-
-


### PR DESCRIPTION
This PR restores the project extensions introduced in #280 and removed by accident in #282. 