### PR TITLE
Migrate `javac-args.gradle` to Kotlin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -64,9 +64,8 @@ val guavaVersion = "30.1.1-jre"
 /**
  * The version of ErrorProne Gradle plugin.
  *
- * Always use the same version as the one specified in `io.spine.internal.dependency.ErrorProne`.
- * Otherwise, when testing Gradle plugins, clashes may occur. Thus, when applying the plugin
- * in build files, no version should be specified, only the plugin's ID.
+ * @see <a href="https://github.com/tbroyer/gradle-errorprone-plugin/releases">
+ *     Error Prone Gradle Plugin Releases</a>
  */
 val errorProneVersion = "2.0.2"
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -61,6 +61,15 @@ val grGitVersion = "3.1.1"
  */
 val guavaVersion = "30.1.1-jre"
 
+/**
+ * The version of ErrorProne Gradle plugin.
+ *
+ * Always use the same version as the one specified in `io.spine.internal.dependency.ErrorProne`.
+ * Otherwise, when testing Gradle plugins, clashes may occur. Thus, when applying the plugin
+ * in build files, no version should be specified, only the plugin's ID.
+ */
+val errorProneVersion = "2.0.2"
+
 dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
     implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
@@ -68,5 +77,5 @@ dependencies {
     }
     implementation("com.google.guava:guava:$guavaVersion")
     api("com.github.jk1:gradle-license-report:$licenseReportVersion")
-    implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")
+    implementation("net.ltgt.gradle:gradle-errorprone-plugin:${errorProneVersion}")
 }

--- a/buildSrc/src/main/groovy/javac-args.gradle
+++ b/buildSrc/src/main/groovy/javac-args.gradle
@@ -28,6 +28,9 @@
  * This script configures Java Compiler.
  */
 
+println("`javac-args.gradle` script is deprecated. Please use `JavaCompile.configureJavac()` " +
+        "and `JavaCompile.configureErrorProne()` utilities instead.")
+
 tasks.withType(JavaCompile) {
 
     if (JavaVersion.current() != JavaVersion.VERSION_1_8) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -45,7 +45,7 @@ object ErrorProne {
 
     /**
      * The version of this plugin is already specified in `build.gradle.kts` file.
-     * Thus, when applying the plugin in projects build files, only id should be specified.
+     * Thus, when applying the plugin in projects build files, only id should be used.
      */
     object GradlePlugin {
         const val id = "net.ltgt.errorprone"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -44,7 +44,7 @@ object ErrorProne {
     const val javacPlugin  = "com.google.errorprone:javac:${javacPluginVersion}"
 
     /**
-     * The version of this plugin is already specified in `build.gradle.kts` file.
+     * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
      * Thus, when applying the plugin in projects build files, only id should be used.
      */
     object GradlePlugin {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -43,10 +43,11 @@ object ErrorProne {
     const val testHelpers = "com.google.errorprone:error_prone_test_helpers:${version}"
     const val javacPlugin  = "com.google.errorprone:javac:${javacPluginVersion}"
 
-    // https://github.com/tbroyer/gradle-errorprone-plugin/releases
+    /**
+     * The version of this plugin is already specified in `build.gradle.kts` file.
+     * Thus, when applying the plugin in projects build files, only id should be specified.
+     */
     object GradlePlugin {
         const val id = "net.ltgt.errorprone"
-        const val version = "2.0.2"
-        const val lib = "net.ltgt.gradle:gradle-errorprone-plugin:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
@@ -31,12 +31,13 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.process.CommandLineArgumentProvider
 
 /**
- * Sets up `Error Prone` by applying [ErrorProneConfig].
+ * Configures Error Prone for this `JavaCompile` task.
  *
- * Which means specifying arguments for the `Error Prone` compiler invocations.
+ * Specifies the arguments for the compiler invocations. In particular, this configuration
+ * overrides a number of Error Prone defaults. See [ErrorProneConfig] for the details.
  *
- * Although `Error Prone` is linked as a dedicated `Gradle` plugin, its configuration is actually
- * performed through the [JavaCompile] task.
+ * Please note that while `ErrorProne` is a standalone Gradle plugin,
+ * it still has to be configured through `JavaCompile` task options.
  *
  * Here's an example of how to use it:
  *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.javac
+
+import net.ltgt.gradle.errorprone.errorprone
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.process.CommandLineArgumentProvider
+
+/**
+ * Sets up `Error Prone` by applying [ErrorProneConfig].
+ *
+ * Which means specifying arguments for the `Error Prone` compiler invocations.
+ *
+ * Although `Error Prone` is linked as a dedicated `Gradle` plugin, its configuration is actually
+ * performed through the [JavaCompile] task.
+ *
+ * Here's an example of how to use it:
+ *
+ * ```
+ * tasks {
+ *     withType<JavaCompile> {
+ *         configureErrorProne()
+ *     }
+ * }
+ *```
+ */
+fun JavaCompile.configureErrorProne() {
+    options.errorprone
+        .errorproneArgumentProviders
+        .add(ErrorProneConfig.ARGUMENTS)
+}
+
+/**
+ * The knowledge that is required to set up `Error Prone`.
+ */
+private object ErrorProneConfig {
+
+    /**
+     * Command line options for the `Error Prone` compiler.
+     */
+    val ARGUMENTS = CommandLineArgumentProvider {
+        listOf(
+
+            // Exclude generated sources from being analyzed by ErrorProne.
+            "-XepExcludedPaths:.*/generated/.*",
+
+            // Turn the check off until ErrorProne can handle `@Nested` JUnit classes.
+            // See issue: https://github.com/google/error-prone/issues/956
+            "-Xep:ClassCanBeStatic:OFF",
+
+            // Turn off checks that report unused methods and method parameters.
+            // See issue: https://github.com/SpineEventEngine/config/issues/61
+            "-Xep:UnusedMethod:OFF",
+            "-Xep:UnusedVariable:OFF",
+
+            "-Xep:CheckReturnValue:OFF",
+            "-Xep:FloggerSplitLogStatement:OFF",
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.javac
+
+import org.gradle.api.GradleException
+import org.gradle.api.JavaVersion
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.process.CommandLineArgumentProvider
+
+/**
+ * Sets up `javac` by applying [JavacConfig].
+ *
+ * Which means:
+ *
+ *  1. Ensuring JDK 8 would be used for compilation;
+ *  2. Specifying arguments for `javac` invocations;
+ *  3. Specifying the `UTF-8` encoding to be used when reading source files.
+ *
+ *
+ * Supporting other JDKs
+ *
+ * `Spine Event Engine` can be built with JDK 8 only. Supporting JDK 11 and above
+ * at build-time is planned in 2.0 release.
+ *
+ *
+ * Here's an example of how to use it:
+ *
+ *```
+ * tasks {
+ *     withType<JavaCompile> {
+ *         configureJavac()
+ *     }
+ * }
+ *```
+ */
+fun JavaCompile.configureJavac() {
+
+    if (JavaVersion.current() != JavacConfig.EXPECTED_JAVA_VERSION) {
+        throw GradleException("Spine Event Engine can be built with JDK 8 only." +
+                " Supporting JDK 11 and above at build-time is planned in 2.0 release." +
+                " Please use the pre-built binaries available in the Spine Maven repository." +
+                " See https://github.com/SpineEventEngine/base/issues/457."
+        )
+    }
+
+    with(options) {
+        encoding = JavacConfig.SOURCE_FILES_ENCODING
+        compilerArgumentProviders.add(JavacConfig.ARGUMENTS)
+    }
+}
+
+/**
+ * The knowledge that is required to set up `javac`.
+ */
+private object JavacConfig {
+    const val SOURCE_FILES_ENCODING = "UTF-8"
+    val EXPECTED_JAVA_VERSION = JavaVersion.VERSION_1_8
+    val ARGUMENTS = CommandLineArgumentProvider {
+        listOf(
+
+            // Protobuf Compiler generates the code, which uses the deprecated `PARSER` field.
+            // See issue: https://github.com/SpineEventEngine/config/issues/173
+            // "-Werror",
+
+            "-Xlint:unchecked",
+            "-Xlint:deprecation",
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -32,20 +32,16 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.process.CommandLineArgumentProvider
 
 /**
- * Sets up `javac` by applying [JavacConfig].
+ * Configures the `javac` tool through this `JavaCompile` task.
  *
- * Which means:
+ * There are several steps performed:
  *
- *  1. Ensuring JDK 8 would be used for compilation;
- *  2. Specifying arguments for `javac` invocations;
- *  3. Specifying the `UTF-8` encoding to be used when reading source files.
+ *  1. Ensures JDK 8 is used for compilation;
+ *  2. Passes a couple of arguments to the compiler. See [JavacConfig] for more details;
+ *  3. Sets the UTF-8 encoding to be used when reading Java source files.
  *
- *
- * Supporting other JDKs
- *
- * `Spine Event Engine` can be built with JDK 8 only. Supporting JDK 11 and above
- * at build-time is planned in 2.0 release.
- *
+ * Please note that Spine Event Engine can be built with JDK 8 only.
+ * Supporting JDK 11 and above at build-time is planned in 2.0 release.
  *
  * Here's an example of how to use it:
  *


### PR DESCRIPTION
This changeset migrates `javac-args.gradle`  to Kotlin.

The original script was split into two: 

1. `Javac.kt` - configures java compilation aspects;
2. `ErrorProne.kt` - configures ErrorProne.

```
// old API

with(Scripts) {
    from(javacArgs(project))
}


// new API

tasks {
    withType<JavaCompile> {
        configureErrorProne()
        configureJavac()
    }
}
```

`ErrorProne Gradle Plugin` was added on a buildSrc classpath to have `ErrorProne.kt` typed. Thus, it'd be on a classpath of each build file and no version should be specified in `plugins.apply` block. Old scripts that specify version would fail.

```
// old API

io.spine.internal.dependency.ErrorProne.GradlePlugin.apply {
    id(id) version version
}


// new API

io.spine.internal.dependency.ErrorProne.GradlePlugin.apply {
    id(id)
}
```

 