### PR TITLE
Migrate `slow-tests.gradle` and `test-output.gradle` to Kotlin

### DIFF
--- a/buildSrc/src/main/groovy/slow-tests.gradle
+++ b/buildSrc/src/main/groovy/slow-tests.gradle
@@ -24,6 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+println("`slow-tests.gradle` script is deprecated. " +
+        "Please use `TestContainer.registerTestTasks()` instead.")
+
 final def slowTag = 'slow' // See io.spine.testing.SlowTest
 
 task fastTest(type: Test) {

--- a/buildSrc/src/main/groovy/test-output.gradle
+++ b/buildSrc/src/main/groovy/test-output.gradle
@@ -33,6 +33,8 @@
  *    of tests and their results.
  */
 
+println("`test-output.gradle` script is deprecated. Please use `Test.configureLogging()` instead.")
+
 tasks.withType(Test).each {
     it.testLogging {
         showStandardStreams = true

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/test/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/test/Logging.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.test
+
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestResult
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.kotlin.dsl.KotlinClosure2
+
+/**
+ * Configures logging of this [Test] task.
+ *
+ * Enables logging of:
+ *  1. Standard `out` and `err` streams;
+ *  2. Thrown exceptions.
+ *
+ *  Additionally, after all the tests are executed, a short summary would be logged. The summary
+ *  consists of the number of tests and their results.
+ *
+ * Usage example:
+ *
+ *```
+ * tasks {
+ *     withType<Test> {
+ *         configureLogging()
+ *     }
+ * }
+ *```
+ */
+fun Test.configureLogging() {
+    testLogging {
+        showStandardStreams = true
+        showExceptions = true
+        exceptionFormat = TestExceptionFormat.FULL
+        showStackTraces = true
+        showCauses = true
+    }
+
+    fun TestResult.summary(): String =
+        """
+        Test summary:
+        >> $testCount tests
+        >> $successfulTestCount succeeded
+        >> $failedTestCount failed
+        >> $skippedTestCount skipped
+        """
+
+    afterSuite(
+
+        // `GroovyInteroperability` is employed as `afterSuite()` has no equivalent in Kotlin DSL.
+        // See issue: https://github.com/gradle/gradle/issues/5431
+
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
+
+            // If the descriptor has no parent, then it is the root test suite,
+            // i.e. it includes the info about all the run tests.
+
+            if (descriptor.parent == null) {
+                logger.lifecycle(result.summary())
+            }
+        })
+    )
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/test/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/test/Tasks.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.test
+
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Registers [slowTest][SlowTest] and [fastTest][FastTest] tasks in this [TaskContainer].
+ *
+ * Usage example:
+ *
+ * ```
+ * tasks {
+ *     registerTestTasks()
+ * }
+ * ```
+ */
+fun TaskContainer.registerTestTasks() {
+    register<FastTest>("fastTest").let {
+        register<SlowTest>("slowTest") {
+            shouldRunAfter(it)
+        }
+    }
+}
+
+/**
+ * Name of a tag for annotating a test class or method that is known to be slow and
+ * should not normally be run together with the main test suite.
+ *
+ * @see io.spine.testing.SlowTest
+ * @see org.junit.jupiter.api.Tag
+ */
+private const val SLOW_TAG = "slow"
+
+/**
+ * Executes JUnit tests filtering out the ones tagged as `slow`.
+ */
+private open class FastTest : Test() {
+    init {
+        description = "Executes all JUnit tests but the ones tagged as `slow`."
+        group = "Verification"
+
+        this.useJUnitPlatform {
+            excludeTags(SLOW_TAG)
+        }
+    }
+}
+
+/**
+ * Executes JUnit tests tagged as `slow`.
+ */
+private open class SlowTest : Test() {
+    init {
+        description = "Executes JUnit tests tagged as `slow`."
+        group = "Verification"
+
+        this.useJUnitPlatform {
+            includeTags(SLOW_TAG)
+        }
+    }
+}


### PR DESCRIPTION
This changeset migrates `slow-tests.gradle` and `test-output.gradle` to Kotlin.

`slow-tests.gradle` was migrated to `test/Tasks.kt`:
```
// old API

apply {
    with(Scripts) {
        from(slowTests(project))
    }
}


// new API

tasks {
    registerTestTasks()
}
```

`test-output.gradle` was migrated to `test/Logging.kt`:
```
// old API

apply {
    with(Scripts) {
        from(testOutput(project))
    }
}


// new API

tasks {
    withType<Test> {
        configureLogging()
     }
}
```