### PR TITLE
Avoid `u` option when copying files in `pull`

### DIFF
--- a/pull
+++ b/pull
@@ -51,16 +51,16 @@ echo "Pulling changes from remote repo"
 git pull
 
 echo "Updating IDEA configuration"
-cp -Ru .idea ..
+cp -R .idea ..
 
 echo "Updating Contributor's Guide"
-cp -u CONTRIBUTING.md ..
+cp CONTRIBUTING.md ..
 
 echo "Updating Contributor Covenant"
-cp -u CODE_OF_CONDUCT.md ..
+cp CODE_OF_CONDUCT.md ..
 
 echo "Updating Codecov settings"
-cp -u .codecov.yml ..
+cp .codecov.yml ..
 
 # Copies the file or directory passed as the first parameter to the upper directory,
 # only if such a file or directory does not exist there.

--- a/pull
+++ b/pull
@@ -81,12 +81,12 @@ cp -a .github/workflows/. ../.github/workflows
 cp -a .github-workflows/. ../.github/workflows
 
 echo "Updating Gradle 'buildSrc' scripts"
-cp -Ru buildSrc ..
+cp -R buildSrc ..
 
 echo "Updating Gradle Wrapper"
-cp -Ru ./gradle ..
-cp -u gradlew ..
-cp -u gradlew.bat ..
+cp -R ./gradle ..
+cp gradlew ..
+cp gradlew.bat ..
 
 cd ..
 


### PR DESCRIPTION
This PR removes earlier added `-u` option for `cp` because the option is not available under macOS.