### PR TITLE
Relax test names inspections and bump Jackson

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -467,6 +467,20 @@
     <inspection_tool class="NestingDepth" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="5" />
     </inspection_tool>
+    <inspection_tool class="NewClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
+      <extension name="ClassNamingConvention" enabled="true">
+        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
+        <option name="m_minLength" value="3" />
+        <option name="m_maxLength" value="64" />
+      </extension>
+      <extension name="InterfaceNamingConvention" enabled="true">
+        <option name="inheritDefaultSettings" value="false" />
+        <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
+        <option name="m_minLength" value="3" />
+        <option name="m_maxLength" value="64" />
+      </extension>
+      <extension name="JUnitTestClassNamingConvention" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Production" level="WARNING" enabled="true">

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -49,7 +49,7 @@ repositories {
 }
 
 /**
- * The version of Jackson used by `buildScr`.
+ * The version of Jackson used by `buildSrc`.
  *
  * Please keep this value in sync. with `io.spine.internal.dependency.Jackson.version`.
  * It's not a requirement, but would be good in terms of consistency.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,7 +48,14 @@ repositories {
     mavenCentral()
 }
 
-val jacksonVersion = "2.11.0"
+/**
+ * The version of Jackson used by `buildScr`.
+ *
+ * Please keep this value in sync. with `io.spine.internal.dependency.Jackson.version`.
+ * It's not a requirement, but would be good in terms of consistency.
+ */
+val jacksonVersion = "2.13.0"
+
 val googleAuthToolVersion = "2.1.2"
 val licenseReportVersion = "2.0"
 val grGitVersion = "3.1.1"
@@ -63,6 +70,8 @@ val guavaVersion = "30.1.1-jre"
 
 /**
  * The version of ErrorProne Gradle plugin.
+ *
+ * Please keep in sync. with `io.spine.internal.dependency.ErrorProne.GradlePlugin.version`.
  *
  * @see <a href="https://github.com/tbroyer/gradle-errorprone-plugin/releases">
  *     Error Prone Gradle Plugin Releases</a>

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.12.4"
+    private const val version = "2.13.0"
     // https://github.com/FasterXML/jackson-core
     const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
     // https://github.com/FasterXML/jackson-databind


### PR DESCRIPTION
This PR:
  * Relaxes IDEA inspection for test class names to NOT require the `Test` suffix.
  * Bumps Jackson -> 2.13.0.