### PR TITLE
Run Gradle in `no-daemon` mode

### DIFF
--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -20,4 +20,5 @@ jobs:
 
       - name: Build project and run tests
         shell: cmd
-        run: gradlew.bat build --stacktrace
+        # For the reason on `--no-daemon` see https://github.com/actions/cache/issues/454
+        run: gradlew.bat build --stacktrace --no-daemon


### PR DESCRIPTION
The post run for `setup-java@v2` under Windows fails with the following console output:
```
Post job cleanup.
C:\Windows\System32\tar.exe --posix -z -cf cache.tgz -P -C D:/a/tool-base/tool-base --files-from manifest.txt
tar.exe: Couldn't open C:/Users/runneradmin/.gradle/caches/modules-2/modules-2.lock: Permission denied
tar.exe: Error exit delayed from previous errors.
Warning: Failed to save Gradle cache on Windows. If tar.exe reported "Permission denied", try to run Gradle with `--no-daemon` option. Refer to https://github.com/actions/cache/issues/454 for details.
Warning: Error: Tar failed with error: The process 'C:\Windows\System32\tar.exe' failed with exit code 1
```

This PR instructs Gradle build to run with `--no-daemon` flag.

Please see https://github.com/actions/cache/issues/454 for details.