### PR TITLE
Checkstyle: set the `config` directory properly

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/checkstyle/CheckStyleConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/checkstyle/CheckStyleConfig.kt
@@ -57,9 +57,11 @@ object CheckStyleConfig {
             plugin(CheckstylePlugin::class.java)
         }
 
+        val configDir = project.rootDir.resolve("config/quality/")
+
         with(project.the<CheckstyleExtension>()) {
             toolVersion = CheckStyle.version
-            configFile = project.rootDir.resolve("config/quality/checkstyle.xml")
+            configDirectory.set(configDir)
         }
 
         project.afterEvaluate {

--- a/quality/checkstyle.xml
+++ b/quality/checkstyle.xml
@@ -35,7 +35,7 @@
     <module name="SuppressWarningsFilter"/>
 
     <module name="SuppressionFilter">
-        <property name="file" value="config/quality/checkstyle-suppressions.xml"/>
+        <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
         <property name="optional" value="false"/>
     </module>
 


### PR DESCRIPTION
This changeset addresses the current misconfiguration of Checkstyle plugin. The current version starts to crash when building Spine with JDK 11.

Now, we use a proper approach to define the `config` folder location. 