### PR TITLE
Make `String.isSnapshot()` more readable

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/StringExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/StringExtensions.kt
@@ -31,5 +31,5 @@ package io.spine.internal.gradle
  * `false` otherwise.
  */
 fun String.isSnapshot(): Boolean {
-    return contains("snapshot", true)
+    return contains("snapshot", ignoreCase = true)
 }


### PR DESCRIPTION
We add the name of the optional argument of a method used in the `isSnapshot()` extension method to make it more readable.