### PR TITLE
Update CheckStyle plugin to the most recent version

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -30,5 +30,5 @@ package io.spine.internal.dependency
 // See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
 @Suppress("unused")
 object CheckStyle {
-    const val version = "8.29"
+    const val version = "9.1"
 }


### PR DESCRIPTION
Previously, we were using `8.29`. Now, it's `9.1`.