### PR TITLE
Add `singleTenant` and `multitenant` to the list of builder methods

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -69,7 +69,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create,stream" />
+      <option name="BUILDER_METHODS" value="newBuilder,builder,toBuilder,create,stream,singleTenant,multitenant" />
       <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <arrangement>
         <groups>


### PR DESCRIPTION
That would help unifying the formatting of the code chains.