### PR TITLE
Kotlin configuration

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -61,6 +61,14 @@ val licenseReportVersion = "2.0"
 val grGitVersion = "3.1.1"
 
 /**
+ * The version of the Kotlin Gradle plugin.
+ *
+ * Please check that this value matches one defined in
+ *  `io.spine.internal.dependency.Kotlin.version`.
+ */
+val kotlinVersion = "1.6.0"
+
+/**
  * The version of Guava used in `buildSrc`.
  *
  * Always use the same version as the one specified in `io.spine.internal.dependency.Guava`.
@@ -87,4 +95,5 @@ dependencies {
     api("com.github.jk1:gradle-license-report:$licenseReportVersion")
     implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:${errorProneVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.31"
+    const val version      = "1.6.0"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -53,6 +53,7 @@ import org.gradle.process.CommandLineArgumentProvider
  * }
  *```
  */
+@Suppress("unused")
 fun JavaCompile.configureJavac() {
 
     if (JavaVersion.current() != JavacConfig.EXPECTED_JAVA_VERSION) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -26,8 +26,6 @@
 
 package io.spine.internal.gradle.javac
 
-import org.gradle.api.GradleException
-import org.gradle.api.JavaVersion
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.process.CommandLineArgumentProvider
 
@@ -55,18 +53,9 @@ import org.gradle.process.CommandLineArgumentProvider
  */
 @Suppress("unused")
 fun JavaCompile.configureJavac() {
-
-    if (JavaVersion.current() != JavacConfig.EXPECTED_JAVA_VERSION) {
-        throw GradleException("Spine Event Engine can be built with JDK 8 only." +
-                " Supporting JDK 11 and above at build-time is planned in 2.0 release." +
-                " Please use the pre-built binaries available in the Spine Maven repository." +
-                " See https://github.com/SpineEventEngine/base/issues/457."
-        )
-    }
-
     with(options) {
         encoding = JavacConfig.SOURCE_FILES_ENCODING
-        compilerArgumentProviders.add(JavacConfig.ARGUMENTS)
+        compilerArgumentProviders.add(JavacConfig.COMMAND_LINE)
     }
 }
 
@@ -75,8 +64,7 @@ fun JavaCompile.configureJavac() {
  */
 private object JavacConfig {
     const val SOURCE_FILES_ENCODING = "UTF-8"
-    val EXPECTED_JAVA_VERSION = JavaVersion.VERSION_1_8
-    val ARGUMENTS = CommandLineArgumentProvider {
+    val COMMAND_LINE = CommandLineArgumentProvider {
         listOf(
 
             // Protobuf Compiler generates the code, which uses the deprecated `PARSER` field.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.kotlin
+
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/**
+ * Opts-in to experimental features that we use in our codebase.
+ */
+fun KotlinCompile.setFreeCompilerArgs() {
+    kotlinOptions {
+        freeCompilerArgs = listOf(
+            "-Xskip-prerelease-check",
+            "-Xjvm-default=all",
+            "-Xopt-in=kotlin.contracts.ExperimentalContracts",
+            "-Xopt-in=kotlin.ExperimentalStdlibApi"
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -31,6 +31,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * Sets Java toolchain to the specified version (e.g. "11" or "8").
+ *
+ * See https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support
  */
 fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) {
     jvmToolchain {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -26,7 +26,17 @@
 
 package io.spine.internal.gradle.kotlin
 
+import org.gradle.jvm.toolchain.JavaToolchainSpec
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/**
+ * Sets Java toolchain to the specified version (e.g. "11" or "8").
+ */
+fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(version))
+    }
+}
 
 /**
  * Opts-in to experimental features that we use in our codebase.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -30,9 +30,8 @@ import org.gradle.jvm.toolchain.JavaToolchainSpec
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
- * Sets Java toolchain to the specified version (e.g. "11" or "8").
- *
- * See https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support
+ * Sets [Java toolchain](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support)
+ * to the specified version (e.g. "11" or "8").
  */
 fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) {
     jvmToolchain {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * Sets [Java toolchain](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support)
  * to the specified version (e.g. "11" or "8").
  */
-fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) {
+fun KotlinJvmProjectExtension.applyJvmToolchain(version: Int) {
     jvmToolchain {
         (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(version))
     }


### PR DESCRIPTION
This PR:
  * Bumps Kotlin version to 1.6.0.
  * Sets the version of Kotlin Gradle plugin under `buildSrc`.
  * Adds extension function for `KotlinCompile` for setting commonly used free compiler args.
  * Adds extension for setting Kotlin JVM toolchain (which also [selects](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support) corresponding Java version).
