### PR TITLE
Fix  missing imports

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -26,7 +26,9 @@
 
 package io.spine.internal.gradle.kotlin
 
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainSpec
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**


### PR DESCRIPTION
This PR fixes imports that were accidentally removed in `KotlinConfig.kt`.