### PR TITLE
JDK 11 and no tests when publishing

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github-workflows/publish.yml
+++ b/.github-workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: zulu
           cache: gradle
 

--- a/.github-workflows/publish.yml
+++ b/.github-workflows/publish.yml
@@ -51,7 +51,9 @@ jobs:
         run: cat ./gradle-plugin-portal.secret.properties >> ./gradle.properties
 
       - name: Publish artifacts to Maven
-        run: ./gradlew build publish --stacktrace
+        # Since we're in the `master` branch already, this means that tests of a PR passed.
+        # So, no need to run the tests again when publishing.
+        run: ./gradlew publish -x test --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.4" />
-    <option name="languageVersion" value="1.4" />
+    <option name="apiVersion" value="1.6" />
+    <option name="languageVersion" value="1.6" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Kotlin2JvmCompilerArguments">
-    <option name="jvmTarget" value="1.8" />
-  </component>
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.5" />
-    <option name="languageVersion" value="1.5" />
+    <option name="apiVersion" value="1.4" />
+    <option name="languageVersion" value="1.4" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="11" />
+  </component>
   <component name="KotlinCommonCompilerArguments">
     <option name="apiVersion" value="1.6" />
     <option name="languageVersion" value="1.6" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -38,5 +38,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -32,14 +32,10 @@ import org.gradle.process.CommandLineArgumentProvider
 /**
  * Configures the `javac` tool through this `JavaCompile` task.
  *
- * There are several steps performed:
+ * The following steps are performed:
  *
- *  1. Ensures JDK 8 is used for compilation;
- *  2. Passes a couple of arguments to the compiler. See [JavacConfig] for more details;
- *  3. Sets the UTF-8 encoding to be used when reading Java source files.
- *
- * Please note that Spine Event Engine can be built with JDK 8 only.
- * Supporting JDK 11 and above at build-time is planned in 2.0 release.
+ *  1. Passes a couple of arguments to the compiler. See [JavacConfig] for more details;
+ *  2. Sets the UTF-8 encoding to be used when reading Java source files.
  *
  * Here's an example of how to use it:
  *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -33,13 +33,21 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * Sets [Java toolchain](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support)
- * to the specified version (e.g. "11" or "8").
+ * to the specified version (e.g. 11 or 8).
  */
 fun KotlinJvmProjectExtension.applyJvmToolchain(version: Int) {
     jvmToolchain {
         (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(version))
     }
 }
+
+/**
+ * Sets [Java toolchain](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support)
+ * to the specified version (e.g. "11" or "8").
+ */
+@Suppress("unused")
+fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
+    applyJvmToolchain(version.toInt())
 
 /**
  * Opts-in to experimental features that we use in our codebase.


### PR DESCRIPTION
This PR sets Java 11 when running GitHub Workflows and in IDEA settings.

Other changes:
  * The `publish` workflow now does not run tests. There's no need to do that since the workflow is associated with the `master` branch, which means tests in a PR passed.
  * Added `String` parameter overload for `KotlinJvmProjectExtension.applyJvmToolchain()`. There was only `Int` version which felt a bit awkward in combination with Java version constants from Gradle.
