### PR TITLE
Migrate `buildSrc/.../groovy/dart/*` scripts to Kotlin

### DIFF
--- a/buildSrc/src/main/groovy/dart/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/build-tasks.gradle
@@ -26,6 +26,9 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+println("`build-tasks.gradle` script is deprecated. " +
+        "Please use `DartTasks.build()` extension instead.")
+
 final def GROUP = 'Dart'
 final def packageIndex = "$projectDir/.packages" as File
 final def extension = Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : ''

--- a/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
@@ -26,6 +26,9 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+println("`pub-publish-tasks.gradle` script is deprecated. " +
+        "Please use `DartTasks.publish()` extension instead.")
+
 final def publicationDir = "$buildDir/pub/publication/$project.name"
 final def extension = Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : ''
 final def PUB_EXECUTABLE = 'pub' + extension

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartContext.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartContext.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.Exec
+
+/**
+ * Provides access to the current [DartEnvironment] and shortcuts for running `pub` tool.
+ */
+open class DartContext(dartEnv: DartEnvironment, internal val project: Project)
+    : DartEnvironment by dartEnv
+{
+    /**
+     * Executes `pub` command in this [Exec] task.
+     *
+     * The Dart ecosystem uses packages to manage shared software such as libraries and tools.
+     * To get or publish Dart packages, the `pub` package manager is to be used.
+     */
+    fun Exec.pub(vararg args: Any) = commandLine(pubExecutable, *args)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartEnvironment.kt
@@ -34,7 +34,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
  *
  * Consists of two parts describing:
  *
- *  1. A module itself.
+ *  1. The module itself.
  *  2. Tools and their input/output files.
  */
 interface DartEnvironment {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartEnvironment.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart
+
+import java.io.File
+import org.apache.tools.ant.taskdefs.condition.Os
+
+/**
+ * Describes the environment in which Dart code is assembled and processed during the build.
+ *
+ * Consists of two parts describing:
+ *
+ *  1. A module itself.
+ *  2. Tools and their input/output files.
+ */
+interface DartEnvironment {
+
+    /*
+     * A module itself
+     ******************/
+
+    /**
+     * Module's root catalog.
+     */
+    val projectDir: File
+
+    /**
+     * Module's name.
+     */
+    val projectName: String
+
+    /**
+     * A directory which all artifacts are generated into.
+     *
+     * Default value: "$projectDir/build".
+     */
+    val buildDir: File
+        get() = projectDir.resolve("build")
+
+    /**
+     * A directory where artifacts for further publishing would be prepared.
+     *
+     * Default value: "$buildDir/pub/publication/$projectName".
+     */
+    val publicationDir: File
+        get() = buildDir
+            .resolve("pub")
+            .resolve("publication")
+            .resolve(projectName)
+
+    /**
+     * A directory which contains integration test Dart sources.
+     *
+     * Default value: "$projectDir/integration-test".
+     */
+    val integrationTestDir: File
+        get() = projectDir.resolve("integration-test")
+
+    /*
+     * Tools and their input/output files
+     *************************************/
+
+    /**
+     * Name of an executable for running `pub` tool.
+     *
+     * Default value:
+     *
+     *  1. "pub.bat" for Windows.
+     *  2. "pub" for other Oss.
+     */
+    val pubExecutable: String
+        get() = if (isWindows()) "pub.bat" else "pub"
+
+    /**
+     * Dart module's metadata file.
+     *
+     * Every pub package needs some metadata so it can specify its dependencies. Pub packages that
+     * are shared with others also need to provide some other information so users can discover
+     * them. All of this metadata goes in the package’s `pubspec`.
+     *
+     * Default value: "$projectDir/pubspec.yaml".
+     *
+     * See [The pubspec file | Dart](https://dart.dev/tools/pub/pubspec)
+     */
+    val pubSpec: File
+        get() = projectDir.resolve("pubspec.yaml")
+
+    /**
+     * Module dependencies' index that maps resolved package names to location URIs.
+     *
+     * By default, pub creates a [packageConfig] file in the `.dart_tool/` directory for this.
+     * Before the [packageConfig], pub used to create this [packageIndex] file in the root
+     * directory.
+     *
+     * As for Dart 2.14,  `pub` still updates the deprecated file for backwards compatibility.
+     *
+     * Default value: "$projectDir/.packages".
+     */
+    val packageIndex: File
+        get() = projectDir.resolve(".packages")
+
+    /**
+     * Module dependencies' index that maps resolved package names to location URIs.
+     *
+     * Default value: "$projectDir/.dart_tool/package_config.json".
+     */
+    val packageConfig: File
+        get() = projectDir
+            .resolve(".dart_tool")
+            .resolve("package_config.json")
+}
+
+/**
+ * Allows overriding [DartEnvironment]'s defaults.
+ *
+ * Please note, not all properties of the environment can be overridden. Properties that describe
+ * `pub` tool's input/output files can NOT be overridden because `pub` itself doesn't allow to
+ * specify them for its execution.
+ *
+ * The next properties could not be overridden:
+ *
+ *  1. [DartEnvironment.pubSpec].
+ *  2. [DartEnvironment.packageIndex].
+ *  3. [DartEnvironment.packageConfig].
+ */
+class ConfigurableDartEnvironment(initialEnv: DartEnvironment)
+    : DartEnvironment by initialEnv
+{
+    /*
+     * A module itself
+     ******************/
+
+    override var projectDir = initialEnv.projectDir
+    override var projectName = initialEnv.projectName
+    override var buildDir = initialEnv.buildDir
+    override var publicationDir = initialEnv.publicationDir
+    override var integrationTestDir = initialEnv.integrationTestDir
+
+    /*
+     * Tools and their input/output files
+     *************************************/
+
+    override var pubExecutable = initialEnv.pubExecutable
+}
+
+internal fun isWindows(): Boolean = Os.isFamily(Os.FAMILY_WINDOWS)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartExtension.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart
+
+import io.spine.internal.gradle.dart.task.DartTasks
+import io.spine.internal.gradle.dart.plugin.DartPlugins
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.findByType
+
+/**
+ * Configures [DartExtension] that facilitates configuration of Gradle tasks and plugins
+ * to build Dart projects.
+ *
+ * The whole structure of the extension looks as follows:
+ *
+ * ```
+ * dart {
+ *     environment {
+ *         // ...
+ *     }
+ *     plugins {
+ *         // ...
+ *     }
+ *     tasks {
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * ### Environment
+ *
+ * One of the main features of this extension is [DartEnvironment]. Environment describes a module
+ * itself and used tools with their input/output files.
+ *
+ * The extension is shipped with a pre-configured environment. So, no pre-configuration is required.
+ * Most properties in [DartEnvironment] have calculated defaults right in the interface.
+ * Only two properties need explicit override.
+ *
+ * The extension defines them as follows:
+ *
+ *  1. [DartEnvironment.projectDir] –> `project.projectDir`.
+ *  2. [DartEnvironment.projectName] —> `project.name`.
+ *
+ * There are two ways to modify the environment:
+ *
+ *  1. Modify [DartEnvironment] interface directly. Go with this option when it is a global change
+ *     that should affect all projects which use this extension.
+ *  2. Use [DartExtension.environment] scope — for temporary and custom overridings.
+ *
+ * An example of a property overriding:
+ *
+ * ```
+ * dart {
+ *     environment {
+ *         integrationTestDir = projectDir.resolve("tests")
+ *     }
+ * }
+ * ```
+ *
+ * Please note, environment should be set up firstly to have the effect on the parts
+ * of the extension that use it.
+ *
+ * ### Tasks and Plugins
+ *
+ * The spirit of tasks configuration in this extension is extracting the code that defines and
+ * registers tasks into extension functions upon `DartTasks` in `buildSrc`. Those extensions should
+ * be named after a task it registers or a task group if several tasks are registered at once.
+ * Then this extension is called in a project's `build.gradle.kts`.
+ *
+ * `DartTasks` and `DartPlugins` scopes extend [DartContext] which provides access
+ * to the current [DartEnvironment] and shortcuts for running `pub` tool.
+ *
+ * Below is the simplest example of how to create a primitive `printPubVersion` task.
+ *
+ * Firstly, a corresponding extension function should be defined in `buildSrc`:
+ *
+ * ```
+ * fun DartTasks.printPubVersion() =
+ *     register<Exec>("printPubVersion") {
+ *         pub("--version")
+ *     }
+ * ```
+ *
+ * Secondly, in a project's `build.gradle.kts` this extension is called:
+ *
+ * ```
+ * dart {
+ *     tasks {
+ *         printPubVersion()
+ *     }
+ * }
+ * ```
+ *
+ * An extension function is not restricted to register exactly one task. If several tasks can
+ * be grouped into a logical bunch, they should be registered together:
+ *
+ * ```
+ * fun DartTasks.build() {
+ *     assembleDart()
+ *     testDart()
+ *     generateCoverageReport()
+ * }
+ *
+ * private fun DartTasks.assembleDart() = ...
+ *
+ * private fun DartTasks.testDart() = ...
+ *
+ * private fun DartTasks.generateCoverageReport() = ...
+ * ```
+ *
+ * This section is mostly dedicated to tasks. But tasks and plugins are configured
+ * in a very similar way. So, everything above is also applicable to plugins. More detailed
+ * guides can be found in docs to `DartTasks` and `DartPlugins`.
+ *
+ * @see [ConfigurableDartEnvironment]
+ * @see [DartTasks]
+ * @see [DartPlugins]
+ */
+fun Project.dart(configuration: DartExtension.() -> Unit) {
+    extensions.run {
+        configuration.invoke(
+            findByType() ?: create("dartExtension", project)
+        )
+    }
+}
+
+/**
+ * Scope for performing Dart-related configuration.
+ *
+ * @see [dart]
+ */
+open class DartExtension(project: Project) {
+
+    private val environment = ConfigurableDartEnvironment(
+        object : DartEnvironment {
+            override val projectDir = project.projectDir
+            override val projectName = project.name
+        }
+    )
+
+    private val tasks = DartTasks(environment, project)
+    private val plugins = DartPlugins(environment, project)
+
+    /**
+     * Overrides default values of [DartEnvironment].
+     *
+     * Please note, environment should be set up firstly to have the effect on the parts
+     * of the extension that use it.
+     */
+    fun environment(overridings: ConfigurableDartEnvironment.() -> Unit) =
+        environment.run(overridings)
+
+    /**
+     * Configures [Dart-related plugins][DartPlugins].
+     */
+    fun plugins(configurations: DartPlugins.() -> Unit) = plugins.run(configurations)
+
+    /**
+     * Configures [Dart-related tasks][DartTasks].
+     */
+    fun tasks(configurations: DartTasks.() -> Unit) = tasks.run(configurations)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/DartPlugins.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/DartPlugins.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.plugin
+
+import io.spine.internal.gradle.dart.DartContext
+import io.spine.internal.gradle.dart.DartEnvironment
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.plugins.PluginContainer
+import org.gradle.api.tasks.TaskContainer
+
+/**
+ * A scope for applying and configuring Dart-related plugins.
+ *
+ * The scope extends [DartContext] and provides shortcuts for key project's containers:
+ *
+ *  1. [plugins].
+ *  2. [extensions].
+ *  3. [tasks].
+ *
+ * Let's imagine one wants to apply and configure `FooBar` plugin. To do that, several steps
+ * should be completed:
+ *
+ *  1. Declare the corresponding extension function upon [DartContext] named after the plugin.
+ *  2. Apply and configure the plugin inside that function.
+ *  3. Call the resulted extension in your `build.gradle.kts` file.
+ *
+ * Here's an example of `dart/plugin/FooBar.kt`:
+ *
+ * ```
+ * fun DartPlugins.fooBar() {
+ *     plugins.apply("com.fooBar")
+ *     extensions.configure<FooBarExtension> {
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * And here's how to apply it in `build.gradle.kts`:
+ *
+ *  ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.plugins.fooBar
+ *
+ * // ...
+ *
+ * dart {
+ *     plugins {
+ *         fooBar()
+ *     }
+ * }
+ *  ```
+ */
+class DartPlugins(dartEnv: DartEnvironment, project: Project) : DartContext(dartEnv, project) {
+
+    internal val plugins = project.plugins
+    internal val extensions = project.extensions
+    internal val tasks = project.tasks
+
+    internal fun plugins(configurations: PluginContainer.() -> Unit) =
+        plugins.run(configurations)
+
+    internal fun extensions(configurations: ExtensionContainer.() -> Unit) =
+        extensions.run(configurations)
+
+    internal fun tasks(configurations: TaskContainer.() -> Unit) =
+        tasks.run(configurations)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.plugin
+
+import com.google.protobuf.gradle.builtins
+import com.google.protobuf.gradle.id
+import com.google.protobuf.gradle.plugins
+import com.google.protobuf.gradle.protobuf
+import com.google.protobuf.gradle.remove
+import io.spine.internal.dependency.Protobuf
+
+/**
+ * Applies `protobuf` plugin and configures `GenerateProtoTask` to work with a Dart module.
+ *
+ * @see DartPlugins
+ */
+fun DartPlugins.protobuf() {
+
+    plugins.apply(Protobuf.GradlePlugin.id)
+
+    project.protobuf {
+        generateProtoTasks.all().forEach { task ->
+            task.apply {
+                plugins { id("dart") }
+                builtins { remove("java") }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Build.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Build.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.TaskName
+import io.spine.internal.gradle.base.assemble
+import io.spine.internal.gradle.base.check
+import io.spine.internal.gradle.base.clean
+import io.spine.internal.gradle.named
+import io.spine.internal.gradle.register
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Registers tasks for building Dart projects.
+ *
+ * List of tasks to be created:
+ *
+ *  1. [TaskContainer.cleanPackageIndex].
+ *  2. [TaskContainer.resolveDependencies].
+ *  3. [TaskContainer.testDart].
+ *
+ * An example of how to apply it in `build.gradle.kts`:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.task.build
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         build()
+ *     }
+ * }
+ * ```
+ *
+ * @param configuration any additional configuration related to the module's building.
+ */
+fun DartTasks.build(configuration: DartTasks.() -> Unit = {}) {
+
+    cleanPackageIndex().also {
+        clean.configure {
+            dependsOn(it)
+        }
+    }
+    resolveDependencies().also {
+        assemble.configure {
+            dependsOn(it)
+        }
+    }
+    testDart().also {
+        check.configure {
+            dependsOn(it)
+        }
+    }
+
+    configuration()
+}
+
+private val resolveDependenciesName = TaskName.of("resolveDependencies", Exec::class)
+
+/**
+ * Locates `resolveDependencies` task in this [TaskContainer].
+ *
+ * The task fetches dependencies declared via `pubspec.yaml` using `pub get` command.
+ */
+val TaskContainer.resolveDependencies: TaskProvider<Exec>
+    get() = named(resolveDependenciesName)
+
+private fun DartTasks.resolveDependencies(): TaskProvider<Exec> =
+    register(resolveDependenciesName) {
+
+        description = "Fetches dependencies declared via `pubspec.yaml`."
+        group = DartTasks.Group.build
+
+        mustRunAfter(cleanPackageIndex)
+
+        inputs.file(pubSpec)
+        outputs.file(packageIndex)
+
+        pub("get")
+    }
+
+private val cleanPackageIndexName = TaskName.of("cleanPackageIndex", Delete::class)
+
+/**
+ * Locates `cleanPackageIndex` task in this [TaskContainer].
+ *
+ * The task deletes the resolved module dependencies' index.
+ *
+ * The standard configuration file that contains index is `package_config.json`. For backwards
+ * compatability `pub` still updates the deprecated `.packages` file. The task deletes both files.
+ */
+val TaskContainer.cleanPackageIndex: TaskProvider<Delete>
+    get() = named(cleanPackageIndexName)
+
+private fun DartTasks.cleanPackageIndex(): TaskProvider<Delete> =
+    register(cleanPackageIndexName) {
+
+        description = "Deletes the resolved `.packages` and `package_config.json` files."
+        group = DartTasks.Group.build
+
+        delete(
+            packageIndex,
+            packageConfig
+        )
+    }
+
+private val testDartName = TaskName.of("testDart", Exec::class)
+
+/**
+ * Locates `testDart` task in this [TaskContainer].
+ *
+ * The task runs Dart tests declared in the `./test` directory.
+ */
+val TaskContainer.testDart: TaskProvider<Exec>
+    get() = named(testDartName)
+
+private fun DartTasks.testDart(): TaskProvider<Exec> =
+    register(testDartName) {
+
+        description = "Runs Dart tests declared in the `./test` directory."
+        group = DartTasks.Group.build
+
+        dependsOn(resolveDependencies)
+
+        pub("run", "test")
+    }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/DartTasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/DartTasks.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.dart.DartContext
+import io.spine.internal.gradle.dart.DartEnvironment
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskContainer
+
+/**
+ * A scope for registering and configuring Dart-related tasks.
+ *
+ * The scope provides:
+ *
+ *  1. Access to the current [DartContext].
+ *  2. Project's [TaskContainer].
+ *  3. Default task groups.
+ *
+ * Supposing, one needs to create a new task that would participate in building. Let the task name
+ * be `testDart`. To do that, several steps should be completed:
+ *
+ *  1. Define the task name and type using [TaskName][io.spine.internal.gradle.TaskName].
+ *  2. Create a public typed reference for the task upon [TaskContainer]. It would facilitate
+ *      referencing to the new task, so that external tasks could depend on it. This reference
+ *      should be documented.
+ *  3. Implement an extension upon [DartTasks] to register the task.
+ *  4. Call the resulted extension from `build.gradle.kts`.
+ *
+ * Here's an example of `testDart()` extension:
+ *
+ * ```
+ * import io.spine.internal.gradle.named
+ * import io.spine.internal.gradle.register
+ * import io.spine.internal.gradle.TaskName
+ * import org.gradle.api.Task
+ * import org.gradle.api.tasks.TaskContainer
+ * import org.gradle.api.tasks.Exec
+ *
+ * // ...
+ *
+ * private val testDartName = TaskName.of("testDart", Exec::class)
+ *
+ * /**
+ *  * Locates `testDart` task in this [TaskContainer].
+ *  *
+ *  * The task runs Dart tests declared in the `./test` directory.
+ *  */
+ * val TaskContainer.testDart: TaskProvider<Exec>
+ *     get() = named(testDartName)
+ *
+ * fun DartTasks.testDart() =
+ *     register(testDartName) {
+ *
+ *         description = "Runs Dart tests declared in the `./test` directory."
+ *         group = DartTasks.Group.build
+ *
+ *         // ...
+ *     }
+ * ```
+ *
+ * And here's how to apply it in `build.gradle.kts`:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.task.testDart
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         testDart()
+ *     }
+ * }
+ * ```
+ *
+ * Declaring typed references upon [TaskContainer] is optional. But it is highly encouraged
+ * to reference other tasks by such extensions instead of hard-typed string values.
+ */
+class DartTasks(dartEnv: DartEnvironment, project: Project)
+    : DartContext(dartEnv, project), TaskContainer by project.tasks
+{
+    /**
+     * Default task groups for tasks that participate in building a Dart module.
+     *
+     * @see [org.gradle.api.Task.getGroup]
+     */
+    internal object Group {
+        const val build = "Dart/Build"
+        const val publish = "Dart/Publish"
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/IntegrationTest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/IntegrationTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.TaskName
+import io.spine.internal.gradle.named
+import io.spine.internal.gradle.register
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+private val integrationTestName = TaskName.of("integrationTest", Exec::class)
+
+/**
+ * Locates `integrationTest` task in this [TaskContainer].
+ *
+ * The task runs integration tests of the `spine-dart` library against a sample
+ * Spine-based application. The tests are run in Chrome browser because they use `WebFirebaseClient`
+ * which only works in web environment.
+ *
+ * A sample Spine-based application is run from the `test-app` module before integration
+ * tests start and is stopped as the tests complete.
+ */
+val TaskContainer.integrationTest: TaskProvider<Exec>
+    get() = named(integrationTestName)
+
+/**
+ * Registers [TaskContainer.integrationTest] task.
+ *
+ * Please note, this task depends on [build] tasks. Therefore, building tasks should be applied in
+ * the first place.
+ *
+ * Here's an example of how to apply it in `build.gradle.kts`:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.task.build
+ * import io.spine.internal.gradle.task.integrationTest
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         build()
+ *         integrationTest()
+ *     }
+ * }
+ * ```
+ */
+fun DartTasks.integrationTest() =
+    register(integrationTestName) {
+
+        dependsOn(
+            resolveDependencies,
+            ":test-app:appBeforeIntegrationTest"
+        )
+
+        pub(
+            "run",
+            "test",
+            integrationTestDir,
+            "-p",
+            "chrome"
+        )
+
+        finalizedBy(":test-app:appAfterIntegrationTest")
+    }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.TaskName
+import io.spine.internal.gradle.base.assemble
+import io.spine.internal.gradle.java.publish.publish
+import io.spine.internal.gradle.named
+import io.spine.internal.gradle.register
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Registers tasks for publishing Dart projects.
+ *
+ * Please note, this task group depends on [build] tasks. Therefore, building tasks should
+ * be applied in the first place.
+ *
+ * List of tasks to be created:
+ *
+ *  1. [TaskContainer.stagePubPublication].
+ *  2. [TaskContainer.activateLocally].
+ *  3. [TaskContainer.publishToPub].
+ *
+ * Usage example:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.task.build
+ * import io.spine.internal.gradle.dart.task.publish
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         build()
+ *         publish()
+ *     }
+ * }
+ * ```
+ */
+fun DartTasks.publish() {
+
+    stagePubPublication()
+    activateLocally()
+
+    publishToPub().also {
+        publish.configure {
+            dependsOn(it)
+        }
+    }
+}
+
+private val stagePubPublicationName = TaskName.of("stagePubPublication", Copy::class)
+
+/**
+ * Locates `stagePubPublication` in this [TaskContainer].
+ *
+ * The task prepares the Dart package for Pub publication in the
+ * [publication directory][io.spine.internal.gradle.dart.DartEnvironment.publicationDir].
+ */
+val TaskContainer.stagePubPublication: TaskProvider<Copy>
+    get() = named(stagePubPublicationName)
+
+private fun DartTasks.stagePubPublication(): TaskProvider<Copy> =
+    register(stagePubPublicationName) {
+
+        description = "Prepares the Dart package for Pub publication."
+        group = DartTasks.Group.publish
+
+        dependsOn(assemble)
+
+        // Beside `.dart` sources itself, `pub` package manager conventions require:
+        // 1. README.md and CHANGELOG.md to build a page at `pub.dev/packages/<your_package>;`.
+        // 2. `pubspec` file to fill out details about your package on the right side of your
+        //    package’s page.
+        // 3. LICENSE file.
+
+        from(project.projectDir) {
+            include("**/*.dart", "pubspec.yaml", "**/*.md")
+            exclude("proto/", "generated/", "build/", "**/.*")
+        }
+        from("${project.rootDir}/LICENSE")
+        into(publicationDir)
+
+        doLast {
+            logger.debug("Pub publication is prepared in directory `$publicationDir`.")
+        }
+    }
+
+private val publishToPubName = TaskName.of("publishToPub", Exec::class)
+
+/**
+ * Locates `publishToPub` task in this [TaskContainer].
+ *
+ * The task publishes the prepared publication to Pub using `pub publish` command.
+ */
+val TaskContainer.publishToPub: TaskProvider<Exec>
+    get() = named(publishToPubName)
+
+private fun DartTasks.publishToPub(): TaskProvider<Exec> =
+    register(publishToPubName) {
+
+        description = "Publishes the prepared publication to Pub."
+        group = DartTasks.Group.publish
+
+        dependsOn(stagePubPublication)
+
+        val sayYes = "y".byteInputStream()
+        standardInput = sayYes
+
+        workingDir(publicationDir)
+
+        pub("publish", "--trace")
+    }
+
+private val activateLocallyName = TaskName.of("activateLocally", Exec::class)
+
+/**
+ * Locates `activateLocally` task in this [TaskContainer].
+ *
+ * Makes this package available in the command line as an executable.
+ *
+ * The `dart run` command supports running a Dart program — located in a file, in the current
+ * package, or in one of the dependencies of the current package - from the command line.
+ * To run a program from an arbitrary location, the package should be "activated".
+ *
+ * See [dart pub global | Dart](https://dart.dev/tools/pub/cmd/pub-global)
+ */
+val TaskContainer.activateLocally: TaskProvider<Exec>
+    get() = named(activateLocallyName)
+
+private fun DartTasks.activateLocally(): TaskProvider<Exec> =
+    register(activateLocallyName) {
+
+        description = "Activates this package locally."
+        group = DartTasks.Group.publish
+
+        dependsOn(stagePubPublication)
+
+        workingDir(publicationDir)
+        pub(
+            "global",
+            "activate",
+            "--source",
+            "path",
+            publicationDir,
+            "--trace"
+        )
+    }


### PR DESCRIPTION
This changeset migrates `buildSrc/.../groovy/dart/*` package to Kotlin:

1.  `build-tasks.groovy` was migrated to `DartTasks.build()`.
2. `pub-publish-tasks.gradle` was migrated to `DartTasks.publish()`.

Here's an example of how to use it in a project's `build.gradle.kts`:

```
// old API

apply {
    from(Deps.scripts.dartBuildTasks(project))
    from(Deps.scripts.pubPublishTasks(project))
}

// new API

dart {
    tasks {
        build()
        publish()
    }
}
```

Additionally, this PR extracts configuration of `protobuf` plugin and `integrationTest` task into `buildSrc`.

Here's an example of how to use it in a project's `build.gradle.kts`:

```
// old API

val integrationTestDir = "./integration-test"
val integrationTest by tasks.creating(Exec::class) {
    // ...
}

protoDart {
    testDir.set(project.layout.projectDirectory.dir(integrationTestDir))
}

tasks {
    named("testDart") { enabled = false }
    assemble { dependsOn("generateDart") }
    generateDart {
        descriptor = protoDart.testDescriptorSet
        target = "$projectDir/integration-test"
    }
}

protobuf {
    generateProtoTasks {
        all().forEach { task ->
            task.plugins { id("dart") }
            task.builtins { remove("java") }
        }
    }
}

// new API

dart {
    plugins {
        protobuf()
        protoDart { testDir.set(integrationTestDir) }
    }
    tasks {
        build {
            assemble { dependsOn("generateDart") }
            testDart { enabled = false }
        }

        integrationTest()

        generateDart {
            descriptor = protoDart.testDescriptorSet
            target = "$projectDir/integration-test"
        }
    }
}
```