### PR TITLE
Update Flogger

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/flogger
 object Flogger {
-    internal const val version = "0.6"
+    internal const val version = "0.7.2"
     const val lib     = "com.google.flogger:flogger:${version}"
     @Suppress("unused")
     object Runtime {


### PR DESCRIPTION
In light of the latest Log4J2 problems, the Flogger team have updated their dependency.

While we don't use Log4J2 directly, this might help users migrate to the safe version of the Log4J2 backend for Flogger.