### PR TITLE
Suppress `SpeadOperator` warning

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,1 @@
+ignoreRules=["SpreadOperator"]

--- a/pull
+++ b/pull
@@ -62,6 +62,9 @@ cp CODE_OF_CONDUCT.md ..
 echo "Updating Codecov settings"
 cp .codecov.yml ..
 
+echo "Updating Sonatype Lift settings"
+cp .lift.toml ..
+
 # Copies the file or directory passed as the first parameter to the upper directory,
 # only if such a file or directory does not exist there.
 function initialize() {


### PR DESCRIPTION
We add the Sonatype Lift configuration file and suppress Detekt's `SpeadOperator` warning.

As the Lift uses an old version of Detekt, [this bug](https://github.com/detekt/detekt/issues/3145) causes false alarm on any spread operator usage in Kotlin.

For now, we turn the check off. Later, we should re-enable it, once Lift upgrades the Detekt version.