### PR TITLE
Bump Gradle and Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ project. The following files will be copied:
  * `.gitignore`
  * `buildSrc` — a folder containing the common build-time code, in Kotlin.
  
-## Adding credentials to a new repository
-
-For details, please see [this page][travis-creds].
-
 ## Checking updated configuration
 
 When changing the configuration (e.g. a version of a dependency, or adding a build script plugin),
@@ -88,4 +84,3 @@ These scripts are copied by the `pull` script when `config` is applied to a new 
 [base]: https://github.com/SpineEventEngine/base
 [base-types]: https://github.com/SpineEventEngine/base-types
 [core-java]: https://github.com/SpineEventEngine/core-java
-[travis-creds]: https://github.com/SpineEventEngine/config/wiki/Encrypting-Credential-Files-for-Travis 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -35,7 +35,7 @@ package io.spine.internal.dependency
  */
 // https://github.com/google/guava
 object Guava {
-    private const val version = "30.1.1-jre"
+    private const val version = "31.0.1-jre"
     const val lib     = "com.google.guava:guava:${version}"
     const val testLib = "com.google.guava:guava-testlib:${version}"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR:
* Bumps Gradle -> `7.3.2`
* Bumps Guava -> `31.0.1-jre`
* Removes the link to a Travis doc in readme.