### PR TITLE
Bump Kotlin, Flogger, and JUnit

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/flogger
 object Flogger {
-    internal const val version = "0.7.2"
+    internal const val version = "0.7.3"
     const val lib     = "com.google.flogger:flogger:${version}"
     @Suppress("unused")
     object Runtime {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://junit.org/junit5/
 @Suppress("unused")
 object JUnit {
-    private const val version            = "5.8.2"
+    const val version                    = "5.8.2"
     private const val platformVersion    = "1.8.2"
     private const val legacyVersion      = "4.13.1"
 
@@ -44,6 +44,7 @@ object JUnit {
         "org.junit.jupiter:junit-jupiter-api:${version}",
         "org.junit.jupiter:junit-jupiter-params:${version}"
     )
+    const val bom     = "org.junit:junit-bom:${version}"
     const val runner  = "org.junit.jupiter:junit-jupiter-engine:${version}"
     const val pioneer = "org.junit-pioneer:junit-pioneer:${pioneerVersion}"
     const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -27,15 +27,16 @@
 package io.spine.internal.dependency
 
 // https://junit.org/junit5/
+@Suppress("unused")
 object JUnit {
-    private const val version            = "5.7.1"
-    private const val platformVersion    = "1.7.1"
+    private const val version            = "5.8.2"
+    private const val platformVersion    = "1.8.2"
     private const val legacyVersion      = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
-    private const val apiGuardianVersion = "1.1.1"
+    private const val apiGuardianVersion = "1.1.2"
     // https://github.com/junit-pioneer/junit-pioneer
-    private const val pioneerVersion     = "1.3.8"
+    private const val pioneerVersion     = "1.5.0"
 
     const val legacy = "junit:junit:${legacyVersion}"
     val api = listOf(
@@ -44,10 +45,8 @@ object JUnit {
         "org.junit.jupiter:junit-jupiter-params:${version}"
     )
     const val runner  = "org.junit.jupiter:junit-jupiter-engine:${version}"
-    @Suppress("unused")
     const val pioneer = "org.junit-pioneer:junit-pioneer:${pioneerVersion}"
     const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"
     const val platformLauncher = "org.junit.platform:junit-platform-launcher:${platformVersion}"
-    @Suppress("unused")
     const val params = "org.junit.jupiter:junit-jupiter-params:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.6.0"
+    const val version      = "1.6.1"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"


### PR DESCRIPTION
This PR bumps versions:
 * Kotlin -> 1.6.1
 * Flogger -> 0.7.3
 * JUnit -> 5.8.2; API Guardian -> 1.1.2; JUnit Pioneer -> 1.5.0
