### PR TITLE
Fix trailing zero in Kotlin version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -64,22 +64,22 @@ val grGitVersion = "3.1.1"
  * The version of the Kotlin Gradle plugin.
  *
  * Please check that this value matches one defined in
- *  `io.spine.internal.dependency.Kotlin.version`.
+ *  [io.spine.internal.dependency.Kotlin.version].
  */
-val kotlinVersion = "1.6.0"
+val kotlinVersion = "1.6.10"
 
 /**
  * The version of Guava used in `buildSrc`.
  *
- * Always use the same version as the one specified in `io.spine.internal.dependency.Guava`.
+ * Always use the same version as the one specified in [io.spine.internal.dependency.Guava].
  * Otherwise, when testing Gradle plugins, clashes may occur.
  */
-val guavaVersion = "30.1.1-jre"
+val guavaVersion = "31.0.1-jre"
 
 /**
  * The version of ErrorProne Gradle plugin.
  *
- * Please keep in sync. with `io.spine.internal.dependency.ErrorProne.GradlePlugin.version`.
+ * Please keep in sync. with [io.spine.internal.dependency.ErrorProne.GradlePlugin.version].
  *
  * @see <a href="https://github.com/tbroyer/gradle-errorprone-plugin/releases">
  *     Error Prone Gradle Plugin Releases</a>
@@ -89,7 +89,7 @@ val errorProneVersion = "2.0.2"
 /**
  * The version of Protobuf Gradle Plugin.
  *
- * Please keep in sync. with `io.spine.internal.dependency.Protobuf.GradlePlugin.version`.
+ * Please keep in sync. with [io.spine.internal.dependency.Protobuf.GradlePlugin.version].
  *
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.6.1"
+    const val version      = "1.6.10"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"


### PR DESCRIPTION
This PR fixes trailing zero in `1.6.10` of Kotlin and syncs versions in `build.gradle.kts` with those recently changed under `dependency` package.