### PR TITLE
Rollback J2ObjC version to 1.3.

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -32,6 +32,10 @@ package io.spine.internal.dependency
  */
 object J2ObjC {
     // https://github.com/google/j2objc/releases
-    private const val version = "1.3.1"
-    const val lib = "com.google.j2objc:j2objc-annotations:${version}"
+    // `1.3.` is the latest version available from Maven Central.
+    // https://search.maven.org/artifact/com.google.j2objc/j2objc-annotations
+    private const val version = "1.3"
+    const val annotations = "com.google.j2objc:j2objc-annotations:${version}"
+    @Deprecated("Please use `annotations` instead.", ReplaceWith("annotations"))
+    const val lib = annotations
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -110,7 +110,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
         AutoValue.annotations,
         Gson.lib,
-        J2ObjC.lib,
+        J2ObjC.annotations,
         Plexus.utils,
         Okio.lib,
         CommonsCli.lib,


### PR DESCRIPTION
This PR rolls back the version of J2ObjC from `1.3.1` to `1.3`, which is the latest version available from Maven Central.
The artifact we use is `j2objc-annotations` and this PR deprecates the `lib` property in favor of a new one called `annotations`, which clarifies the nature of the dependency.
