### PR TITLE
Bump versions of Google Cloud libraries

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Apache.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Apache.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+// https://commons.apache.org/
+@Suppress("unused")
+object Apache {
+
+    // https://hc.apache.org/downloads.cgi
+    const val httpCore = "org.apache.httpcomponents:httpcore:4.4.14"
+
+    // https://commons.apache.org/proper/commons-codec/changes-report.html
+    const val codec = "commons-codec:commons-codec:1.15"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ApacheHttp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ApacheHttp.kt
@@ -26,13 +26,9 @@
 
 package io.spine.internal.dependency
 
-// https://commons.apache.org/
 @Suppress("unused")
-object Apache {
+object ApacheHttp {
 
     // https://hc.apache.org/downloads.cgi
-    const val httpCore = "org.apache.httpcomponents:httpcore:4.4.14"
-
-    // https://commons.apache.org/proper/commons-codec/changes-report.html
-    const val codec = "commons-codec:commons-codec:1.15"
+    const val core = "org.apache.httpcomponents:httpcore:4.4.14"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCodec.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCodec.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+// https://commons.apache.org/proper/commons-codec/changes-report.html
+@Suppress("unused")
+object CommonsCodec {
+    private const val version = "1.15"
+    const val lib = "commons-codec:commons-codec:$version"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
@@ -32,8 +32,8 @@ object GoogleCloud {
     // https://github.com/googleapis/java-core
     const val core = "com.google.cloud:google-cloud-core:2.3.3"
 
-    // https://github.com/googleapis/java-pubsub
-    const val pubSubGrpcApi = "com.google.cloud:google-cloud-pubsub:1.115.0"
+    // https://github.com/googleapis/java-pubsub/tree/main/proto-google-cloud-pubsub-v1
+    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.97.0"
 
     // https://github.com/googleapis/java-trace
     const val trace = "com.google.cloud:google-cloud-trace:2.1.0"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
@@ -33,17 +33,11 @@ object GoogleCloud {
     const val core = "com.google.cloud:google-cloud-core:2.3.3"
 
     // https://github.com/googleapis/java-pubsub
-    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.115.0"
+    const val pubSubGrpcApi = "com.google.cloud:google-cloud-pubsub:1.115.0"
 
     // https://github.com/googleapis/java-trace
-    // Release 2.0.0 introduces breaking changes:
-    // https://github.com/googleapis/java-trace/releases/tag/v2.0.0
-    // Latest: https://github.com/googleapis/java-trace/releases/tag/v2.1.0
-    const val trace = "com.google.cloud:google-cloud-trace:1.4.2"
+    const val trace = "com.google.cloud:google-cloud-trace:2.1.0"
 
     // https://github.com/googleapis/java-datastore
-    // Release 2.0.0 introduces breaking changes:
-    // https://github.com/googleapis/java-datastore/releases/tag/v2.0.0
-    // Latest: https://github.com/googleapis/java-datastore/releases/tag/v2.2.1
-    const val datastore = "com.google.cloud:google-cloud-datastore:1.107.1"
+    const val datastore = "com.google.cloud:google-cloud-datastore:2.2.1"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -32,6 +32,7 @@ object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
     const val version        = "1.43.1"
     const val api            = "io.grpc:grpc-api:${version}"
+    const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"
     const val context        = "io.grpc:grpc-context:${version}"
     const val stub           = "io.grpc:grpc-stub:${version}"


### PR DESCRIPTION
This PR advances versions of Google Cloud libraries and adds Apache Commons dependency. 

`GoogleApis.AuthLibrary.oAuth2Http` and `Grpc.auth` libs were moved from the `api` configuration of the latest `google-cloud-trace` library. Modules that used those libraries transitively, now should link them explicitly and force the versions if conflicts occur:

```
dependencies {
    api(GoogleCloud.trace)
    testImplementation(GoogleApis.AuthLibrary.oAuth2Http)
    testImplementation(Grpc.auth)
}

 configurations {
     all {
         resolutionStrategy {
             force(
                 ApacheHttp.core,
                 CommonsCodec.lib,
                 Grpc.auth,
                 GoogleApis.AuthLibrary.credentials
              )
         }
     }
}
```

