### PR TITLE
Bump the version of `Firebase.admin` library

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
@@ -27,7 +27,8 @@
 package io.spine.internal.dependency
 
 // https://firebase.google.com/docs/admin/setup#java
+@Suppress("unused")
 object Firebase {
-    private const val adminVersion = "6.12.2"
+    private const val adminVersion = "8.1.0"
     const val admin = "com.google.firebase:firebase-admin:${adminVersion}"
 }


### PR DESCRIPTION
This PR bumps the version of `firebase-admin` library to `8.1.0`.