### PR TITLE
Add `google-http-client-apache-v2` dependency

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -36,6 +36,7 @@ object HttpClient {
     const val google   = "com.google.http-client:google-http-client:${version}"
     const val jackson2 = "com.google.http-client:google-http-client-jackson2:${version}"
     const val gson     = "com.google.http-client:google-http-client-gson:${version}"
+    const val apache2  = "com.google.http-client:google-http-client-apache-v2:${version}"
 
     const val apache   = "com.google.http-client:google-http-client-apache:2.1.2"
 }


### PR DESCRIPTION
This PR adds `apache2` implementation of Google Http Java Client. This is used to force version.