### PR TITLE
Bump Protobuf version -> `3.19.2`, add `protobuf-kotlin`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,12 +29,14 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.19.1"
+    private const val group = "com.google.protobuf"
+    const val version       = "3.19.2"
     val libs = listOf(
-        "com.google.protobuf:protobuf-java:${version}",
-        "com.google.protobuf:protobuf-java-util:${version}"
+        "${group}:protobuf-java:${version}",
+        "${group}:protobuf-java-util:${version}",
+        "${group}:protobuf-kotlin:${version}"
     )
-    const val compiler = "com.google.protobuf:protoc:${version}"
+    const val compiler = "${group}:protoc:${version}"
 
     // https://github.com/google/protobuf-gradle-plugin/releases
     object GradlePlugin {
@@ -46,6 +48,6 @@ object Protobuf {
          */
         const val version = "0.8.18"
         const val id = "com.google.protobuf"
-        const val lib = "com.google.protobuf:protobuf-gradle-plugin:${version}"
+        const val lib = "${group}:protobuf-gradle-plugin:${version}"
     }
 }


### PR DESCRIPTION
This PR bumps the version of Protobuf, addressing the [security vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569) recently reported by [OSS-Fuzz](https://github.com/google/oss-fuzz).

Also, the `protobuf-kotlin` artifact was added to the list of Protobuf `libs` we use to ease the adoption of Kotlin Protobuf DSL.
