### PR TITLE
Do not ErrorProne directories starting from `generated`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/ErrorProne.kt
@@ -49,6 +49,7 @@ import org.gradle.process.CommandLineArgumentProvider
  * }
  *```
  */
+@Suppress("unused")
 fun JavaCompile.configureErrorProne() {
     options.errorprone
         .errorproneArgumentProviders
@@ -67,7 +68,8 @@ private object ErrorProneConfig {
         listOf(
 
             // Exclude generated sources from being analyzed by ErrorProne.
-            "-XepExcludedPaths:.*/generated/.*",
+            // Include all directories started from `generated`, such as `generated-proto`.
+            "-XepExcludedPaths:.*/generated.*/.*",
 
             // Turn the check off until ErrorProne can handle `@Nested` JUnit classes.
             // See issue: https://github.com/google/error-prone/issues/956


### PR DESCRIPTION
This PR extends the exclusion of source code from being checked by ErrorProne from those belonging to the `generated` directories, to those who belong to directories the name of which _start_ from `generated`. This includes, for example, `build/generated-proto` directory being used by ProtoData.