### PR TITLE
Bump License Report, publish test reports

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -22,8 +22,15 @@ jobs:
         shell: bash
         run: ./gradlew build --stacktrace
 
+      # See: https://github.com/marketplace/actions/junit-report-action
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2.8.4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
       - name: Upload code coverage report
         uses: codecov/codecov-action@v2
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true

--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -22,3 +22,10 @@ jobs:
         shell: cmd
         # For the reason on `--no-daemon` see https://github.com/actions/cache/issues/454
         run: gradlew.bat build --stacktrace --no-daemon
+
+      # See: https://github.com/marketplace/actions/junit-report-action
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2.8.4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -28,9 +28,6 @@
  * This script uses two declarations of the constant [licenseReportVersion] because
  * currently there is no way to define a constant _before_ a build script of `buildSrc`.
  * We cannot use imports or do something else before the `buildscript` or `plugin` clauses.
- *
- * Therefore, when a version of [io.spine.internal.dependency.LicenseReport] changes, it should be
- * changed in the Kotlin object _and_ in this file below twice.
  */
 
 plugins {
@@ -38,7 +35,7 @@ plugins {
     groovy
     `kotlin-dsl`
     pmd
-    val licenseReportVersion = "2.0"
+    val licenseReportVersion = "2.1"
     id("com.github.jk1.dependency-license-report").version(licenseReportVersion)
 }
 
@@ -57,7 +54,7 @@ repositories {
 val jacksonVersion = "2.13.0"
 
 val googleAuthToolVersion = "2.1.2"
-val licenseReportVersion = "2.0"
+val licenseReportVersion = "2.1"
 val grGitVersion = "3.1.1"
 
 /**


### PR DESCRIPTION
This PR:
  * Advances the version of License Report used in `buildSrc` to version `2.1`.
  * Adds [publishing of test reports](https://github.com/marketplace/actions/junit-report-action) to build workflows under Ubuntu and Windows.
