### PR TITLE
Downgrade ErrorProne to version 2.10.0

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object ErrorProne {
     // https://github.com/google/error-prone
-    private const val version = "2.11.0"
+    private const val version = "2.10.0"
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 


### PR DESCRIPTION
We've run into problems with migrating to ErrorProne 2.11.0.

Once we figure out how to work around the compilation error, we shall upgrade ErrorProne to its latest version again.

See the [tracking issue](https://github.com/SpineEventEngine/mc-java/issues/26).