### PR TITLE
Make publishing of `testJar` artifact optional

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -92,9 +92,9 @@ abstract class WriteVersions : DefaultTask() {
      *
      * The name of the file would be: `versions-<artifactId>.properties`.
      *
-     * Usually, value of [Project.artifactId] property is a project name with "spine" prefix,
-     * followed by a hyphen. For example, if a project name is "tools", then the name
-     * of the file would be: `versions-spine-tools.properties`.
+     * By default, value of [Project.artifactId] property is a project name with "spine-" prefix.
+     * For example, if a project name is "tools", then the name of the file would be:
+     * `versions-spine-tools.properties`.
      */
     @TaskAction
     private fun writeFile() {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -92,8 +92,8 @@ abstract class WriteVersions : DefaultTask() {
      *
      * The name of the file would be: `versions-<artifactId>.properties`.
      *
-     * By default, value of [Project.artifactId] property is a project name with "spine-" prefix.
-     * For example, if a project name is "tools", then the name of the file would be:
+     * By default, value of [Project.artifactId] property is a project's name with "spine-" prefix.
+     * For example, if a project's name is "tools", then the name of the file would be:
      * `versions-spine-tools.properties`.
      */
     @TaskAction

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
@@ -89,12 +89,12 @@ internal fun Project.protoJar() = tasks.getOrCreate("protoJar") {
 }
 
 /**
- * Locates or creates `testOutputJar` task in this [Project].
+ * Locates or creates `testJar` task in this [Project].
  *
  * The output of this task is a `jar` archive. The archive contains compilation output
  * of `test` source set.
  */
-internal fun Project.testOutputJar() = tasks.getOrCreate("testOutputJar") {
+internal fun Project.testJar() = tasks.getOrCreate("testJar") {
     archiveClassifier.set("test")
     from(sourceSets["test"].output)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/MavenJavaPublication.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/MavenJavaPublication.kt
@@ -61,8 +61,8 @@ import org.gradle.kotlin.dsl.getByType
  */
 internal class MavenJavaPublication(
     private val artifactId: String,
-    private val jars: Collection<TaskProvider<Jar>>,
-    private val destinations: Collection<Repository>,
+    private val jars: Set<TaskProvider<Jar>>,
+    private val destinations: Set<Repository>,
 ) {
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publish
+
+/**
+ * A DSL element of [SpinePublishing] extension which allows disabling publishing
+ * of [protoJar] artifact.
+ *
+ * This artifact contains all the `.proto` definitions from `sourceSets.main.proto`. By default,
+ * it is published.
+ *
+ * Take a look on [SpinePublishing.protoJar] for a usage example.
+ *
+ * @see [registerArtifacts]
+ */
+class ProtoJar {
+
+    /**
+     * Set of modules, for which a proto JAR will not be published.
+     */
+    var exclusions: Set<String> = emptySet()
+
+    /**
+     * Disables proto JAR publishing for all published modules.
+     */
+    var disabled = false
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoLocators.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoLocators.kt
@@ -48,8 +48,8 @@ internal fun Project.hasProto(): Boolean {
  * "main" source set is added by `java` plugin. Special treatment for Proto sources is needed,
  * because they are not Java-related, and, thus, not included in `sourceSets["main"].allSource`.
  */
-internal fun Project.protoSources(): Collection<File> {
+internal fun Project.protoSources(): Set<File> {
     val mainSourceSet = sourceSets["main"]
     val protoSourceDirs = mainSourceSet.extensions.findByName("proto") as SourceDirectorySet?
-    return protoSourceDirs?.srcDirs ?: emptyList()
+    return protoSourceDirs?.srcDirs ?: emptySet()
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -95,9 +95,9 @@ private fun PublishingConfig.createPublication(project: Project) {
 private fun Project.registerArtifacts(
     includeProtoJar: Boolean = true,
     includeTestJar: Boolean = false
-): List<TaskProvider<Jar>> {
+): Set<TaskProvider<Jar>> {
 
-    val artifacts = mutableListOf(
+    val artifacts = mutableSetOf(
         sourcesJar(),
         javadocJar(),
     )

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -87,7 +87,7 @@ private fun PublishingConfig.createPublication(project: Project) {
  *  3. [javadocJar] – documentation, generated upon Java files.
  *  4. [testJar] – compilation output of "test" source set.
  *
- * Registration of [protoJar] and [testJar] is optional. It can be controlled by method's
+ * Registration of [protoJar] and [testJar] is optional. It can be controlled by the method's
  * parameters.
  *
  * @return the list of the registered tasks.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -42,7 +42,7 @@ import org.gradle.kotlin.dsl.apply
  */
 internal class PublishingConfig(
     val artifactId: String,
-    val destinations: Collection<Repository>,
+    val destinations: Set<Repository>,
     val includeProtoJar: Boolean = true,
     val includeTestJar: Boolean = false,
 )

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -36,13 +36,15 @@ import org.gradle.kotlin.dsl.apply
  * Information, required to set up publishing of a project using `maven-publish` plugin.
  *
  * @param artifactId a name that a project is known by.
- * @param excludeProtoJar tells whether [protoJar] artifact should be published.
  * @param destinations set of repositories, to which the resulting artifacts will be sent.
+ * @param includeProtoJar tells whether [protoJar] artifact should be published.
+ * @param includeTestJar tells whether [testJar] artifact should be published.
  */
 internal class PublishingConfig(
     val artifactId: String,
-    val excludeProtoJar: Boolean = false,
     val destinations: Collection<Repository>,
+    val includeProtoJar: Boolean = true,
+    val includeTestJar: Boolean = false,
 )
 
 /**
@@ -63,7 +65,7 @@ internal fun PublishingConfig.apply(project: Project) = with(project) {
 }
 
 private fun PublishingConfig.createPublication(project: Project) {
-    val artifacts = project.registerArtifacts(excludeProtoJar)
+    val artifacts = project.registerArtifacts(includeProtoJar, includeTestJar)
     val publication = MavenJavaPublication(
         artifactId = artifactId,
         jars = artifacts,
@@ -82,24 +84,33 @@ private fun PublishingConfig.createPublication(project: Project) {
  *
  *  1. [sourcesJar] – Java, Kotlin and Proto source files.
  *  2. [javadocJar] – documentation, generated upon Java files.
- *  3. [testOutputJar] – compilation output of "test" source set.
- *  4. [protoJar] – only Proto sources. It is an optional artifact.
+ *
+ * Optionally, the following artifacts can also be registered:
+ *
+ *  1. [testJar] – compilation output of "test" source set.
+ *  2. [protoJar] – only Proto source files.
  *
  * @return the list of the registered tasks.
  */
-private fun Project.registerArtifacts(excludeProtoJar: Boolean = false): List<TaskProvider<Jar>> {
+private fun Project.registerArtifacts(
+    includeProtoJar: Boolean = true,
+    includeTestJar: Boolean = false
+): List<TaskProvider<Jar>> {
+
     val artifacts = mutableListOf(
         sourcesJar(),
         javadocJar(),
-        testOutputJar(),
     )
 
-    // We don't want to have an empty "proto.jar",
-    // when a project doesn't have any Proto files at all.
-
-    val publishProto = excludeProtoJar.not()
-    if (hasProto() && publishProto) {
+    // We don't want to have an empty "proto.jar" when a project doesn't have any Proto files.
+    if (hasProto() && includeProtoJar) {
         artifacts.add(protoJar())
+    }
+
+    // Here, we don't have the corresponding `hasTests()` check, since this artifact is disabled
+    // by default. And turning it on means "We have tests and need them to be published."
+    if (includeTestJar) {
+        artifacts.add(testJar())
     }
 
     return artifacts

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -80,15 +80,15 @@ private fun PublishingConfig.createPublication(project: Project) {
  * By default, only a jar with java compilation output is included into publication. This method
  * registers tasks which produce additional artifacts.
  *
- * The list of additional artifacts:
+ * The list of additional artifacts to be registered:
  *
  *  1. [sourcesJar] – Java, Kotlin and Proto source files.
- *  2. [javadocJar] – documentation, generated upon Java files.
- *
- * Optionally, the following artifacts can also be registered:
- *
- *  1. [testJar] – compilation output of "test" source set.
  *  2. [protoJar] – only Proto source files.
+ *  3. [javadocJar] – documentation, generated upon Java files.
+ *  4. [testJar] – compilation output of "test" source set.
+ *
+ * Registration of [protoJar] and [testJar] is optional. It can be controlled by method's
+ * parameters.
  *
  * @return the list of the registered tasks.
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -92,7 +92,7 @@ import org.gradle.kotlin.dsl.findByType
  *        }
  *    }
  *    ```
- * 2. [javadocJar] - javadoc, generated upon Java sources from `main` source set.
+ * 2. [javadocJar] - javadoc, generated upon Java sources from "main" source set.
  *   If javadoc for Kotlin is also needed, apply Dokka plugin. It tunes `javadoc` task to generate
  *   docs upon Kotlin sources as well.
  * 3. [protoJar] – only Proto sources from "main" source set. It's published only if

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -157,11 +157,9 @@ open class SpinePublishing(private val project: Project) {
     /**
      * A prefix to be added before the name of each artifact.
      *
-     * The added prefix is followed by a hyphen.
-     *
-     * Default value is "spine".
+     * Default value is "spine-".
      */
-    var artifactPrefix: String = "spine"
+    var artifactPrefix: String = "spine-"
 
     /**
      * Allows disabling publishing of [protoJar] artifact, containing all Proto sources
@@ -301,20 +299,12 @@ open class SpinePublishing(private val project: Project) {
     }
 
     /**
-     * Obtains an artifact ID for the given project, taking into account
-     * the value of [artifactPrefix] property.
+     * Obtains an artifact ID for the given project.
      *
-     * If [artifactPrefix] is set to a non-empty string, it will be used before
-     * the published project name, followed by a hyphen. Otherwise, just project name is returned.
+     * It consists of an [artifactPrefix] followed by a project's name:
+     * `<artifactPrefix><project.name>`.
      */
-    internal fun artifactId(project: Project): String {
-        if (artifactPrefix.isEmpty()) {
-            return project.name
-        }
-
-        val id = "$artifactPrefix-${project.name}"
-        return id
-    }
+    internal fun artifactId(project: Project): String = "$artifactPrefix${project.name}"
 
     /**
      * Ensures that all modules, marked as excluded from proto JAR publishing,

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -307,11 +307,11 @@ open class SpinePublishing(private val project: Project) {
     internal fun artifactId(project: Project): String = "$artifactPrefix${project.name}"
 
     /**
-     * Ensures that all modules, marked as excluded from proto JAR publishing,
+     * Ensures that all modules, marked as excluded from [protoJar] publishing,
      * are actually published.
      *
-     * It makes no sense to exclude a module from [protoJar] publication, if a module
-     * is not published at all.
+     * It makes no sense to tell a module don't publish [protoJar] artifact, if the module is not
+     * published at all.
      */
     private fun ensureProtoJarExclusionsArePublished() {
         val nonPublishedExclusions = protoJar.exclusions.minus(modules)
@@ -322,11 +322,11 @@ open class SpinePublishing(private val project: Project) {
     }
 
     /**
-     * Ensures that all modules, marked as included into test JAR publishing,
+     * Ensures that all modules, marked as included into [testJar] publishing,
      * are actually published.
      *
-     * It makes no sense to include a module into [testJar] publication, if a module
-     * is not published at all.
+     * It makes no sense to tell a module publish [testJar] artifact, if the module is not
+     * published at all.
      */
     private fun ensureTestJarInclusionsArePublished() {
         val nonPublishedInclusions = testJar.inclusions.minus(modules)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -92,12 +92,12 @@ import org.gradle.kotlin.dsl.findByType
  *        }
  *    }
  *    ```
- * 2. [javadocJar] - javadoc, generated upon Java sources from "main" source set.
- *   If javadoc for Kotlin is also needed, apply Dokka plugin. It tunes `javadoc` task to generate
- *   docs upon Kotlin sources as well.
- * 3. [protoJar] – only Proto sources from "main" source set. It's published only if
+ * 2. [protoJar] – only Proto sources from "main" source set. It's published only if
  *   Proto files are actually present in the source set. Publication of this artifact is optional
  *   and can be disabled via [SpinePublishing.protoJar].
+ * 3. [javadocJar] - javadoc, generated upon Java sources from "main" source set.
+ *   If javadoc for Kotlin is also needed, apply Dokka plugin. It tunes `javadoc` task to generate
+ *   docs upon Kotlin sources as well.
  *
  * Additionally, [testJar] artifact can be published. This artifact contains compilation output
  * of "test" source set. Use [SpinePublishing.testJar] to enable its publishing.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -301,7 +301,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * Obtains an artifact ID for the given project.
      *
-     * It consists of an [artifactPrefix] followed by a project's name:
+     * It consists of a project's name and [prefix][artifactPrefix]:
      * `<artifactPrefix><project.name>`.
      */
     internal fun artifactId(project: Project): String = "$artifactPrefix${project.name}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -204,7 +204,7 @@ open class SpinePublishing(private val project: Project) {
 
     /**
      * Allows enabling publishing of [testJar] artifact, containing compilation output
-     * of `test` source set.
+     * of "test" source set.
      *
      * Here's an example of how to enable it for some of published modules:
      *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Tasks.kt
@@ -41,7 +41,7 @@ import org.gradle.api.tasks.TaskContainer
  *  2. Makes local `publish` task verify that credentials are present for each
  *     of destination repositories.
  */
-internal fun Project.configurePublishTask(destinations: Collection<Repository>) {
+internal fun Project.configurePublishTask(destinations: Set<Repository>) {
     val rootPublish = rootProject.tasks.getOrCreatePublishTask()
     val localPublish = tasks.getOrCreatePublishTask()
     val checkCredentials = tasks.registerCheckCredentialsTask(destinations)
@@ -58,7 +58,7 @@ private fun TaskContainer.getOrCreatePublishTask() =
         register(PUBLISH)
     }
 
-private fun TaskContainer.registerCheckCredentialsTask(destinations: Collection<Repository>) =
+private fun TaskContainer.registerCheckCredentialsTask(destinations: Set<Repository>) =
     register("checkCredentials") {
         doLast {
             destinations.forEach { it.ensureCredentials(project) }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publish
+
+/**
+ * A DSL element of [SpinePublishing] extension which allows enabling publishing
+ * of [testJar] artifact.
+ *
+ * This artifact contains compilation output of `test` source set. By default, it is not published.
+ *
+ * Take a look on [SpinePublishing.testJar] for a usage example.
+
+ * @see [registerArtifacts]
+ */
+class TestJar {
+
+    /**
+     * Set of modules, for which a test JAR will be published.
+     */
+    var inclusions: Set<String> = emptySet()
+
+    /**
+     * Enables test JAR publishing for all published modules.
+     */
+    var enabled = false
+}


### PR DESCRIPTION
This changeset removes `testJar` from the list of artifacts that are published by default. Publishing of this artifact is optional now and can be enabled via `SpinePublishing.testJar` method.

In addition to that, the PR does the following refactoring:

1. Renames `testOutputJar` task to just `testJar`. Each task within `Artifacts.kt` has a name that matches to pattern `<archive classifier>Jar`. This one was an exception.
2. Extracts `ProtoJar` DSL element for `SpinePublishing` into a separate file.
3. Makes `spinePublishing` not append a hyphen to `artifactPrefix`.
4. Drops usages of `Collection` when it is not required by a domain.