### PR TITLE
Bump dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/
 object AnimalSniffer {
-    private const val version = "1.19"
+    private const val version = "1.21"
     const val lib = "org.codehaus.mojo:animal-sniffer-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
@@ -31,7 +31,8 @@ package io.spine.internal.dependency
  *
  * [AssertK](https://github.com/willowtreeapps/assertk)
  */
+@Suppress("unused")
 object AssertK {
-    private const val version = "0.23.1"
+    private const val version = "0.25"
     const val libJvm = "com.willowtreeapps.assertk:assertk-jvm:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.dependency
 
 // https://www.bouncycastle.org/java.html
+@Suppress("unused")
 object BouncyCastle {
     const val libPkcsJdk15 = "org.bouncycastle:bcpkix-jdk15on:1.68"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -30,5 +30,5 @@ package io.spine.internal.dependency
 // See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
 @Suppress("unused")
 object CheckStyle {
-    const val version = "9.2"
+    const val version = "10.1"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://checkerframework.org/
 object CheckerFramework {
-    private const val version = "3.21.0"
+    private const val version = "3.21.3"
     const val annotations = "org.checkerframework:checker-qual:${version}"
     @Suppress("unused")
     val dataflow = listOf(

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
@@ -33,6 +33,6 @@ package io.spine.internal.dependency
  * [Commons CLI](https://commons.apache.org/proper/commons-cli/)
  */
 object CommonsCli {
-    private const val version = "1.4"
+    private const val version = "1.5.0"
     const val lib = "commons-cli:commons-cli:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.43.1"
+    const val version        = "1.45.0"
     const val api            = "io.grpc:grpc-api:${version}"
     const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
@@ -33,6 +33,6 @@ package io.spine.internal.dependency
  * [Gson](https://github.com/google/gson)
  */
 object Gson {
-    private const val version = "2.8.9"
+    private const val version = "2.9.0"
     const val lib = "com.google.code.gson:gson:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -35,7 +35,7 @@ package io.spine.internal.dependency
  */
 // https://github.com/google/guava
 object Guava {
-    private const val version = "31.0.1-jre"
+    private const val version = "31.1-jre"
     const val lib     = "com.google.guava:guava:${version}"
     const val testLib = "com.google.guava:guava-testlib:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -32,7 +32,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object HttpClient {
     // https://github.com/googleapis/google-http-java-client
-    const val version  = "1.40.1"
+    const val version  = "1.41.5"
     const val google   = "com.google.http-client:google-http-client:${version}"
     const val jackson2 = "com.google.http-client:google-http-client-jackson2:${version}"
     const val gson     = "com.google.http-client:google-http-client-gson:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.13.1"
+    private const val version = "2.13.2"
     // https://github.com/FasterXML/jackson-core
     const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
     // https://github.com/FasterXML/jackson-databind

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
@@ -31,7 +31,8 @@ package io.spine.internal.dependency
  *
  * [Java JWT](https://github.com/auth0/java-jwt)
  */
+@Suppress("unused")
 object JavaJwt {
-    private const val version = "3.18.1"
+    private const val version = "3.19.1"
     const val lib = "com.auth0:java-jwt:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.dependency
 
 // https://github.com/square/javapoet
+@Suppress("unused")
 object JavaPoet {
     private const val version = "1.13.0"
     const val lib = "com.squareup:javapoet:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
@@ -32,6 +32,6 @@ package io.spine.internal.dependency
  * [Klaxon](https://github.com/cbeust/klaxon)
  */
 object Klaxon {
-    private const val version = "5.5"
+    private const val version = "5.6"
     const val lib = "com.beust:klaxon:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -29,5 +29,5 @@ package io.spine.internal.dependency
 // https://pmd.github.io/
 @Suppress("unused") // Will be used when `config/gradle/pmd.gradle` migrates to Kotlin.
 object Pmd {
-    const val version = "6.41.0"
+    const val version = "6.44.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.19.3"
+    const val version       = "3.19.4"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.dependency
 
 // https://github.com/forge/roaster
+@Suppress("unused")
 object Roaster {
 
     /**
@@ -36,7 +37,7 @@ object Roaster {
      *
      * Please see [this issue][https://github.com/SpineEventEngine/config/issues/220] for details.
      */
-    private const val version = "2.23.2.Final"
+    private const val version = "2.24.0.Final"
 
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"


### PR DESCRIPTION
This PR bumps versions of several dependencies.

For some of the dependencies, like `ApaheHttp` or `Netty`, advancing the version needs testing. Issues on them were added (#342, #343).
