### PR TITLE
Rename `exposeTestArtifacts` to `exposeTestConfiguration`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
@@ -64,7 +64,7 @@ fun Project.exposeTestConfiguration() {
 
     if (pluginManager.hasPlugin("java").not()) {
         throw IllegalStateException(
-            "Can't expose the test configuration because `java` plugin has not been applied!"
+            "Can't expose the test configuration because `java` plugin has not been applied."
         )
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
@@ -53,6 +53,7 @@ import io.spine.internal.gradle.publish.testJar
  * }
  * ```
  */
+@Suppress("unused")
 fun Project.exposeTestConfiguration() {
 
     if (pluginManager.hasPlugin("java").not()) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Multiproject.kt
@@ -37,7 +37,9 @@ import io.spine.internal.gradle.publish.testJar
  * of some "parent" project.
  *
  * Please note that this utility requires Gradle `java` plugin to be applied. Hence, it is
- * recommended to call this extension method from `java` scope:
+ * recommended to call this extension method from `java` scope.
+ *
+ * Here's an example of how to expose the test classes of "projectA":
  *
  * ```
  * java {
@@ -45,20 +47,24 @@ import io.spine.internal.gradle.publish.testJar
  * }
  * ```
  *
- * Here's an example of how to consume the exposed configuration:
+ * Here's an example of how to consume the exposed classes in "projectB":
  *
  * ```
  * dependencies {
- *     testImplementation(project(path = ":projectName", configuration = "testArtifacts"))
+ *     testImplementation(project(path = ":projectA", configuration = "testArtifacts"))
  * }
  * ```
+ *
+ * Don't forget that this exposure mechanism works only for projects that reside within the same
+ * multi-project build. In order to share the test classes with external projects, publish a
+ * dedicated [testJar][io.spine.internal.gradle.publish.SpinePublishing.testJar] artifact.
  */
 @Suppress("unused")
 fun Project.exposeTestConfiguration() {
 
     if (pluginManager.hasPlugin("java").not()) {
         throw IllegalStateException(
-            "Can't expose test configuration because `java` plugin has not been applied!"
+            "Can't expose the test configuration because `java` plugin has not been applied!"
         )
     }
 


### PR DESCRIPTION
This changeset renames `exposeTestArtifacts()` in order not to clash with artifacts that are published to Maven.

As for now It is possible to expose the test classes in two ways:

1. With `exposeTestArtifacts() -> exposeTestConfiguration()` as a consumable Gradle configuration. Such exposure works only within a Gradle multi-project build. One subproject exposes its test classes to other subprojects. 
2. With `SpinePublishing.testJar` artifact. The test classes are packed into a jar archive in a form of compiled classes. This archive is published to a Maven repository and then can be consumed by external projects.