### PR TITLE
Enable `spinePublishing` publish a root project itself

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -272,8 +272,9 @@ open class SpinePublishing(private val extensionReceiver: Project) {
      * The method considers two options:
      *
      * 1. The set of [modules] is not empty. It means that the extension is opened in
-     *   a root project. And each of the specified modules is a subproject of [extensionReceiver].
-     * 2. The set is empty. Then the published module is an [extensionReceiver] itself.
+     *   a root project. And each of the specified modules is a subproject
+     *   of the [extensionReceiver].
+     * 2. The set is empty. Then the published module is the [extensionReceiver] itself.
      */
     private fun publishedProjects() = modules.map { name -> extensionReceiver.project(name) }
         .ifEmpty { setOf(extensionReceiver) }
@@ -282,7 +283,7 @@ open class SpinePublishing(private val extensionReceiver: Project) {
      * Sets up `maven-publish` plugin for the given project.
      *
      * Firstly, an instance of [PublishingConfig] is assembled for the project. Then, this
-     * config is applied to the project.
+     * config is applied.
      *
      * This method utilizes `project.afterEvaluate` closure. General rule of thumb is to avoid using
      * of this closure, as it configures a project when its configuration is considered completed.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -116,11 +116,11 @@ fun Project.spinePublishing(configuration: SpinePublishing.() -> Unit) {
 /**
  * A Gradle extension for setting up publishing of spine modules using `maven-publish` plugin.
  *
- * @param targetProject a project in which the extension is opened
+ * @param project a project in which the extension is opened
  *
  * @see spinePublishing
  */
-open class SpinePublishing(private val targetProject: Project) {
+open class SpinePublishing(private val project: Project) {
 
     private val protoJar = ProtoJar()
     private val testJar = TestJar()
@@ -132,8 +132,7 @@ open class SpinePublishing(private val targetProject: Project) {
      *
      * Use this property if the extension is configured from a root project's build file.
      *
-     * If left empty, the [project][targetProject], in which the extension is opened,
-     * will be published.
+     * If left empty, the [project] in which the extension is opened, will be published.
      *
      * Empty by default.
      */
@@ -271,14 +270,15 @@ open class SpinePublishing(private val targetProject: Project) {
      *
      * The method considers two options:
      *
-     * 1. The set of [modules] is not empty. It means that a [targetProject] is a root. And each
-     *  of the specified modules is a subproject of a [targetProject].
-     * 2. The set is empty. Then the published module is a [targetProject] itself.
+     * 1. The [set][modules] of subprojects to publish is not empty. It means that the extension
+     *   is opened from a root project.
+     * 2. The [set][modules] is empty. Then, the [project] in which the extension is opened
+     *   will be published.
      *
      * @see modules
      */
-    private fun publishedProjects() = modules.map { name -> targetProject.project(name) }
-        .ifEmpty { setOf(targetProject) }
+    private fun publishedProjects() = modules.map { name -> project.project(name) }
+        .ifEmpty { setOf(project) }
 
     /**
      * Sets up `maven-publish` plugin for the given project.
@@ -360,14 +360,14 @@ open class SpinePublishing(private val targetProject: Project) {
      * Here we verify that publishing of a module is not configured in both places simultaneously.
      */
     private fun ensuresModulesNotDuplicated() {
-        val rootProject = targetProject.rootProject
-        if (rootProject == targetProject) {
+        val rootProject = project.rootProject
+        if (rootProject == project) {
             return
         }
 
         val rootExtension = with(rootProject.extensions) { findByType<SpinePublishing>() }
         rootExtension?.let { rootPublishing ->
-            val thisProject = setOf(targetProject.name, targetProject.path)
+            val thisProject = setOf(project.name, project.path)
             if (thisProject.minus(rootPublishing.modules).size != 2) {
                 throw IllegalStateException("Publishing of `$thisProject` module is already " +
                             "configured in a root project!")

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -116,7 +116,8 @@ fun Project.spinePublishing(configuration: SpinePublishing.() -> Unit) {
 /**
  * A Gradle extension for setting up publishing of spine modules using `maven-publish` plugin.
  *
- * @param project a project in which the extension is opened
+ * @param project a project in which the extension is opened. By default, this project will be
+ *  published as long as a [set][modules] of modules to publish is not specified explicitly.
  *
  * @see spinePublishing
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -132,7 +132,7 @@ open class SpinePublishing(private val project: Project) {
      *
      * Use this property if the extension is configured from a root project's build file.
      *
-     * If left empty, the [project] in which the extension is opened, will be published.
+     * If left empty, the [project], in which the extension is opened, will be published.
      *
      * Empty by default.
      */


### PR DESCRIPTION
There are several places where `spinePublishing` can be opened:

1. In a root project to configure publishing of:
    1.1. subprojects.
    1.2. a root project itself.
2. In a subproject to configure publishing of a subproject itself.

Case (1.2) didn't work. The build failed. This PR fixes this.
