### PR TITLE
Bump Dokka -> `1.6.10`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -29,6 +29,6 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin/dokka
 @Suppress("unused")
 object Dokka {
-    const val version = "1.5.0"
+    const val version = "1.6.10"
     const val pluginId = "org.jetbrains.dokka"
 }


### PR DESCRIPTION
This PR advances the version of Dokka we use to [`1.6.10`](https://github.com/Kotlin/dokka/releases/tag/v1.6.10).