### PR TITLE
Bump Dokka -> `1.6.20`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -101,7 +101,7 @@ val protobufPluginVersion = "0.8.18"
  * @see <a href="https://github.com/Kotlin/dokka/releases">
  *     Dokka Releases</a>
  */
-val dokkaVersion = "1.6.10"
+val dokkaVersion = "1.6.20"
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -34,7 +34,7 @@ object Dokka {
     /**
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.6.10"
+    const val version = "1.6.20"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"


### PR DESCRIPTION
This PR advances the version of Dokka we use to [`1.6.20`](https://github.com/Kotlin/dokka/releases/tag/v1.6.20).