### PR TITLE
Finish bumping Kotlin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -63,7 +63,7 @@ val grGitVersion = "3.1.1"
  * Please check that this value matches one defined in
  *  [io.spine.internal.dependency.Kotlin.version].
  */
-val kotlinVersion = "1.6.10"
+val kotlinVersion = "1.6.20"
 
 /**
  * The version of Guava used in `buildSrc`.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -29,6 +29,9 @@ package io.spine.internal.dependency
 // https://github.com/JetBrains/kotlin
 // https://github.com/Kotlin
 object Kotlin {
+    /**
+    * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
+    */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
     const val version      = "1.6.20"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"


### PR DESCRIPTION
This PR finishes bumping the Kotlin version to `1.6.20`, started in [this PR](https://github.com/SpineEventEngine/config/pull/354). Also, a reminder-comment was added to keep versions in sync across multiple places.