### PR TITLE
Fix Dokka documentation for Kotlin+Java projects

### DIFF
--- a/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
@@ -25,6 +25,8 @@
  */
 
 import io.spine.internal.dependency.Dokka
+import io.spine.internal.gradle.dokka.onlyJavaSources
+
 import java.time.LocalDate
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
@@ -56,6 +58,10 @@ dependencies {
 
 tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets.configureEach {
+        sourceRoots.setFrom(
+            onlyJavaSources()
+        )
+
         skipEmptyPackages.set(true)
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -70,7 +70,7 @@ object Dokka {
     object SpineExtensions {
         private const val group = "io.spine.tools"
 
-        const val version = "2.0.0-SNAPSHOT.2"
+        const val version = "2.0.0-SNAPSHOT.3"
         const val lib = "${group}:spine-dokka-extensions:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -34,6 +34,12 @@ import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.gradle.GradleDokkaSourceSetBuilder
 
+/**
+ * Returns only Java source roots out of all present in the source set.
+ *
+ * This method helps restrict Kotlin code from being documented. When both Kotlin and Java source
+ * files are present in multi-language projects, only one source file type is documented correctly.
+ */
 public fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
     return sourceRoots.filter(File::isJavaSourceDirectory)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dokka
+
+import java.io.File
+import java.time.LocalDate
+import org.gradle.api.file.FileCollection
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.DokkaBaseConfiguration
+import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.dokka.gradle.GradleDokkaSourceSetBuilder
+
+public fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
+    return sourceRoots.filter(File::isJavaSourceDirectory)
+}
+
+private fun File.isJavaSourceDirectory(): Boolean {
+    return isDirectory() && name == "java"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -40,7 +40,7 @@ import org.jetbrains.dokka.gradle.GradleDokkaSourceSetBuilder
  * This method helps restrict Kotlin code from being documented. When both Kotlin and Java source
  * files are present in multi-language projects, only one source file type is documented correctly.
  */
-public fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
+internal fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
     return sourceRoots.filter(File::isJavaSourceDirectory)
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -37,9 +37,9 @@ import org.jetbrains.dokka.gradle.GradleDokkaSourceSetBuilder
 /**
  * Returns only Java source roots out of all present in the source set.
  *
- * This method helps restrict Kotlin code from being documented. When both Kotlin and Java source
- * files are present in multi-language projects, only one source file type is documented correctly
- * depending on the configuration used.
+ * It is a helper method for generating documentation by Dokka only for Java code. It is helpful
+ * when both Java and Kotlin source files are present in a source set. Dokka can properly generate
+ * documentation for either Kotlin or Java depending on the configuration, but not both.
  */
 internal fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
     return sourceRoots.filter(File::isJavaSourceDirectory)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dokka/DokkaExtensions.kt
@@ -38,7 +38,8 @@ import org.jetbrains.dokka.gradle.GradleDokkaSourceSetBuilder
  * Returns only Java source roots out of all present in the source set.
  *
  * This method helps restrict Kotlin code from being documented. When both Kotlin and Java source
- * files are present in multi-language projects, only one source file type is documented correctly.
+ * files are present in multi-language projects, only one source file type is documented correctly
+ * depending on the configuration used.
  */
 internal fun GradleDokkaSourceSetBuilder.onlyJavaSources(): FileCollection {
     return sourceRoots.filter(File::isJavaSourceDirectory)


### PR DESCRIPTION
[The PR](https://github.com/SpineEventEngine/config/pull/352) which extended our Dokka support did not fully cover all edge-cases of generating documentation. One was found during generating documentation for a multi-language project with both Java and Kotlin source files. Currently, Dokka does not allow a clear and concise way to generate documentation for both Java+Kotlin projects. You are either "seeing Java code as Kotlin" or vice versa. Now we are sticking to generating documentation for Java code. This PR is fixing the described issue by considering only Java source files when generating Dokka documentation via `dokka-for-java` script plugin. Also, this PR bumps `spine-dokka-extensions`.