### PR TITLE
Tune Kotlin compiler flags

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -58,8 +58,13 @@ fun KotlinCompile.setFreeCompilerArgs() {
         freeCompilerArgs = listOf(
             "-Xskip-prerelease-check",
             "-Xjvm-default=all",
-            "-opt-in=kotlin.contracts.ExperimentalContracts",
-            "-opt-in=kotlin.ExperimentalStdlibApi"
+            "-Xinline-classes",
+            "-opt-in=" +
+                    "kotlin.contracts.ExperimentalContracts," +
+                    "kotlin.io.path.ExperimentalPathApi," +
+                    "kotlin.ExperimentalUnsignedTypes," +
+                    "kotlin.ExperimentalStdlibApi," +
+                    "kotlin.experimental.ExperimentalTypeInference",
         )
     }
 }


### PR DESCRIPTION
This PR:
  1. Adds Kotlin compiler flags that were recently used in ProtoData.
  2. Removes the `X` prefix before `-opt-in`, thus avoiding the warning issued since Kotlin version `1.6.20`.