### PR TITLE
Filter out duplicated dependencies from `pom.xml`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/DependencyWriter.kt
@@ -111,7 +111,6 @@ fun Project.dependencies(): SortedSet<ScopedDependency> {
     val result = deduplicate(dependencies)
         .map { it.scoped }
         .toSortedSet()
-
     return result
 }
 
@@ -177,7 +176,7 @@ private fun Project.logDuplicate(dependency: String, versions: List<ModuleDepend
 
     versions.forEach {
         logger.lifecycle(
-            "module: {}, configuration: {},version: {}",
+            "module: {}, configuration: {}, version: {}",
             it.module.name,
             it.configuration.name,
             it.version

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/DependencyWriter.kt
@@ -145,10 +145,10 @@ private fun Dependency.isExternal(): Boolean {
  * When there are several versions of the same dependency, the method will retain only
  * the one with the newest version.
  *
- * Sometimes, set of project dependencies contain several versions of the same dependency.
- * This may happen when different modules of the project use different versions of the
- * same dependency. But for our `pom.xml`, which has clearly representative character,
- * a single version of a dependency is quite enough.
+ * Sometimes, a project uses several versions of the same dependency. This may happen
+ * when different modules of the project use different versions of the same dependency.
+ * But for our `pom.xml`, which has clearly representative character, a single version
+ * of a dependency is quite enough.
  */
 private fun MutableSet<ScopedDependency>.deduplicate() =
     groupBy { it.dependency().run { "$group:$name" } }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/DependencyWriter.kt
@@ -112,8 +112,7 @@ fun Project.dependencies(): SortedSet<ScopedDependency> {
 }
 
 /**
- * Returns the scoped dependencies of the project from all
- * the project configurations.
+ * Returns the scoped dependencies of the project from all the project configurations.
  */
 private fun Project.depsFromAllConfigurations(): Set<ScopedDependency> {
     val result = mutableSetOf<ScopedDependency>()

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/ModuleDependency.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.report.pom
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
+
+/**
+ * A module's dependency.
+ *
+ * Contains information about a module and configuration, from which
+ * the dependency comes.
+ */
+internal class ModuleDependency(
+    val module: Project,
+    val configuration: Configuration,
+    private val dependency: Dependency,
+
+) : Dependency by dependency, Comparable<ModuleDependency> {
+
+    companion object {
+        private val COMPARATOR = compareBy<ModuleDependency> { it.module }
+            .thenBy { it.configuration.name }
+            .thenBy { it.group }
+            .thenBy { it.name }
+            .thenBy { it.version }
+    }
+
+    /**
+     * A project dependency with its [scope][DependencyScope].
+     *
+     * Doesn't contain any info about an origin module and configuration.
+     */
+    val scoped = ScopedDependency.of(dependency, configuration)
+
+    /**
+     * GAV coordinates of this dependency.
+     *
+     * Gradle's [Dependency] is a mutable object. Its properties can change their
+     * values with time. In parcticular, the version can be changed as more
+     * configurations are getting resolved. This is why this property is calculated.
+     */
+    val gav: String
+        get() = "$group:$name:$version"
+
+    override fun compareTo(other: ModuleDependency): Int = COMPARATOR.compare(this, other)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ModuleDependency
+
+        if (module != other.module) return false
+        if (configuration != other.configuration) return false
+        if (dependency != other.dependency) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = module.hashCode()
+        result = 31 * result + configuration.hashCode()
+        result = 31 * result + dependency.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
This PR addresses #362.

As described in the issue, sometimes we can't overcome the presence of several versions of the same dependency. `pom.xml` is generated upon a whole project and doesn't group dependencies by modules. Specific modules override versions dictated by `config`. And, as a result, several versions of the same dependency leak to `pom.xml`.

`spine-time` repository is an example here. Each subproject is configured to use a specific version of `protoc` from `config`. The configuration is performed from the root project:

```
 protoc {
    artifact = Protobuf.compiler
}
```

Meanwhile, `time` module applies our `mc-java` plugin, and not the last version. The plugin overrides the version of `protoc`, specified by the root. As a result, the module uses its own version.

---

This PR makes `DependencyWriter` filter out duplicates by group and name. Only the one, with the newest version, is retained. The duplicates are logged.

Generation of license reports is not changed, since dependencies there are grouped by modules.