### PR TITLE
Add more Jackson dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,8 +28,8 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.13.2"
-    private const val databindVersion = "2.13.2.2"
+    const val version = "2.13.2"
+    const val databindVersion = "2.13.2.2"
     // https://github.com/FasterXML/jackson-core
     const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
     // https://github.com/FasterXML/jackson-databind

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -40,4 +40,8 @@ object Jackson {
     const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
     // https://github.com/FasterXML/jackson-module-kotlin/releases
     const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
+    // https://github.com/FasterXML/jackson-bom
+    const val bom = "com.fasterxml.jackson:jackson-bom:${version}"
+    // https://github.com/FasterXML/jackson-annotations
+    const val annotations = "com.fasterxml.jackson.core:jackson-annotations:${version}"
 }


### PR DESCRIPTION
Applying Dokka in `web` repository requires forcing of two more Jackson dependencies.

This PR adds the following dependencies:

1. `jackson-bom`.
2. `jackson-annotations`.