### PR TITLE
Write manifests and improvements for Windows

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -145,4 +145,7 @@ dependencies {
     implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}")
     implementation("org.jetbrains.dokka:dokka-base:${dokkaVersion}")
+
+    // https://github.com/srikanth-lingala/zip4j
+    implementation("net.lingala.zip4j:zip4j:2.10.0")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -104,8 +104,8 @@ val dokkaVersion = "1.6.20"
 
 configurations.all {
     resolutionStrategy {
-        // Force Kotlin lib versions avoiding using those bundled with Gradle.
         force(
+            // Force Kotlin lib versions avoiding using those bundled with Gradle.
             "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
             "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion",
             "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,6 @@ plugins {
     java
     groovy
     `kotlin-dsl`
-    pmd
     val licenseReportVersion = "2.1"
     id("com.github.jk1.dependency-license-report").version(licenseReportVersion)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.45.1"
+    const val version        = "1.46.0"
     const val api            = "io.grpc:grpc-api:${version}"
     const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.gradle
 
 import java.io.File
+import java.io.FileOutputStream
 import java.util.concurrent.TimeUnit
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -94,13 +95,17 @@ open class RunGradle : DefaultTask() {
     private fun execute() {
         // Ensure build error output log.
         // Since we're executing this task in another process, we redirect error output to
-        // the file under the `build` directory.
-        val buildDir = File(directory, "build")
+        // the file under the `_out` directory. Using the `build` directory for this purpose
+        // proved to cause problems under Windows when executing the `clean` command, which
+        // fails because another process holds files.
+        val buildDir = File(directory, "_out")
         if (!buildDir.exists()) {
             buildDir.mkdir()
         }
         val errorOut = File(buildDir, "error-out.txt")
+        errorOut.truncate()
         val debugOut = File(buildDir, "debug-out.txt")
+        debugOut.truncate()
 
         val command = buildCommand()
         val process = startProcess(command, errorOut, debugOut)
@@ -154,7 +159,7 @@ open class RunGradle : DefaultTask() {
     }
 
     private fun buildScript(): String {
-        val runsOnWindows = OperatingSystem.current().isWindows()
+        val runsOnWindows = OperatingSystem.current().isWindows
         return if (runsOnWindows) "gradlew.bat" else "gradlew"
     }
 
@@ -165,4 +170,11 @@ open class RunGradle : DefaultTask() {
             .redirectError(errorOut)
             .redirectOutput(debugOut)
             .start()
+}
+
+private fun File.truncate() {
+    val stream = FileOutputStream(this)
+    stream.use {
+        it.channel.truncate(0)
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
@@ -57,7 +57,7 @@ import org.gradle.kotlin.dsl.get
  *     }
  * }
  * ```
- * Using the same code under `subprojects` in a root build file does not seem work because
+ * Using the same code under `subprojects` in a root build file does not seem to work because
  * test descriptor set files are not copied to resources. Performing this configuration from
  * subprojects solves the issue.
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/protobuf/ProtoTaskExtensions.kt
@@ -34,9 +34,9 @@ import org.gradle.kotlin.dsl.get
 /**
  * Configures protobuf code generation task.
  *
- * The task configuration consists of the following steps.
+ * The task configuration consists of the following steps:
  *
- * 1. Generation of descriptor set file is turned op for each source set.
+ * 1. Generation of descriptor set file is turned on for each source set.
  *    These files are placed under the `build/descriptors` directory.
  *
  * 2. At the final steps of the code generation, the code belonging to

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -75,7 +75,7 @@ fun implementationTitle() = "${project.group}:$artifactPrefix${project.name}"
 /**
  * The name of the manifest attribute holding the timestamp of the build.
  */
-val BUILD_TIMESTAMP = "Build-Timestamp"
+val buildTimestampAttr = "Build-Timestamp"
 
 /**
  * The attributes we put into the JAR manifest.
@@ -85,7 +85,7 @@ val BUILD_TIMESTAMP = "Build-Timestamp"
  */
 val manifestAttributes = mapOf(
     "Built-By" to prop("user.name"),
-    BUILD_TIMESTAMP to currentTime(),
+    buildTimestampAttr to currentTime(),
     "Created-By" to "Gradle ${gradle.gradleVersion}",
     "Build-Jdk" to buildJdk(),
     "Build-OS" to buildOs(),
@@ -150,7 +150,7 @@ tasks.jar {
 }
 
 /**
- * Makes Gradle ignore the [BUILD_TIMESTAMP] attribute during normalization.
+ * Makes Gradle ignore the [buildTimestampAttr] attribute during normalization.
  *
  * See [Java META-INF normalization](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:meta_inf_normalization)
  * section of the Gradle documentation for details.
@@ -158,7 +158,7 @@ tasks.jar {
 normalization {
     runtimeClasspath {
         metaInf {
-            ignoreAttribute(BUILD_TIMESTAMP)
+            ignoreAttribute(buildTimestampAttr)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -40,7 +40,7 @@ plugins {
 }
 
 /**
- * Obtains a string value of a [Sysmtem] property with the given key.
+ * Obtains a string value of a [System] property with the given key.
  */
 fun prop(key: String): String = System.getProperties()[key].toString()
 
@@ -66,7 +66,7 @@ val spinePublishing = rootProject.the<SpinePublishing>()
 val artifactPrefix = spinePublishing.artifactPrefix
 
 /**
- * Obtains the imlementation title for the project using project group,
+ * Obtains the implementation title for the project using project group,
  * artifact prefix from [SpinePublishing], and the name of the project to which
  * this script plugin is applied.
  */
@@ -153,7 +153,7 @@ tasks.jar {
  * Makes Gradle ignore the [BUILD_TIMESTAMP] attribute during normalization.
  *
  * See [Java META-INF normalization](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:meta_inf_normalization)
- * sectio of the Gradle documentation for details.
+ * section of the Gradle documentation for details.
  */
 normalization {
     runtimeClasspath {

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.internal.gradle.publish.SpinePublishing
+import java.nio.file.Files.createDirectories
+import java.nio.file.Files.createFile
+import java.text.SimpleDateFormat
+import java.util.*
+import java.util.jar.Attributes.Name.IMPLEMENTATION_TITLE
+import java.util.jar.Attributes.Name.IMPLEMENTATION_VENDOR
+import java.util.jar.Attributes.Name.IMPLEMENTATION_VERSION
+import java.util.jar.Attributes.Name.MANIFEST_VERSION
+import java.util.jar.Manifest
+
+plugins {
+    java
+}
+
+/**
+ * Obtains a string value of a [Sysmtem] property with the given key.
+ */
+fun prop(key: String): String = System.getProperties()[key].toString()
+
+/**
+ * Obtains the current time in UTC using ISO 8601 format.
+ */
+fun currentTime(): String = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(Date())
+
+/**
+ * Obtains the information on the JDK used for the build.
+ */
+fun buildJdk(): String =
+    "${prop("java.version")} (${prop("java.vendor")} ${prop("java.vm.version")})"
+
+/**
+ * Obtains the information on the operating system used for the build.
+ */
+fun buildOs(): String =
+    "${prop("os.name")} ${prop("os.arch")} ${prop("os.version")}"
+
+/** The publishing settings from the root project. */
+val spinePublishing = rootProject.the<SpinePublishing>()
+val artifactPrefix = spinePublishing.artifactPrefix
+
+/**
+ * Obtains the imlementation title for the project using project group,
+ * artifact prefix from [SpinePublishing], and the name of the project to which
+ * this script plugin is applied.
+ */
+fun implementationTitle() = "${project.group}:$artifactPrefix${project.name}"
+
+/**
+ * The name of the manifest attribute holding the timestamp of the build.
+ */
+val BUILD_TIMESTAMP = "Build-Timestamp"
+
+/**
+ * The attributes we put into the JAR manifest.
+ *
+ * This map is shared between the [exposeManifestForTests] task and the action which
+ * customizes the [Jar] task below.
+ */
+val manifestAttributes = mapOf(
+    "Built-By" to prop("user.name"),
+    BUILD_TIMESTAMP to currentTime(),
+    "Created-By" to "Gradle ${gradle.gradleVersion}",
+    "Build-Jdk" to buildJdk(),
+    "Build-OS" to buildOs(),
+    IMPLEMENTATION_TITLE.toString() to implementationTitle(),
+    IMPLEMENTATION_VERSION.toString() to project.version,
+    IMPLEMENTATION_VENDOR.toString() to "TeamDev"
+)
+
+/**
+ * Creates a manifest file in `resources` so that it is available for the tests.
+ *
+ * This task does the same what does the block which configures the `tasks.jar` below.
+ * We cannot use the manifest file created by the `Jar` task because it's not visible
+ * when running tests. We cannot depend on the `Jar` from `resources` because it would
+ * form a circular dependency.
+ */
+val exposeManifestForTests by tasks.creating {
+
+    val outputFile = layout.buildDirectory.file("resources/main/META-INF/MANIFEST.MF")
+    outputs.file(outputFile).withPropertyName("manifestFile")
+
+    fun createManifest(): Manifest {
+        val manifest = Manifest()
+
+        // The manifest version attribute is crucial for writing.
+        // It it's absent nothing would be written.
+        manifest.mainAttributes[MANIFEST_VERSION] = "1.0"
+
+        manifestAttributes.forEach { entry ->
+            manifest.mainAttributes.putValue(entry.key, entry.value.toString())
+        }
+        return manifest
+    }
+
+    fun writeManifest(manifest: Manifest) {
+        val file = outputFile.get().getAsFile()
+        val path = file.toPath()
+        createDirectories(path.parent)
+        if (!file.exists()) {
+            createFile(path)
+        }
+        val stream = file.outputStream()
+        stream.use {
+            manifest.write(stream)
+        }
+    }
+
+    doLast {
+        val manifest = createManifest()
+        writeManifest(manifest)
+    }
+}
+
+tasks.processResources {
+    dependsOn(exposeManifestForTests)
+}
+
+tasks.jar {
+    manifest {
+        attributes(manifestAttributes)
+    }
+}
+
+/**
+ * Makes Gradle ignore the [BUILD_TIMESTAMP] attribute during normalization.
+ *
+ * See [Java META-INF normalization](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:meta_inf_normalization)
+ * sectio of the Gradle documentation for details.
+ */
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute(BUILD_TIMESTAMP)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds storing of necessary attributes is done by the script plugin `write-manifest.gradle.kts` which should be applied to each subproject which needs version information. It was previously [introduced in `tool-base`](https://github.com/SpineEventEngine/tool-base/pull/21).
 
It also brings stability improvements for running under Windows:
 * `GitHubPackages.kt` was modified to extract the ZIP archive using the [zip4j](https://github.com/srikanth-lingala/zip4j) library, instead of using `unzip` command line utility which is not available in vanilla Windows.
 * `RunGradle.kt` was modified to use the `_out` directory instead of `build`. Using `build` for debug output of processes created by `ProcessBuilder` failed the `clean` command under Windows because of files already opened in the directory.
