### PR TITLE
Force Jackson dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -52,6 +52,10 @@ object Dokka {
         const val lib = "${group}:dokka-base:${version}"
     }
 
+    object CorePlugin {
+        const val lib = "${group}:dokka-core:${version}"
+    }
+
     /**
      * To generate the documentation as seen from Java perspective use this plugin.
      *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -40,6 +40,7 @@ import io.spine.internal.dependency.Gson
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.J2ObjC
 import io.spine.internal.dependency.JUnit
+import io.spine.internal.dependency.Jackson
 import io.spine.internal.dependency.Kotlin
 import io.spine.internal.dependency.Okio
 import io.spine.internal.dependency.Plexus
@@ -120,7 +121,14 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
         Okio.lib,
         CommonsCli.lib,
         CheckerFramework.compatQual,
-        CommonsLogging.lib
+        CommonsLogging.lib,
+        Jackson.databind,
+        Jackson.core,
+        Jackson.dataformatXml,
+        Jackson.dataformatYaml,
+        Jackson.moduleKotlin,
+        Jackson.bom,
+        Jackson.annotations
     )
 }
 


### PR DESCRIPTION
This PR enforces the version of the `jackson`-related dependencies. Dokka is dependent on [`jackson-databind@2.12.4`](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.12.4), which has a critical vulnerability. To avoid this vulnerability the version is forced to the `2.13.2.2` for `jackson-databind` and to the `2.13.2` for all other `jackson`-related dependencies.

Also, the `Dokka.CorePlugin` dependency object was created. The dependency is used in `dokka-tools`, but it does not have a typed wrapper.