### PR TITLE
Bump `spine-dokka-extensions`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -76,7 +76,7 @@ object Dokka {
     object SpineExtensions {
         private const val group = "io.spine.tools"
 
-        const val version = "2.0.0-SNAPSHOT.3"
+        const val version = "2.0.0-SNAPSHOT.4"
         const val lib = "${group}:spine-dokka-extensions:${version}"
     }
 }


### PR DESCRIPTION
This PR bumps `spine-dokka-extensions` to `2.0.0-SNAPSHOT.4`.