### PR TITLE
Fix the publish-documentation script

### DIFF
--- a/scripts/publish-documentation/publish.sh
+++ b/scripts/publish-documentation/publish.sh
@@ -55,7 +55,7 @@ if [ -z "$repositoryUrl" ] || [ -z "$tags" ] || [ -z "$modules" ]; then
 fi
 
 mkdir "workspace" && cd "workspace" || exit 2 # Folder does not exist.
-git clone --branch="1.x-dev" "$repositoryUrl" "."
+git clone "$repositoryUrl" "."
 
 log() {
   echo "-----------------$1-----------------"


### PR DESCRIPTION
This PR fixes a problem with the publish-documentation script. It removes the redundant checkout of the `1.x-dev` branch. This checkout is not required to fulfil the script's purpose. Moreover, it breaks the script if there is no such branch in the target repository.