### PR TITLE
Support nested modules when publishing Dokka documentation

### DIFF
--- a/scripts/publish-documentation/README.md
+++ b/scripts/publish-documentation/README.md
@@ -30,7 +30,7 @@ Prerequisites for running the script:
 
 The script should be launched from this directory and follow the template provided below:
 ```Bash
-./publish.sh repositoryUrl='' tags='x,y,*z' paths='x,foo/y,z'
+./publish.sh repositoryUrl='' tags='x,*y,z' paths='foo,bar/baz'
 ```
 
 Description of parameters:
@@ -38,7 +38,7 @@ Description of parameters:
 * `tags` - a list of comma-separated git tags. A tag marked with an asterisk is considered 'primary'. 
    A tag without it is considered 'secondary'.
 * `paths` - a list of comma-separated paths to modules. A path should be using the Unix file separator("/"). 
-   A path is considered relative to the root of the repository, i.e. for a root-level module the path 
+   A path is considered relative to the root of the repository, i.e. for a root-level module, the path 
    is just the name of the module.
 
 An example is provided below:

--- a/scripts/publish-documentation/README.md
+++ b/scripts/publish-documentation/README.md
@@ -30,18 +30,20 @@ Prerequisites for running the script:
 
 The script should be launched from this directory and follow the template provided below:
 ```Bash
-./publish.sh repositoryUrl='' tags='x,y,*z' modules='x,y,z'
+./publish.sh repositoryUrl='' tags='x,y,*z' paths='x,foo/y,z'
 ```
 
 Description of parameters:
 * `repositoryUrl` - a GitHub HTTPS URL.
 * `tags` - a list of comma-separated git tags. A tag marked with an asterisk is considered 'primary'. 
    A tag without it is considered 'secondary'.
-* `modules` - a list of comma-separated module names.
+* `paths` - a list of comma-separated paths to modules. A path should be using the Unix file separator("/"). 
+   A path is considered relative to the root of the repository, i.e. for a root-level module the path 
+   is just the name of the module.
 
 An example is provided below:
 ```Bash
-./publish.sh repositoryUrl='https://github.com/SpineEventEngine/core-java.git' tags='v1.7.0,*v1.8.0' modules='core,client'
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/base.git' tags='v1.7.0,*v1.8.0' paths='base,tools/proto-js-plugin'
 ```
 
 After running the example, the following happens:
@@ -53,20 +55,20 @@ After running the example, the following happens:
     /(root)
     └───dokka-reference
     │   │
-    │   └───client
+    │   └───base
     │   │   └───v
     │   │       └───1.7.0
-    │   │           │   client
+    │   │           │   base
     │   │           │   images
     │   │           │   scripts
     │   │           │   styles
     │   │           │   index.html
     │   │           │   navigation.html
     │   │
-    │   └───server
+    │   └───proto-js-plugin
     │       └───v
     │           └───1.7.0
-    │               │   server
+    │               │   proto-js-plugin
     │               │   images
     │               │   scripts
     │               │   styles
@@ -82,8 +84,8 @@ After running the example, the following happens:
     /(root)
     └───dokka-reference
     │   │
-    │   └───client
-    │   │   │   client
+    │   └───base
+    │   │   │   base
     │   │   │   images
     │   │   │   scripts
     │   │   │   styles
@@ -92,7 +94,7 @@ After running the example, the following happens:
     │   │   │
     │   │   └───v
     │   │       └───1.7.0
-    │   │       │    │   client
+    │   │       │    │   base
     │   │       │    │   images
     │   │       │    │   scripts
     │   │       │    │   styles
@@ -100,15 +102,15 @@ After running the example, the following happens:
     │   │       │    │   navigation.html
     │   │       │   
     │   │       └───1.8.0
-    │   │           │   client
+    │   │           │   base
     │   │           │   images
     │   │           │   scripts
     │   │           │   styles
     │   │           │   index.html
     │   │           │   navigation.html
     │   │
-    │   └───server
-    │       │   server
+    │   └───proto-js-plugin
+    │       │   proto-js-plugin
     │       │   images
     │       │   scripts
     │       │   styles
@@ -117,7 +119,7 @@ After running the example, the following happens:
     │       │
     │       └───v
     │           └───1.7.0
-    │           │    │   server
+    │           │    │   proto-js-plugin
     │           │    │   images
     │           │    │   scripts
     │           │    │   styles
@@ -125,7 +127,7 @@ After running the example, the following happens:
     │           │    │   navigation.html
     │           │   
     │           └───1.8.0
-    │               │   server
+    │               │   proto-js-plugin
     │               │   images
     │               │   scripts
     │               │   styles

--- a/scripts/publish-documentation/publish.sh
+++ b/scripts/publish-documentation/publish.sh
@@ -54,11 +54,6 @@ if [ -z "$repositoryUrl" ] || [ -z "$tags" ] || [ -z "$paths" ]; then
     exit 22 # Invalid argument
 fi
 
-# Extracts the module name from a path. A path should use the "/" as a file separator.
-moduleNameFromPath() {
-  return "${1##*\/}"
-}
-
 mkdir "workspace" && cd "workspace" || exit 2 # Folder does not exist.
 git clone "$repositoryUrl" "."
 
@@ -97,7 +92,7 @@ do
 
   for path in $(echo "$paths" | tr "," "\n")
   do
-      # Extracts the module name from a path. A path should use the "/" as a file separator
+      # Extracts the module name from a path. A path should use the "/" as a file separator.
       module="${path##*\/}"
       log "Started working on the \`$module\` module."
 
@@ -123,7 +118,7 @@ do
 
   for path in $(echo "$paths" | tr "," "\n")
   do
-    # Extracts the module name from a path. A path should use the "/" as a file separator
+    # Extracts the module name from a path. A path should use the "/" as a file separator.
     module="${path##*\/}"
 
     mkdir -p "dokka-reference/$module/v/$version"

--- a/scripts/publish-documentation/publish.sh
+++ b/scripts/publish-documentation/publish.sh
@@ -26,7 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 PRIMARY_MARK="*"
-USAGE_TEMPLATE="Usage: publish.sh repositoryUrl='' tags='x,${PRIMARY_MARK}y,z' paths='x,y,z'"
+USAGE_TEMPLATE="Usage: publish.sh repositoryUrl='' tags='x,${PRIMARY_MARK}y,z' paths='foo,bar/baz'"
 USAGE_EXAMPLE="Example: publish.sh repositoryUrl='https://github.com/SpineEventEngine/base.git' tags='v1.7.0,${PRIMARY_MARK}v1.8.0' paths='base,tools/proto-js-plugin'"
 
 # Check that exactly three parameters were provided.

--- a/scripts/publish-documentation/publish.sh
+++ b/scripts/publish-documentation/publish.sh
@@ -63,7 +63,7 @@ mkdir "workspace" && cd "workspace" || exit 2 # Folder does not exist.
 git clone "$repositoryUrl" "."
 
 # Create the `gh-pages` branch if it does not exist.
-if ! [[ $(git branch --list gh-pages) ]]; then
+if ! [[ $(git branch --list --all origin/gh-pages) ]]; then
   git switch --orphan gh-pages
   git commit --allow-empty -m "Initial commit"
   git push -u origin gh-pages


### PR DESCRIPTION
### Main changes

This PR adds support for nested modules in the script for publishing Dokka documentation. This is done by changing the API  of the script, so it operates with paths to modules instead of module names. 

### Additional changes

Also, this PR fixes a minor flaw with creating the `gh-pages` if it does not exist. The problem was with the script looking only through local branches which leads to the branch being created even if a remote one already exists.

