### PR TITLE
Add margin to code blocks in Dokka documentation

### DIFF
--- a/buildSrc/src/main/resources/dokka/styles/custom-styles.css
+++ b/buildSrc/src/main/resources/dokka/styles/custom-styles.css
@@ -46,3 +46,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+.symbol.monospace.block {
+    margin: 10px;
+}


### PR DESCRIPTION
This PR fixes a minor flaw with code blocks sticking to each other in Dokka's output. 

Before:
![Before](https://user-images.githubusercontent.com/54888768/174023398-6f87e3f4-62e6-4258-abf8-6a8865e16ea6.png)
After:
![After](https://user-images.githubusercontent.com/54888768/174023953-3e5fd241-7e6c-418e-8c26-4f557f961022.png)
