### PR TITLE
Use idiomatic Kotlin preconditions

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Config.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Config.kt
@@ -46,14 +46,8 @@ class Config {
              *         string.
              */
             fun of(name: String, email: String): User {
-                Preconditions.checkArgument(
-                    name.isNotBlank(),
-                    "Name cannot be an empty string."
-                )
-                Preconditions.checkArgument(
-                    email.isNotBlank(),
-                    "Email cannot be an empty string."
-                )
+                check(name.isNotBlank()) { "Name cannot be an empty string." }
+                check(email.isNotBlank()) { "Email cannot be an empty string." }
 
                 return User(name, email)
             }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
@@ -60,11 +60,12 @@ class Repository : AutoCloseable {
      *
      * This configuration determines what ends up in author and commiter fields of a commit.
      */
-    var user: Config.User
+    var user: UserInfo
         get() = field
         private set(value) {
             field = value
         }
+
     /**
      * Currently checked out branch.
      */
@@ -75,7 +76,7 @@ class Repository : AutoCloseable {
         }
 
 
-    private constructor(sshUrl: String, user: Config.User, branch: String) {
+    private constructor(sshUrl: String, user: UserInfo, branch: String) {
         this.sshUrl = sshUrl
         this.user = user
         this.currentBranch = branch
@@ -110,7 +111,7 @@ class Repository : AutoCloseable {
      * values from [user]. These settings determine what ends up in author and
      * commiter fields of a commit.
      */
-    fun configureUser(user: Config.User) {
+    fun configureUser(user: UserInfo) {
         repoExecute("git", "config", "user.name", user.name)
         repoExecute("git", "config", "user.email", user.email)
 
@@ -158,14 +159,14 @@ class Repository : AutoCloseable {
          *
          * @throws IllegalArgumentException if SSH URL is an empty string.
          */
-        fun of(sshUrl: String, user: Config.User, branch: String = Branch.master): Repository {
+        fun of(sshUrl: String, user: UserInfo, branch: String = Branch.master): Repository {
             check(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }
 
             val repo = Repository(sshUrl, user, branch)
             repo.clone()
             repo.configureUser(user)
 
-            if(branch != Branch.master) {
+            if (branch != Branch.master) {
                 repo.checkout(branch)
             }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
@@ -26,7 +26,6 @@
 
 package io.spine.internal.gradle.git
 
-import com.google.common.base.Preconditions
 import io.spine.internal.gradle.Cli
 import io.spine.internal.gradle.fs.LazyTempPath
 
@@ -160,10 +159,7 @@ class Repository : AutoCloseable {
          * @throws IllegalArgumentException if SSH URL is an empty string.
          */
         fun of(sshUrl: String, user: Config.User, branch: String = Branch.master): Repository {
-            Preconditions.checkArgument(
-                !sshUrl.isBlank(),
-                "SSH URL cannot be an empty string."
-            )
+            check(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }
 
             val repo = Repository(sshUrl, user, branch)
             repo.clone()

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -26,31 +26,23 @@
 
 package io.spine.internal.gradle.git
 
-import com.google.api.client.util.Preconditions
-
 /**
- * Wrapper for different Git settings.
+ * Encapsulates `user.name` and `user.email` settings. These settings determine
+ * what ends up in author and commiter fields of a commit.
  */
-class Config {
+data class UserInfo private constructor(val name: String, val email: String) {
+    companion object Factory {
+        /**
+         * Validates provided parameters and constructs a [UserInfo] object.
+         *
+         * @throws IllegalArgumentException if the name or the email is an empty
+         *         string.
+         */
+        fun of(name: String, email: String): UserInfo {
+            check(name.isNotBlank()) { "Name cannot be an empty string." }
+            check(email.isNotBlank()) { "Email cannot be an empty string." }
 
-    /**
-     * Encapsulates `user.name` and `user.email` settings. These settings determine
-     * what ends up in author and commiter fields of a commit.
-     */
-    data class User private constructor(val name: String, val email: String) {
-        companion object Factory{
-            /**
-             * Validates provided parameters and constructs a [User] object.
-             *
-             * @throws IllegalArgumentException if the name or the email is an empty
-             *         string.
-             */
-            fun of(name: String, email: String): User {
-                check(name.isNotBlank()) { "Name cannot be an empty string." }
-                check(email.isNotBlank()) { "Email cannot be an empty string." }
-
-                return User(name, email)
-            }
+            return UserInfo(name, email)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.gradle.git
 
 /**
- * Contains infromation about a Git user.
+ * Contains information about a Git user.
  *
  * Determines the author and committer fields of a commit.
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -27,8 +27,9 @@
 package io.spine.internal.gradle.git
 
 /**
- * Encapsulates `user.name` and `user.email` settings. These settings determine
- * what ends up in author and commiter fields of a commit.
+ * Contains infromation about a Git user.
+ *
+ * Determines the author and committer fields of a commit.
  */
 data class UserInfo private constructor(val name: String, val email: String) {
     companion object Factory {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -32,6 +32,7 @@ package io.spine.internal.gradle.git
  * Determines the author and committer fields of a commit.
  */
 data class UserInfo private constructor(val name: String, val email: String) {
+
     companion object Factory {
         /**
          * Validates provided parameters and constructs a [UserInfo] object.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
@@ -28,8 +28,8 @@ package io.spine.internal.gradle.github.pages
 
 import io.spine.internal.gradle.RepoSlug
 import io.spine.internal.gradle.git.Branch
-import io.spine.internal.gradle.git.Config
 import io.spine.internal.gradle.git.Repository
+import io.spine.internal.gradle.git.UserInfo
 
 /**
  * Clones the current project repository with the branch dedicated to publishing
@@ -50,7 +50,7 @@ internal fun Repository.Factory.forPublishingDocumentation(): Repository {
 
     val username = "UpdateGitHubPages Plugin"
     val userEmail = AuthorEmail.fromVar().toString()
-    val user = Config.User.Factory.of(username, userEmail)
+    val user = UserInfo.Factory.of(username, userEmail)
 
     val branch = Branch.documentation
 


### PR DESCRIPTION
This PR addresses #383. 

The main issue was with using `com.google.api.client.util.Preconditions.checkArgument` in `io.spine.internal.gradle.git` package. Firstly, there is a built-in Kotlin function for doing the same thing. Secondly, this `checkArgument` depends on the Google API client library rather than Guava. This PR fixes this.

Also, there was a naming issue with `io.spine.internal.gradle.git.Config`. This PR removes the excessive nesting and leaves only the setting needed for our current needs.