### PR TITLE
Fix issues with `io.spine.internal.gradle.git`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
@@ -157,10 +157,10 @@ class Repository : AutoCloseable {
          * documentation for more information. Performs checkout of the branch in
          * case it was passed. By default, [master][Branch.master] is checked out.
          *
-         * @throws IllegalStateException if SSH URL is an empty string.
+         * @throws IllegalArgumentException if SSH URL is an empty string.
          */
         fun of(sshUrl: String, user: UserInfo, branch: String = Branch.master): Repository {
-            check(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }
+            require(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }
 
             val repo = Repository(sshUrl, user, branch)
             repo.clone()

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Repository.kt
@@ -157,7 +157,7 @@ class Repository : AutoCloseable {
          * documentation for more information. Performs checkout of the branch in
          * case it was passed. By default, [master][Branch.master] is checked out.
          *
-         * @throws IllegalArgumentException if SSH URL is an empty string.
+         * @throws IllegalStateException if SSH URL is an empty string.
          */
         fun of(sshUrl: String, user: UserInfo, branch: String = Branch.master): Repository {
             check(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -30,21 +30,13 @@ package io.spine.internal.gradle.git
  * Contains information about a Git user.
  *
  * Determines the author and committer fields of a commit.
+ *
+ * @constructor throws an [IllegalStateException] if the provided name
+ *              or the email is an empty string.
  */
-data class UserInfo private constructor(val name: String, val email: String) {
-
-    companion object Factory {
-        /**
-         * Validates provided parameters and constructs a [UserInfo] object.
-         *
-         * @throws IllegalArgumentException if the name or the email is an empty
-         *         string.
-         */
-        fun of(name: String, email: String): UserInfo {
-            check(name.isNotBlank()) { "Name cannot be an empty string." }
-            check(email.isNotBlank()) { "Email cannot be an empty string." }
-
-            return UserInfo(name, email)
-        }
+data class UserInfo(val name: String, val email: String) {
+    init {
+        check(name.isNotBlank()) { "Name cannot be an empty string." }
+        check(email.isNotBlank()) { "Email cannot be an empty string." }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -31,12 +31,12 @@ package io.spine.internal.gradle.git
  *
  * Determines the author and committer fields of a commit.
  *
- * @constructor throws an [IllegalStateException] if the name or the email
+ * @constructor throws an [IllegalArgumentException] if the name or the email
  *              is an empty string.
  */
 data class UserInfo(val name: String, val email: String) {
     init {
-        check(name.isNotBlank()) { "Name cannot be an empty string." }
-        check(email.isNotBlank()) { "Email cannot be an empty string." }
+        require(name.isNotBlank()) { "Name cannot be an empty string." }
+        require(email.isNotBlank()) { "Email cannot be an empty string." }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/UserInfo.kt
@@ -31,8 +31,8 @@ package io.spine.internal.gradle.git
  *
  * Determines the author and committer fields of a commit.
  *
- * @constructor throws an [IllegalStateException] if the provided name
- *              or the email is an empty string.
+ * @constructor throws an [IllegalStateException] if the name or the email
+ *              is an empty string.
  */
 data class UserInfo(val name: String, val email: String) {
     init {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
@@ -50,7 +50,7 @@ internal fun Repository.Factory.forPublishingDocumentation(): Repository {
 
     val username = "UpdateGitHubPages Plugin"
     val userEmail = AuthorEmail.fromVar().toString()
-    val user = UserInfo.Factory.of(username, userEmail)
+    val user = UserInfo(username, userEmail)
 
     val branch = Branch.documentation
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
@@ -45,7 +45,7 @@ fun Task.updateGhPages(project: Project) {
         SshKey(rootFolder).register()
     }
 
-    val repository = Repository.Factory.forPublishingDocumentation()
+    val repository = Repository.forPublishingDocumentation()
 
     val updateJavadoc = with(plugin) {
         UpdateJavadoc(project, javadocOutputFolder, repository, logger)


### PR DESCRIPTION
This PR continues fixing issues with `io.spine.internal.gradle.git`. More specifically, it addresses comments of @alexander-yevsyukov in the #384 after it was merged. 

The first issue was using factory methods the following way `ClassName.Factory.of`. At the time of development, IDEA did not allow traversing from a companion object's documentation to the enclosing class' documentation. It seemed reasonable to state the `Factory` part explicitly. Currently, there is no such issue, so this part is removed.

The second issue was with the `UserInfo` factory method. This factory method, at this point, can be reduced to a simple validation in the `init{}` block. 