### PR TITLE
Use constants in the `Branch` object

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Branch.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Branch.kt
@@ -31,10 +31,10 @@ package io.spine.internal.gradle.git
  */
 object Branch {
 
-    val master = "master"
+    const val master = "master"
 
     /**
      * The branch used for publishing documentation to GitHub Pages.
      */
-    val documentation = "gh-pages"
+    const val documentation = "gh-pages"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Branch.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/git/Branch.kt
@@ -31,6 +31,9 @@ package io.spine.internal.gradle.git
  */
 object Branch {
 
+    /**
+     * The default branch.
+     */
     const val master = "master"
 
     /**


### PR DESCRIPTION
This PR addresses #386. 

This PR adds missing `const` to members of the `io.spine.internal.gradle.git.Branch` and documentation for the `Branch.master`.