### PR TITLE
Improve filtering for generated code

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -62,7 +62,7 @@ val grGitVersion = "3.1.1"
  * Please check that this value matches one defined in
  *  [io.spine.internal.dependency.Kotlin.version].
  */
-val kotlinVersion = "1.6.21"
+val kotlinVersion = "1.7.20"
 
 /**
  * The version of Guava used in `buildSrc`.
@@ -90,7 +90,7 @@ val errorProneVersion = "2.0.2"
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.8.18"
+val protobufPluginVersion = "0.8.19"
 
 /**
  * The version of Dokka Gradle Plugins.
@@ -100,7 +100,7 @@ val protobufPluginVersion = "0.8.18"
  * @see <a href="https://github.com/Kotlin/dokka/releases">
  *     Dokka Releases</a>
  */
-val dokkaVersion = "1.6.21"
+val dokkaVersion = "1.7.10"
 
 configurations.all {
     resolutionStrategy {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -142,7 +142,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 
-    implementation("gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion")
+    implementation("com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}")
     implementation("org.jetbrains.dokka:dokka-base:${dokkaVersion}")
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -30,5 +30,5 @@ package io.spine.internal.dependency
 // See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
 @Suppress("unused")
 object CheckStyle {
-    const val version = "10.1"
+    const val version = "10.3.4"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -35,7 +35,7 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.6.21"
+    const val version = "1.7.10"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -33,7 +33,7 @@ object Kotlin {
     * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
     */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.6.21"
+    const val version      = "1.7.20"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.20.1"
+    const val version       = "3.21.6"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",
@@ -46,7 +46,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.8.18"
+        const val version = "0.8.19"
         const val id = "com.google.protobuf"
         const val lib = "${group}:protobuf-gradle-plugin:${version}"
     }

--- a/quality/checkstyle-suppressions.xml
+++ b/quality/checkstyle-suppressions.xml
@@ -32,7 +32,11 @@
 
 <suppressions>
 
-    <!-- Suppress all checks for the Protobuf-generated files. -->
+    <!-- Suppress all checks for the Protobuf-generated files.
+         This is a double measure, since these files are excluded at the configuration level.
+         See `checkstyle.xml` and `BeforeExecutionExclusionFileFilter` configuration for details.
+     -->
     <suppress files=".*[\\/]generated[\\/].*" checks=".*"/>
+    <suppress files=".*[\\/]generated-proto[\\/].*" checks=".*"/>
 
 </suppressions>

--- a/quality/checkstyle.xml
+++ b/quality/checkstyle.xml
@@ -32,6 +32,16 @@
 
 <module name="Checker">
 
+    <!--  Exclude `generated` subdirectory for each module for being checked.  -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*[/\\]generated[/\\]*.$"/>
+    </module>
+
+    <!--  Exclude `generated-proto` subdirectory for each module for being checked.  -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*[/\\]generated-proto[/\\]*.$"/>
+    </module>
+
     <module name="SuppressWarningsFilter"/>
 
     <module name="SuppressionFilter">


### PR DESCRIPTION
This PR configures Checkstyle to ignore generated code.

Bumps dependencies (checked under `core-java`).
