### PR TITLE
Extend `Project` with `configureTaskDependencies()`

### DIFF
--- a/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -51,8 +51,8 @@ fun Project.configureTaskDependencies() {
     fun String.dependOn(taskName: String) {
         val whoDepends = this
         val dependOntoTask: Task? = tasks.findByName(taskName)
-        dependOntoTask?.apply {
-            tasks.findByName(whoDepends)?.dependsOn(this)
+        dependOntoTask?.let {
+            tasks.findByName(whoDepends)?.dependsOn(it)
         }
     }
 

--- a/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+/**
+ * Configures the dependencies between third-party Gradle tasks
+ * and those defined via ProtoData and Spine Model Compiler.
+ *
+ * It is required in order to avoid warnings in build logs, detecting the undeclared
+ * usage of Spine-specific task output by other tasks,
+ * e.g. the output of `launchProtoDataMain` is used by `compileKotlin`.
+ */
+@Suppress("unused")
+fun Project.configureTaskDependencies() {
+
+    /**
+     * Creates a dependency between the Gradle task of *this* name
+     * onto the task with `taskName`.
+     *
+     * If either of tasks does not exist in the enclosing `Project`,
+     * this method does nothing.
+     *
+     * This extension is kept local to `configureTaskDependencies` extension
+     * to prevent its direct usage from outside.
+     */
+    fun String.dependOn(taskName: String) {
+        val whoDepends = this
+        val dependOntoTask: Task? = tasks.findByName(taskName)
+        dependOntoTask?.apply {
+            tasks.findByName(whoDepends)?.dependsOn(this)
+        }
+    }
+
+    afterEvaluate {
+        "compileKotlin".dependOn("launchProtoDataMain")
+        "compileTestKotlin".dependOn("launchProtoDataTest")
+        "sourcesJar".dependOn("launchProtoDataMain")
+        "sourcesJar".dependOn("createVersionFile")
+        "dokkaHtml".dependOn("launchProtoDataMain")
+        "dokkaJavadoc".dependOn("launchProtoDataMain")
+        "publishPluginJar".dependOn("createVersionFile")
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/fs/LazyTempPath.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/fs/LazyTempPath.kt
@@ -54,17 +54,17 @@ class LazyTempPath(private val prefix: String) : Path {
             return tempPath
         }
 
-    override fun compareTo(other: Path?): Int = delegate.compareTo(other)
+    override fun compareTo(other: Path): Int = delegate.compareTo(other)
 
     override fun iterator(): MutableIterator<Path> = delegate.iterator()
 
     override fun register(
-        watcher: WatchService?,
-        events: Array<out WatchEvent.Kind<*>>?,
+        watcher: WatchService,
+        events: Array<out WatchEvent.Kind<*>>,
         vararg modifiers: WatchEvent.Modifier?
     ): WatchKey = delegate.register(watcher, events, *modifiers)
 
-    override fun register(watcher: WatchService?, vararg events: WatchEvent.Kind<*>?): WatchKey =
+    override fun register(watcher: WatchService, vararg events: WatchEvent.Kind<*>?): WatchKey =
         delegate.register(watcher, *events)
 
     override fun getFileSystem(): FileSystem = delegate.fileSystem

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/RepositoryExtensions.kt
@@ -42,7 +42,7 @@ import io.spine.internal.gradle.git.UserInfo
  * to "UpdateGitHubPages Plugin", and the email is derived from
  * the `FORMAL_GIT_HUB_PAGES_AUTHOR` environment variable.
  *
- * @throws GradleException if any of the environment variables described above
+ * @throws org.gradle.api.GradleException if any of the environment variables described above
  *         is not set.
  */
 internal fun Repository.Factory.forPublishingDocumentation(): Repository {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
@@ -75,7 +75,7 @@ private abstract class UpdateDocumentation(
      * The value should not contain any leading or trailing file separators.
      *
      * The absolute path to the project's documentation is made by appending its
-     * name to the end, making `/[docsDestinationFolder]/[project.name]`.
+     * name to the end, making `/docsDestinationFolder/project.name`.
      */
     protected abstract val docsDestinationFolder: String
 
@@ -86,25 +86,29 @@ private abstract class UpdateDocumentation(
      */
     protected abstract val toolName: String
 
-    private val mostRecentFolder = File("${repository.location}/${docsDestinationFolder}/${project.name}")
+    private val mostRecentFolder by lazy {
+        File("${repository.location}/${docsDestinationFolder}/${project.name}")
+    }
 
     fun run() {
-        logger.debug("Update of the ${toolName} documentation for module `${project.name}` started.")
+        val module = project.name
+        logger.debug("Update of the $toolName documentation for module `$module` started.")
 
         val documentation = replaceMostRecentDocs()
         copyIntoVersionDir(documentation)
 
-        val updateMessage = "Update ${toolName} documentation for module `${project.name}` as for " +
-                "version ${project.version}"
+        val version = project.version
+        val updateMessage = "Update $toolName documentation for module `$module` as for " +
+                "version $version"
         repository.commitAllChanges(updateMessage)
 
-        logger.debug("Update of the ${toolName} documentation for `${project.name}` successfully finished.")
+        logger.debug("Update of the $toolName documentation for `$module` successfully finished.")
     }
 
     private fun replaceMostRecentDocs(): ConfigurableFileCollection {
         val generatedDocs = project.files(docsSourceFolder)
 
-        logger.debug("Replacing the most recent ${toolName} documentation in ${mostRecentFolder}.")
+        logger.debug("Replacing the most recent $toolName documentation in ${mostRecentFolder}.")
         copyDocs(generatedDocs, mostRecentFolder)
 
         return generatedDocs
@@ -121,7 +125,7 @@ private abstract class UpdateDocumentation(
     private fun copyIntoVersionDir(generatedDocs: ConfigurableFileCollection) {
         val versionedDocDir = File("$mostRecentFolder/v/${project.version}")
 
-        logger.debug("Storing the new version of ${toolName} documentation in `${versionedDocDir}.")
+        logger.debug("Storing the new version of $toolName documentation in `${versionedDocDir}.")
         copyDocs(generatedDocs, versionedDocDir)
     }
 }


### PR DESCRIPTION
This PR adds extension function for tentatively add dependencies between tasks created by ProtoData and Spine Model Compiler that are otherwise cause Gradle warnings in the console.

This extension was tried under `core-java` and `ProtoData` already.