### PR TITLE
Simplify return statements in `Spine.kt`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -173,12 +173,10 @@ class Spine(p: ExtensionAware) {
  *         If `null` then rely on the property declaration, even if this would cause an error.
  */
 private fun String.asExtra(p: ExtensionAware, defaultValue: String? = null): String {
-    if (defaultValue != null) {
-        if (p.extra.has(this)) {
-            return p.extra[this] as String
-        }
-        return defaultValue
+    return if (defaultValue == null || p.extra.has(this)) {
+        p.extra[this] as String
+    } else {
+        defaultValue
     }
-    return p.extra[this] as String
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -173,7 +173,7 @@ class Spine(p: ExtensionAware) {
  *         If `null` then rely on the property declaration, even if this would cause an error.
  */
 private fun String.asExtra(p: ExtensionAware, defaultValue: String? = null): String {
-    return if (defaultValue == null || p.extra.has(this)) {
+    return if (p.extra.has(this) || defaultValue == null) {
         p.extra[this] as String
     } else {
         defaultValue


### PR DESCRIPTION
This PR refactors `String.asExtra()` to reduce the number of `return` statements (which causes detekt complains),