### PR TITLE
Bump dependencies

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,5 +39,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -50,7 +50,7 @@ repositories {
  * Please keep this value in sync. with `io.spine.internal.dependency.Jackson.version`.
  * It's not a requirement, but would be good in terms of consistency.
  */
-val jacksonVersion = "2.13.0"
+val jacksonVersion = "2.13.4"
 
 val googleAuthToolVersion = "2.1.2"
 val licenseReportVersion = "2.1"
@@ -100,7 +100,7 @@ val protobufPluginVersion = "0.8.19"
  * @see <a href="https://github.com/Kotlin/dokka/releases">
  *     Dokka Releases</a>
  */
-val dokkaVersion = "1.7.10"
+val dokkaVersion = "1.7.20"
 
 configurations.all {
     resolutionStrategy {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -35,7 +35,7 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.7.10"
+    const val version = "1.7.20"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -29,14 +29,14 @@ package io.spine.internal.dependency
 // https://junit.org/junit5/
 @Suppress("unused")
 object JUnit {
-    const val version                    = "5.8.2"
-    private const val platformVersion    = "1.8.2"
+    const val version                    = "5.9.1"
+    private const val platformVersion    = "1.9.1"
     private const val legacyVersion      = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
     private const val apiGuardianVersion = "1.1.2"
     // https://github.com/junit-pioneer/junit-pioneer
-    private const val pioneerVersion     = "1.5.0"
+    private const val pioneerVersion     = "1.7.1"
 
     const val legacy = "junit:junit:${legacyVersion}"
     val api = listOf(

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -26,22 +26,31 @@
 
 package io.spine.internal.dependency
 
+
 @Suppress("unused")
 object Jackson {
     const val version = "2.13.4"
-    const val databindVersion = "2.13.4.2"
+    private const val databindVersion = "2.13.4.2"
+
+    private const val coreGroup = "com.fasterxml.jackson.core"
+    private const val dataformatGroup = "com.fasterxml.jackson.dataformat"
+    private const val moduleGroup = "com.fasterxml.jackson.module"
+
     // https://github.com/FasterXML/jackson-core
-    const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
+    const val core = "$coreGroup:jackson-core:${version}"
     // https://github.com/FasterXML/jackson-databind
-    const val databind = "com.fasterxml.jackson.core:jackson-databind:${databindVersion}"
+    const val databind = "$coreGroup:jackson-databind:${databindVersion}"
+    // https://github.com/FasterXML/jackson-annotations
+    const val annotations = "$coreGroup:jackson-annotations:${version}"
+
     // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version}"
+    const val dataformatXml = "$dataformatGroup:jackson-dataformat-xml:${version}"
     // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatYaml = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version}"
+    const val dataformatYaml = "$dataformatGroup:jackson-dataformat-yaml:${version}"
+
     // https://github.com/FasterXML/jackson-module-kotlin/releases
-    const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:${version}"
+    const val moduleKotlin = "$moduleGroup:jackson-module-kotlin:${version}"
+
     // https://github.com/FasterXML/jackson-bom
     const val bom = "com.fasterxml.jackson:jackson-bom:${version}"
-    // https://github.com/FasterXML/jackson-annotations
-    const val annotations = "com.fasterxml.jackson.core:jackson-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,8 +28,8 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    const val version = "2.13.2"
-    const val databindVersion = "2.13.2.2"
+    const val version = "2.13.4"
+    const val databindVersion = "2.13.4.2"
     // https://github.com/FasterXML/jackson-core
     const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
     // https://github.com/FasterXML/jackson-databind

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.21.7"
+    const val version       = "3.19.6"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -106,7 +106,7 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoDataVersion = "0.2.18"
+        const val protoDataVersion = "0.2.20"
     }
 
     val base = "$group:spine-base:${p.baseVersion}"


### PR DESCRIPTION
This PR updates dependencies:
  * Protobuf was rolled back to `3.19.6` to address the absence of access modifiers in the generated code, so that the code can be used in projects with strict API mode.
  * Jackson Databind and Jackson were bumed to address security reports.
  * Dokka was bumped to `1.7.20`, the usability of this version was [tested under ProtoData](https://github.com/SpineEventEngine/ProtoData/pull/93).
  * JUnit dependencies were bumed to latest release versions, allowing to use configurable `@TempDir` annotation.
  * ProtoData was bumped to `0.2.20` so that projects can use Kotlin code gen (when [this PR](https://github.com/SpineEventEngine/ProtoData/pull/93) is merged).
