### PR TITLE
Depend `sourceJar` on `prepareProtocConfigVersions`

### DIFF
--- a/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -62,6 +62,7 @@ fun Project.configureTaskDependencies() {
         "sourcesJar".dependOn("generateProto")
         "sourcesJar".dependOn("launchProtoDataMain")
         "sourcesJar".dependOn("createVersionFile")
+        "sourcesJar".dependOn("prepareProtocConfigVersions")
         "dokkaHtml".dependOn("generateProto")
         "dokkaHtml".dependOn("launchProtoDataMain")
         "dokkaJavadoc".dependOn("launchProtoDataMain")


### PR DESCRIPTION
This PR updates `buildSrc/.../deps-between-tasks.kt` to arrange conditional dependency of `sourceJar` on `prepareProtocConfigVersions`.

Some of the projects (like `mc-java`) need such a dependency, and this arrangement is needed to prevent accidental overwriting.