### PR TITLE
Use `mavenLocal()` for Spine artifacts only

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -204,9 +204,6 @@ fun RepositoryHandler.applyGitHubPackages(project: Project, vararg shortReposito
 @Suppress("unused")
 fun RepositoryHandler.applyStandard() {
 
-    gradlePluginPortal()
-    mavenLocal()
-
     val spineRepos = listOf(
         Repos.spine,
         Repos.spineSnapshots,
@@ -223,10 +220,13 @@ fun RepositoryHandler.applyStandard() {
             }
         }
 
-    mavenCentral()
     maven {
         url = URI(Repos.sonatypeSnapshots)
     }
+
+    mavenCentral()
+    gradlePluginPortal()
+    mavenLocal().includeSpineOnly()
 }
 
 /**


### PR DESCRIPTION
This PR:
  * Limits the artifacts to be found at `mavenLocal` to only `io.spine.*`.
  * Rearranges repositories under `applyStandard()` so that `mavenCentral()` comes first, and `mavenLocal()` last.

Hopefully it would make our builds run a bit faster.