### PR TITLE
Add Gradle Doctor, improve Spine

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,9 @@
 @file:Suppress("unused", "UnusedReceiverParameter")
 
 import io.spine.internal.dependency.ErrorProne
+import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Protobuf
+import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Spine.ProtoData
 import org.gradle.plugin.use.PluginDependenciesSpec
 
@@ -50,3 +52,9 @@ val PluginDependenciesSpec.errorPronePlugin: String
 
 val PluginDependenciesSpec.protobufPlugin: String
     get() = Protobuf.GradlePlugin.id
+
+val PluginDependenciesSpec.gradleDoctor: GradleDoctor
+    get() = GradleDoctor
+
+val PluginDependenciesSpec.mcJava: Spine.McJava
+    get() = Spine.McJava

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GradleDoctor.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GradleDoctor.kt
@@ -24,18 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-plugins {
-    id("config-tester")
-    id("detekt-code-analysis")
-    id(gradleDoctor.pluginId) version gradleDoctor.version
-}
+package io.spine.internal.dependency
 
-repositories {
-    mavenCentral()
-}
-
-detekt {
-    source.from("buildSrc/src/main/kotlin")
-    config = files("quality/detekt-config.yml")
-    baseline = file("detekt-baseline.xml")
+/**
+ * Helps optimize Gradle Builds by ensuring recommendations at build time.
+ *
+ * See [plugin site](https://runningcode.github.io/gradle-doctor) for features and usage.
+ */
+object GradleDoctor {
+    const val version = "0.8.1"
+    const val pluginId = "com.osacky.doctor"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -85,7 +85,7 @@ class Spine(p: ExtensionAware) {
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.104"
+        const val mcJava = "2.0.0-SNAPSHOT.105"
 
         /**
          * The version of `base-types` to use.
@@ -150,7 +150,24 @@ class Spine(p: ExtensionAware) {
     val pluginBase = "$toolsGroup:spine-plugin-base:${p.toolBaseVersion}"
     val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${p.toolBaseVersion}"
     val modelCompiler = "$toolsGroup:spine-model-compiler:${p.mcVersion}"
+
+    /**
+     * Coordinates of the McJava plugin bundle which uses version of the bundle
+     * from [ExtensionAware.mcJavaVersion] property.
+     *
+     * This property and [ExtensionAware.mcJavaVersion] are deprecated because
+     * we discourage using versions of Spine components outside of this dependency
+     * object class.
+     */
+    @Deprecated(message = "Please use `McJava.pluginLib` instead")
+    @Suppress("DEPRECATION")
     val mcJavaPlugin = "$toolsGroup:spine-mc-java-plugins:${p.mcJavaVersion}:all"
+
+    object McJava {
+        const val version = DefaultVersion.mcJava
+        const val pluginId = "io.spine.mc-java"
+        const val pluginLib = "$toolsGroup:spine-mc-java-plugins:${version}:all"
+    }
 
     /**
      *  Does not allow re-definition via a project property.
@@ -182,6 +199,7 @@ class Spine(p: ExtensionAware) {
     private val ExtensionAware.mcVersion: String
         get() = "mcVersion".asExtra(this, DefaultVersion.mc)
 
+    @Deprecated(message = "Please use `Spine.McJava` dependency object instead.")
     private val ExtensionAware.mcJavaVersion: String
         get() = "mcJavaVersion".asExtra(this, DefaultVersion.mcJava)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC


### PR DESCRIPTION
This PR adds dependency object for Gradle Doctor and improves `Spine` dependency object to handle McJava plugin.