### PR TITLE
Fix false-positive check for `.github` directory existence in `pull` script

### DIFF
--- a/pull
+++ b/pull
@@ -84,7 +84,7 @@ workflows_without_detekt=$(find .github/workflows -type f ! -name detekt-code-an
 cp -a "$workflows_without_detekt" ../.github/workflows
 cp -a .github-workflows/. ../.github/workflows
 
-ehcho "Cleaning up Gradle 'buildSrc' scripts"
+echo "Cleaning up Gradle 'buildSrc' scripts"
 # TODO:2022-11-02:yevhenii.nadtochii: Drop or update clean-up code below from time to time.
 rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
 rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt

--- a/pull
+++ b/pull
@@ -80,9 +80,9 @@ initialize .github
 
 # Update existing workflows with more recent versions
 echo "Updating GitHub workflows"
-workflows_without_detekt=$(find .github/workflows -type f ! -name detekt-code-analysis.yml)
-cp -a "$workflows_without_detekt" ../.github/workflows
 cp -a .github-workflows/. ../.github/workflows
+cp -a .github/workflows/. ../.github/workflows
+rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
 
 echo "Cleaning up Gradle 'buildSrc' scripts"
 # TODO:2022-11-02:yevhenii.nadtochii: Drop or update clean-up code below from time to time.

--- a/pull
+++ b/pull
@@ -68,7 +68,7 @@ cp .lift.toml ..
 # Copies the file or directory passed as the first parameter to the upper directory,
 # only if such a file or directory does not exist there.
 function initialize() {
-  if [ ! -f ../"$1" ]; then
+  if [ ! -e ../"$1" ]; then
       echo "Creating $1"
       cp -R "$1" ..
   fi


### PR DESCRIPTION
I've just discovered that `pull` script copies ignored `detekt-code-analysis` workflow while shouldn't.

This changeset fixes a function that checks for existence of the given file or directory. Now it uses `-e` operator.

From [internet](https://linuxize.com/post/bash-check-if-file-exists/):

>When checking if a file exists, the most commonly used FILE operators are -e and -f. The first one will check whether a file exists regardless of the type, while the second one will return true only if the FILE is a regular file (not a directory or a device).

Also, instead of copying filtered workflows, the script now copies them all and then deletes the one that belongs only to `config`. It is for the case, when `.github` directory copied from scratch by `initialize .github` line above.