### PR TITLE
Add `text` version

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -106,6 +106,13 @@ class Spine(p: ExtensionAware) {
         const val change = "2.0.0-SNAPSHOT.117"
 
         /**
+         * The version of `text` to use.
+         *
+         * @see Spine.text
+         */
+        const val text = "2.0.0-SNAPSHOT.1"
+
+        /**
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
@@ -143,9 +150,10 @@ class Spine(p: ExtensionAware) {
     val baseTypes = "$group:spine-base-types:${p.baseTypesVersion}"
     val time = "$group:spine-time:${p.timeVersion}"
     val change = "$group:spine-change:${p.changeVersion}"
+    val text = "$group:spine-text:${p.textVersion}"
 
     val testlib = "$toolsGroup:spine-testlib:${p.baseVersion}"
-    val testUtilTime = "io.spine.tools:spine-testutil-time:${p.timeVersion}"
+    val testUtilTime = "$toolsGroup:spine-testutil-time:${p.timeVersion}"
     val toolBase = "$toolsGroup:spine-tool-base:${p.toolBaseVersion}"
     val pluginBase = "$toolsGroup:spine-plugin-base:${p.toolBaseVersion}"
     val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${p.toolBaseVersion}"
@@ -195,6 +203,9 @@ class Spine(p: ExtensionAware) {
 
     private val ExtensionAware.changeVersion: String
         get() = "changeVersion".asExtra(this, DefaultVersion.change)
+
+    private val ExtensionAware.textVersion: String
+        get() = "textVersion".asExtra(this, DefaultVersion.text)
 
     private val ExtensionAware.mcVersion: String
         get() = "mcVersion".asExtra(this, DefaultVersion.mc)


### PR DESCRIPTION
We add the dependency coordinates for the new `text` library.