### PR TITLE
Escape our dependency objects with plugin accessors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,9 +38,3 @@ detekt {
     source.from("buildSrc/src/main/kotlin")
     config = files("quality/detekt-config.yml")
 }
-
-doctor {
-    javaHome {
-        failOnError.set(false)
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,9 @@
  */
 
 plugins {
-    id("config-tester")
-    id("detekt-code-analysis")
-    id(gradleDoctor.pluginId) version gradleDoctor.version
+    `config-tester`
+    `detekt-code-analysis`
+    `gradle-doctor`
 }
 
 repositories {
@@ -37,4 +37,10 @@ repositories {
 detekt {
     source.from("buildSrc/src/main/kotlin")
     config = files("quality/detekt-config.yml")
+}
+
+doctor {
+    javaHome {
+        failOnError.set(false)
+    }
 }

--- a/buildSrc/src/main/kotlin/PluginsAccessors.kt.kt
+++ b/buildSrc/src/main/kotlin/PluginsAccessors.kt.kt
@@ -24,7 +24,8 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-@file:Suppress("UnusedReceiverParameter", "unused")
+// Those accessors should match Gradle's naming conventions.
+@file:Suppress("TopLevelPropertyNaming", "unused")
 
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.GradleDoctor
@@ -67,7 +68,7 @@ val PluginDependenciesSpec.protobuf: PluginDependencySpec
     get() = id(Protobuf.GradlePlugin.id)
 
 val PluginDependenciesSpec.`gradle-doctor`: PluginDependencySpec
-    get() = id(GradleDoctor.pluginId)
+    get() = id(GradleDoctor.pluginId).version(GradleDoctor.version)
 
 val PluginDependenciesSpec.`mc-java`: PluginDependencySpec
     get() = id(Spine.McJava.pluginId).version(Spine.McJava.version)

--- a/buildSrc/src/main/kotlin/PluginsAccessors.kt.kt
+++ b/buildSrc/src/main/kotlin/PluginsAccessors.kt.kt
@@ -32,29 +32,42 @@ import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Spine.ProtoData
 import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.use.PluginDependencySpec
 
 /**
- * Allows to escape a fully qualified names for dependencies which cannot be used
- * under `plugins` section because `io` is a value declared in
- * `org.gradle.kotlin.dsl.PluginAccessors.kt`.
+ * Provides shortucts for applying plugins from our dependnecy objects.
  *
- * We still want to keep versions numbers in [io.spine.internal.dependency.Spine]
- * for the time being. So this file allows to reference those without resorting
- * to using strings again.
+ * Dependency objects cannot be used under `plugins` section because `io` is a value
+ * declared in auto-generatated `org.gradle.kotlin.dsl.PluginAccessors.kt` file.
+ * It conflicts with our own declarations.
+ *
+ * Declaring of top-level shortucts eliminates need in applying plugins
+ * using fully-qualified name of dependency objects.
+ *
+ * It is still possible to apply a plugin with a custom version, if needed.
+ * Just delcate a version again on the returned [PluginDependencySpec].
+ *
+ * For example:
+ *
+ * ```
+ * plugins {
+ *     protodata version("0.3.0-custom")
+ * }
+ * ```
  */
 private const val ABOUT = ""
 
-val PluginDependenciesSpec.protoData: ProtoData
-    get() = ProtoData
+val PluginDependenciesSpec.protodata: PluginDependencySpec
+    get() = id(ProtoData.pluginId).version(ProtoData.version)
 
-val PluginDependenciesSpec.errorPronePlugin: String
-    get() = ErrorProne.GradlePlugin.id
+val PluginDependenciesSpec.errorprone: PluginDependencySpec
+    get() = id(ErrorProne.GradlePlugin.id)
 
-val PluginDependenciesSpec.protobufPlugin: String
-    get() = Protobuf.GradlePlugin.id
+val PluginDependenciesSpec.protobuf: PluginDependencySpec
+    get() = id(Protobuf.GradlePlugin.id)
 
-val PluginDependenciesSpec.gradleDoctor: GradleDoctor
-    get() = GradleDoctor
+val PluginDependenciesSpec.`gradle-doctor`: PluginDependencySpec
+    get() = id(GradleDoctor.pluginId)
 
-val PluginDependenciesSpec.mcJava: Spine.McJava
-    get() = Spine.McJava
+val PluginDependenciesSpec.`mc-java`: PluginDependencySpec
+    get() = id(Spine.McJava.pluginId).version(Spine.McJava.version)


### PR DESCRIPTION
This changeset updates escaped dependency objects to be plugin accessors. 

Reasoning is the following:

1. Those escaped dependencies seems to be used only in `plugins` sections, and the only way to use them there is to apply plugins.
2. Script-plugins also have such accessors generated along with the ones, provided by Gradle. Thus, in many cases, we can drop all `id(<string litaral>)` calls, making `plugins` section look coherent.
3. Custom versions can still be declared.
4. Names of those accessors should match [naming conventions](https://docs.gradle.org/current/userguide/custom_plugins.html#sec:creating_a_plugin_id).

This change was previously adopted in [`base-types` #31](https://github.com/SpineEventEngine/base-types/pull/31).