### PR TITLE
Force Dokka library

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -54,7 +54,7 @@ val jacksonVersion = "2.13.4"
 
 val googleAuthToolVersion = "2.1.2"
 val licenseReportVersion = "2.1"
-val grGitVersion = "3.1.1"
+val grGitVersion = "4.1.1"
 
 /**
  * The version of the Kotlin Gradle plugin.

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,16 +26,12 @@
 
 @file:Suppress("UnusedReceiverParameter", "unused")
 
-import io.spine.internal.dependency.ErrorProne
-import io.spine.internal.dependency.GradleDoctor
-import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Spine.ProtoData
 import org.gradle.plugin.use.PluginDependenciesSpec
-import org.gradle.plugin.use.PluginDependencySpec
 
 /**
- * Provides shortucts to reference our dependnecy objects.
+ * Provides shortucts to reference our dependency objects.
  *
  * Dependency objects cannot be used under `plugins` section because `io` is a value
  * declared in auto-generatated `org.gradle.kotlin.dsl.PluginAccessors.kt` file.

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -31,13 +31,13 @@ import io.spine.internal.dependency.Spine.ProtoData
 import org.gradle.plugin.use.PluginDependenciesSpec
 
 /**
- * Provides shortucts to reference our dependency objects.
+ * Provides shortcuts to reference our dependency objects.
  *
  * Dependency objects cannot be used under `plugins` section because `io` is a value
- * declared in auto-generatated `org.gradle.kotlin.dsl.PluginAccessors.kt` file.
+ * declared in auto-generated `org.gradle.kotlin.dsl.PluginAccessors.kt` file.
  * It conflicts with our own declarations.
  *
- * In such cases, a shortctut to apply a plugin can be created:
+ * In such cases, a shortcut to apply a plugin can be created:
  *
  * ```
  * val PluginDependenciesSpec.`gradle-doctor`: PluginDependencySpec
@@ -48,7 +48,7 @@ import org.gradle.plugin.use.PluginDependenciesSpec
  * For example, when a plugin is not published to Gradle Portal, it can only be
  * applied with buildscript's classpath. Thus, it's needed to leave some freedom
  * upon how to apply them. In such cases, just a shortcut to a dependency object
- * can be declared, without applyin of the plugin in-place.
+ * can be declared, without applying of the plugin in-place.
  */
 private const val ABOUT = ""
 

--- a/buildSrc/src/main/kotlin/PluginsAccessors.kt
+++ b/buildSrc/src/main/kotlin/PluginsAccessors.kt
@@ -34,17 +34,17 @@ import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
 
 /**
- * Provides shortucts for applying plugins from our dependnecy objects.
+ * Provides shortcuts for applying plugins from our dependency objects.
  *
  * Dependency objects cannot be used under `plugins` section because `io` is a value
- * declared in auto-generatated `org.gradle.kotlin.dsl.PluginAccessors.kt` file.
+ * declared in auto-generated `org.gradle.kotlin.dsl.PluginAccessors.kt` file.
  * It conflicts with our own declarations.
  *
- * Declaring of top-level shortucts eliminates need in applying plugins
+ * Declaring of top-level shortcuts eliminates need in applying plugins
  * using fully-qualified name of dependency objects.
  *
  * It is still possible to apply a plugin with a custom version, if needed.
- * Just delcate a version again on the returned [PluginDependencySpec].
+ * Just declare a version again on the returned [PluginDependencySpec].
  *
  * For example:
  *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -33,6 +33,7 @@ import io.spine.internal.dependency.AutoValue
 import io.spine.internal.dependency.CheckerFramework
 import io.spine.internal.dependency.CommonsCli
 import io.spine.internal.dependency.CommonsLogging
+import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.FindBugs
 import io.spine.internal.dependency.Flogger
@@ -82,6 +83,7 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         AutoCommon.lib,
         AutoService.annotations,
         CheckerFramework.annotations,
+        Dokka.BasePlugin.lib,
         ErrorProne.annotations,
         ErrorProne.core,
         Guava.lib,

--- a/quality/detekt-config.yml
+++ b/quality/detekt-config.yml
@@ -26,3 +26,7 @@ complexity:
   TooManyFunctions:
     excludes:
       - '**/*Extensions.kt'
+  LongMethod:
+    excludes:
+      - "**/*Test.kt" # Allows long names for test methods.
+      - "**/*Spec.kt" # Allows long names for spec methods.


### PR DESCRIPTION
This PR forces the version of Dokka base library. 

Dokka is widely used now among our modules and the same lib is usually forced.

By the way, this PR does the following:

1. Bumps `grGit` to `4.1.1`. The currently used version is not unavailable because JCenter is deprecated now. And bumping the version to the one, which is available in Maven Central, seems to be a good alternative to [registering](https://github.com/ajoberstar/grgit#old-versions-from-bintrayjcenter) another repository.
2. Allows long method names in `test` and `spec` sources.
3. Fixes numerous typos.