### PR TITLE
Update Detekt configuration

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/RunGradle.kt
@@ -55,7 +55,6 @@ open class RunGradle : DefaultTask() {
         private const val BUILD_TIMEOUT_MINUTES: Long = 10
     }
 
-
     /**
      * Path to the directory which contains a Gradle wrapper script.
      */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
@@ -75,7 +75,7 @@ class IncrementGuard : Plugin<Project> {
      * Returns `false` if the associated reference is not a branch (e.g. a tag) or if it has
      * the name which ends with `master` or `main`.
      *
-     * For example, on the following branhces the method would return `false`:
+     * For example, on the following branches the method would return `false`:
      *
      * 1. `master`.
      * 2. `main`.

--- a/quality/detekt-config.yml
+++ b/quality/detekt-config.yml
@@ -1,12 +1,11 @@
 naming:
   ClassNaming:
-    excludes:
-      - "**/*Test.kt" # Allows ticks-named nested test suites.
-      - "**/*Spec.kt" # Allows ticks-named nested spec suites.
+    excludes: &testFiles # Allows ticks-named nested test and spec suites.
+      - "**/*Test.kt"
+      - "**/*Spec.kt"
   MatchingDeclarationName:
-    excludes:
-      - "**/*Test.kt" # Allows ticks-named top-level test suites.
-      - "**/*Spec.kt" # Allows ticks-named top-level spec suites.
+    excludes: *testFiles # Allows ticks-named top-level test and spec suites.
+
 style:
   UnusedPrivateMember:
     allowedNames: '(_|ignored|expected|serialVersionUID|about|ABOUT)'
@@ -22,6 +21,7 @@ style:
     excludeCommentStatements: true
   ForbiddenComment:
     allowedPatterns: 'TODO:'
+
 complexity:
   TooManyFunctions:
     excludes:
@@ -29,6 +29,4 @@ complexity:
       - '**/*View.kt'
       - '**/*Projection.kt'
   LongMethod:
-    excludes:
-      - "**/*Test.kt" # Allows long names for test methods.
-      - "**/*Spec.kt" # Allows long names for spec methods.
+    excludes: *testFiles # Allows long names for test and spec methods.

--- a/quality/detekt-config.yml
+++ b/quality/detekt-config.yml
@@ -26,6 +26,8 @@ complexity:
   TooManyFunctions:
     excludes:
       - '**/*Extensions.kt'
+      - '**/*View.kt'
+      - '**/*Projection.kt'
   LongMethod:
     excludes:
       - "**/*Test.kt" # Allows long names for test methods.


### PR DESCRIPTION
This PR updates Detekt config to exclude `*View.kt` and `*Projection.kt` files from `TooManyFunctions` rule.

Inheritors of `Projection` usually have a number of subscribing methods, so I propose to exclude them from this rule.

Also, this PR defines an [anchor](https://yaml.org/spec/1.2-old/spec.html#id2785586) for test and spec files to re-use them in filters to other rules.