### PR TITLE
Bump Gradle -> `7.6-rc-3`

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR bumps Gradle version to `7.6-rc-3`.

[Gradle 7.6-rc-3 Release Notes](https://docs.gradle.org/7.6-rc-3/release-notes.html).