### PR TITLE
Include `generated-proto` directories in PMD

### DIFF
--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -34,6 +34,7 @@
 
     <!-- Always exclude the Protobuf-generated files, as they generate a lot of warnings. -->
     <exclude-pattern>.*/generated/.*</exclude-pattern>
+    <exclude-pattern>.*/generated-proto/.*</exclude-pattern>
 
     <!-- Best Practices       -->
     <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>


### PR DESCRIPTION
This PR configures PMD to ignore `generated-proto` directories that are used by ProtoData as an interim location for source code generated by Protobuf Compiler.

Sometimes these directories are picked up by PMD during the build, which fails it because of numerous issues in the generated code. Ideally, `generated-proto` directories should not be seen by PMD as source code directories, but teaching ProtoData to do such tricks as a separate task.

This PR configures PMD do not look into them in any case, so that we can build anyway.