### PR TITLE
Bump versions of subprojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ These scripts are copied by the `pull` script when `config` is applied to a new 
 
 ## Further reading
 
-  * [GitHub: Working with submodules](https://blog.github.com/2016-02-01-working-with-submodules/)
-  * [Pro Git: Git Tools - Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+  * [GitHub: Working with submodules][working-with-submodules]
+  * [Pro Git: Git Tools - Git Submodules][submodule-tools]
   
 [base]: https://github.com/SpineEventEngine/base
 [base-types]: https://github.com/SpineEventEngine/base-types
 [core-java]: https://github.com/SpineEventEngine/core-java
+[working-with-submodules]: https://blog.github.com/2016-02-01-working-with-submodules
+[submodule-tools]: https://git-scm.com/book/en/v2/Git-Tools-Submodules 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,13 +61,13 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.6.0"
+        const val protoData = "0.6.1"
 
         /**
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.144"
+        const val base = "2.0.0-SNAPSHOT.145"
 
         /**
          * The default version of `core-java` to use.
@@ -80,12 +80,12 @@ class Spine(p: ExtensionAware) {
          * The version of `model-compiler` to use.
          * @see [Spine.modelCompiler]
          */
-        const val mc = "2.0.0-SNAPSHOT.90"
+        const val mc = "2.0.0-SNAPSHOT.130"
 
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.123"
+        const val mcJava = "2.0.0-SNAPSHOT.131"
 
         /**
          * The version of `base-types` to use.
@@ -116,13 +116,13 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.154"
+        const val toolBase = "2.0.0-SNAPSHOT.155"
 
         /**
          * The version of `validation` to use.
          * @see [Spine.validation]
          */
-        const val validation = "2.0.0-SNAPSHOT.71"
+        const val validation = "2.0.0-SNAPSHOT.80"
 
         /**
          * The version of Javadoc Tools to use.

--- a/scripts/publish-documentation/README.md
+++ b/scripts/publish-documentation/README.md
@@ -34,7 +34,7 @@ Prerequisites for the target repository:
 - have at least one tag and module.
 
 Prerequisites for running the script:
-- have [`git`](https://git-scm.com/downloads) and [`jenv`][jenv] installed;
+- have [`git`](https://git-scm.com/downloads) and [`jenv`][jenv-add] installed;
 - have Java **1.8** installed and [registered][jenv-add] in `jenv`;
 - have Java **11** installed, registered and [set as global][jenv-global] in `jenv`.
 
@@ -172,7 +172,6 @@ After running the example, the following happens:
 The script was developed under and for the macOS. It should not have problems working on a Linux 
 distribution. However, it was not meant and tested to do so.
 
-[jenv]: https://github.com/jenv/jenv#12-adding-your-java-environment
 [jenv-add]: https://github.com/jenv/jenv#12-adding-your-java-environment
 [jenv-global]: https://github.com/jenv/jenv#13-setting-a-global-java-version
 [dokka-for-java]: ../../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts

--- a/scripts/publish-documentation/README.md
+++ b/scripts/publish-documentation/README.md
@@ -1,17 +1,29 @@
-### Description
+## `publish-documentation` directory
 
-This directory contains a script and serves as a workspace for it. The script generates and publishes 
-Dokka documentation for releases of Spine projects prior to the `2.0.0` version. Documentation is 
-published to the `gh-pages` branch of the target repository.
+This directory contains the [`publish.sh`](publish.sh) script and serves as a workspace for it. 
+The script generates and publishes Dokka documentation for releases of Spine projects prior
+to the `2.0.0` version. Documentation is published to the `gh-pages` branch of
+the target repository.
 
 ### Important details
 
 - The script works with the repository over HTTPS, so if you are not authenticated in `git`, you will 
   be prompted to do so using a username and a personal access token.
-- The script conceptually relies on the fact that each release has a corresponding tag.
+
+
+- The script relies on the fact that each release has a corresponding tag.
+
+
 - If the `gh-pages` branch does not exist, it is created.
+
+
 - It is assumed that releases of Spine projects prior to the `2.0.0` version use Java 8.
-- Documentation is generated using [this configuration](../../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts).
+
+
+- Documentation is generated using 
+  [`dokka-for-java.gradle.kts`][dokka-for-java] script.
+
+
 - The script modifies the parent directory during its run. At the end, of its run the script reverts 
   the directory to the initial state.
 
@@ -22,9 +34,9 @@ Prerequisites for the target repository:
 - have at least one tag and module.
 
 Prerequisites for running the script:
-- have [`git`](https://git-scm.com/downloads) and [`jenv`](https://github.com/jenv/jenv#12-adding-your-java-environment) installed;
-- have Java **1.8** installed and [registered](https://github.com/jenv/jenv#12-adding-your-java-environment) in `jenv`;
-- have Java **11** installed, registered and [set as global](https://github.com/jenv/jenv#13-setting-a-global-java-version) in `jenv`.
+- have [`git`](https://git-scm.com/downloads) and [`jenv`][jenv] installed;
+- have Java **1.8** installed and [registered][jenv-add] in `jenv`;
+- have Java **11** installed, registered and [set as global][jenv-global] in `jenv`.
 
 ### Usage
 
@@ -34,10 +46,14 @@ The script should be launched from this directory and follow the template provid
 ```
 
 Description of parameters:
-* `repositoryUrl` - a GitHub HTTPS URL.
-* `tags` - a list of comma-separated git tags. A tag marked with an asterisk is considered 'primary'. 
+* `repositoryUrl` — a GitHub HTTPS URL.
+
+
+* `tags` — a list of comma-separated git tags. A tag marked with an asterisk is considered 'primary'. 
    A tag without it is considered 'secondary'.
-* `paths` - a list of comma-separated paths to modules. A path should be using the Unix file separator("/"). 
+
+
+* `paths` — a list of comma-separated paths to modules. A path should be using the Unix file separator("/"). 
    A path is considered relative to the root of the repository, i.e. for a root-level module, the path 
    is just the name of the module.
 
@@ -136,14 +152,16 @@ After running the example, the following happens:
     │
     ```
 
-#### Edge cases
+### Edge cases
 
 - If any of the passed tags already has Dokka documentation published to the `gh-pages` branch, the 
   script tries to overwrite it if there are changes in a tool output. The presence of changes 
   depends on how much the Dokka configuration has changed since the last publication. If an output 
   matches the published one, a commit is not made.
 
+
 - If no tags are marked 'primary', they all are considered 'secondary' and processed accordingly.
+
 
 - If multiple tags are marked 'primary', then each of these tags is published as 'primary' one by one. 
   That means the last in the list marked as 'primary' overwrites all others as if they were published
@@ -153,3 +171,8 @@ After running the example, the following happens:
 
 The script was developed under and for the macOS. It should not have problems working on a Linux 
 distribution. However, it was not meant and tested to do so.
+
+[jenv]: https://github.com/jenv/jenv#12-adding-your-java-environment
+[jenv-add]: https://github.com/jenv/jenv#12-adding-your-java-environment
+[jenv-global]: https://github.com/jenv/jenv#13-setting-a-global-java-version
+[dokka-for-java]: ../../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts

--- a/scripts/publish-documentation/README.md
+++ b/scripts/publish-documentation/README.md
@@ -34,7 +34,7 @@ Prerequisites for the target repository:
 - have at least one tag and module.
 
 Prerequisites for running the script:
-- have [`git`](https://git-scm.com/downloads) and [`jenv`][jenv-add] installed;
+- have [`git`](https://git-scm.com/downloads) and [`jenv`][jenv-repo] installed;
 - have Java **1.8** installed and [registered][jenv-add] in `jenv`;
 - have Java **11** installed, registered and [set as global][jenv-global] in `jenv`.
 
@@ -172,6 +172,7 @@ After running the example, the following happens:
 The script was developed under and for the macOS. It should not have problems working on a Linux 
 distribution. However, it was not meant and tested to do so.
 
+[jenv-repo]: https://github.com/jenv/jenv
 [jenv-add]: https://github.com/jenv/jenv#12-adding-your-java-environment
 [jenv-global]: https://github.com/jenv/jenv#13-setting-a-global-java-version
 [dokka-for-java]: ../../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts


### PR DESCRIPTION
This PR:
  * Bumps versions of internal Spine SDK dependencies.
  * Improves readability of the documentation for the `scripts/publish-documentation` directory.
