### PR TITLE
Extend detekt configuration, bump versions

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -62,7 +62,7 @@ val grGitVersion = "4.1.1"
  * Please check that this value matches one defined in
  *  [io.spine.internal.dependency.Kotlin.version].
  */
-val kotlinVersion = "1.7.21"
+val kotlinVersion = "1.8.0"
 
 /**
  * The version of Guava used in `buildSrc`.
@@ -107,7 +107,7 @@ val dokkaVersion = "1.7.20"
  *
  * @see <a href="https://github.com/detekt/detekt/releases">Detekt Releases</a>
  */
-val detektVersion = "1.21.0"
+val detektVersion = "1.22.0"
 
 configurations.all {
     resolutionStrategy {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -35,13 +35,14 @@ object Kotlin {
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version = "1.7.21"
+    const val version = "1.8.0"
 
     private const val group = "org.jetbrains.kotlin"
 
     const val stdLib       = "${group}:kotlin-stdlib:${version}"
     const val stdLibCommon = "${group}:kotlin-stdlib-common:${version}"
-    const val stdLibJdk8   = "${group}:kotlin-stdlib-jdk8:${version}"
+    @Deprecated("Please use `stdLib` instead.")
+    const val stdLibJdk8   = "${group}:kotlin-stdlib:${version}"
 
     const val reflect    = "${group}:kotlin-reflect:${version}"
     const val testJUnit5 = "${group}:kotlin-test-junit5:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -67,14 +67,14 @@ class Spine(p: ExtensionAware) {
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.145"
+        const val base = "2.0.0-SNAPSHOT.150"
 
         /**
          * The default version of `core-java` to use.
          * @see [Spine.CoreJava.client]
          * @see [Spine.CoreJava.server]
          */
-        const val core = "2.0.0-SNAPSHOT.122"
+        const val core = "2.0.0-SNAPSHOT.141"
 
         /**
          * The version of `model-compiler` to use.
@@ -85,7 +85,7 @@ class Spine(p: ExtensionAware) {
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.131"
+        const val mcJava = "2.0.0-SNAPSHOT.132"
 
         /**
          * The version of `base-types` to use.
@@ -116,7 +116,7 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.155"
+        const val toolBase = "2.0.0-SNAPSHOT.156"
 
         /**
          * The version of `validation` to use.

--- a/quality/detekt-config.yml
+++ b/quality/detekt-config.yml
@@ -25,6 +25,7 @@ style:
 complexity:
   TooManyFunctions:
     excludes:
+      - '**/*Exts.kt'
       - '**/*Extensions.kt'
       - '**/*View.kt'
       - '**/*Projection.kt'


### PR DESCRIPTION
This PR:
  * Extends detekt configuration to exclude `*Exts.ts` files from being checked for `TooManyFunctions`.
  * Bumps detekt -> `1.22.0`.
  * Bumps Kotlin -> `1.8.0.
  * Bumps some Spine SDK subprojects.
