### PR TITLE
Restore `stdLibX` properties in `Kotlin` dependency object

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -117,8 +117,6 @@ configurations.all {
             // Force Kotlin lib versions avoiding using those bundled with Gradle.
             "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
             "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion",
             "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
         )
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -41,8 +41,12 @@ object Kotlin {
 
     const val stdLib       = "${group}:kotlin-stdlib:${version}"
     const val stdLibCommon = "${group}:kotlin-stdlib-common:${version}"
+
     @Deprecated("Please use `stdLib` instead.")
-    const val stdLibJdk8   = "${group}:kotlin-stdlib:${version}"
+    const val stdLibJdk7   = "${group}:kotlin-stdlib-jdk7:${version}"
+
+    @Deprecated("Please use `stdLib` instead.")
+    const val stdLibJdk8   = "${group}:kotlin-stdlib-jdk8:${version}"
 
     const val reflect    = "${group}:kotlin-reflect:${version}"
     const val testJUnit5 = "${group}:kotlin-test-junit5:$version"


### PR DESCRIPTION
This PR restores `Kotlin.stdLib7` and `Kotlin.stdLib7` properties which are still needed in subprojects for forcing versions, until all of them are migrated to Kotlin `1.8.0`.

Also, forcing these Kotlin artifacts in `buildSrc/build.gradle.kts` was removed because they are no longer applicable to Kotlin `1.8.0+`.