### PR TITLE
Use Oracle JDK for Javadoc refs.

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,13 +61,13 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.6.1"
+        const val protoData = "0.7.2"
 
         /**
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.150"
+        const val base = "2.0.0-SNAPSHOT.153"
 
         /**
          * The default version of `core-java` to use.
@@ -110,7 +110,7 @@ class Spine(p: ExtensionAware) {
          *
          * @see Spine.text
          */
-        const val text = "2.0.0-SNAPSHOT.2"
+        const val text = "2.0.0-SNAPSHOT.3"
 
         /**
          * The version of `tool-base` to use.
@@ -122,7 +122,7 @@ class Spine(p: ExtensionAware) {
          * The version of `validation` to use.
          * @see [Spine.validation]
          */
-        const val validation = "2.0.0-SNAPSHOT.80"
+        const val validation = "2.0.0-SNAPSHOT.81"
 
         /**
          * The version of Javadoc Tools to use.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/JavadocConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/JavadocConfig.kt
@@ -43,9 +43,9 @@ object JavadocConfig {
     /**
      * Link to the documentation for Java 11 Standard Library API.
      *
-     * OpenJDK SE 11 is used for the reference.
+     * Oracle JDK SE 11 is used for the reference.
      */
-    private const val standardLibraryAPI = "https://cr.openjdk.java.net/~iris/se/11/latestSpec/api/"
+    private const val standardLibraryAPI = "https://docs.oracle.com/en/java/javase/11/docs/api/"
 
     @Suppress("MemberVisibilityCanBePrivate") // opened to be visible from docs.
     val tags = listOf(


### PR DESCRIPTION
This PR:
  * Sets Oracle JDK Javadoc to be used for standard type links. The OpenJDK documentation site has expired certificate and is down time after time recently.
  * Some versions of Spine SDK artifacts were also bumped.