### PR TITLE
Depend on `generateProto` conditionally

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
@@ -28,7 +28,6 @@ package io.spine.internal.gradle.publish
 
 import io.spine.internal.gradle.sourceSets
 import org.gradle.api.Project
-import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
@@ -50,19 +49,6 @@ fun TaskContainer.excludeGoogleProtoFromArtifacts() {
 }
 
 /**
- * Checks if the given file belongs to the Google `.proto` sources.
- */
-private fun FileTreeElement.isGoogleProtoSource(): Boolean {
-    val pathSegments = relativePath.segments
-    return pathSegments.isNotEmpty() && pathSegments[0].equals("google")
-}
-
-/**
- * The reference to the `generateProto` task of a `main` source set.
- */
-internal fun Project.generateProto() = tasks.getByName("generateProto")
-
-/**
  * Locates or creates `sourcesJar` task in this [Project].
  *
  * The output of this task is a `jar` archive. The archive contains sources from `main` source set.
@@ -77,7 +63,7 @@ internal fun Project.generateProto() = tasks.getByName("generateProto")
  * For Proto sources to be included – [special treatment][protoSources] is needed.
  */
 internal fun Project.sourcesJar() = tasks.getOrCreate("sourcesJar") {
-    dependsOn(generateProto())
+    dependOnGenerateProto()
     archiveClassifier.set("sources")
     from(sourceSets["main"].allSource) // Puts Java and Kotlin sources.
     from(protoSources()) // Puts Proto sources.
@@ -90,7 +76,7 @@ internal fun Project.sourcesJar() = tasks.getOrCreate("sourcesJar") {
  * [Proto sources][protoSources] from `main` source set.
  */
 internal fun Project.protoJar() = tasks.getOrCreate("protoJar") {
-    dependsOn(generateProto())
+    dependOnGenerateProto()
     archiveClassifier.set("proto")
     from(protoSources())
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoExts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoExts.kt
@@ -29,9 +29,11 @@ package io.spine.internal.gradle.publish
 import io.spine.internal.gradle.sourceSets
 import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.get
-
 
 /**
  * Tells whether there are any Proto sources in "main" source set.
@@ -52,4 +54,26 @@ internal fun Project.protoSources(): Set<File> {
     val mainSourceSet = sourceSets["main"]
     val protoSourceDirs = mainSourceSet.extensions.findByName("proto") as SourceDirectorySet?
     return protoSourceDirs?.srcDirs ?: emptySet()
+}
+
+/**
+ * Checks if the given file belongs to the Google `.proto` sources.
+ */
+internal fun FileTreeElement.isGoogleProtoSource(): Boolean {
+    val pathSegments = relativePath.segments
+    return pathSegments.isNotEmpty() && pathSegments[0].equals("google")
+}
+
+/**
+ * The reference to the `generateProto` task of a `main` source set.
+ */
+internal fun Project.generateProto(): Task? = tasks.findByName("generateProto")
+
+/**
+ * Makes this [Jar] task depend on the [generateProto] task, if it exists in the same project.
+ */
+internal fun Jar.dependOnGenerateProto() {
+    project.generateProto()?.let {
+        this.dependsOn(it)
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR improves task dependency arrangements in `Artifacts.kt` to handle the case when Protobuf Gradle Plugin is not applied to a project. Also, Protobuf-related extensions functions are now gathered under `ProtoExts.kt` file.

These changes are tested under an in-progress PR in `mc-java`.

Also Gradle bumped to 7.6.1. See the [release notes](https://github.com/gradle/gradle/releases/tag/v7.6.1) for the issues this release fixes.