### PR TITLE
Bump dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("unused")
+
 package io.spine.internal.dependency
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
@@ -32,7 +32,7 @@ package io.spine.internal.dependency
  * @see <a href="https://kotest.io/">Kotest site</a>
  */
 object Kotest {
-    const val version = "5.5.4"
+    const val version = "5.5.5"
     const val group = "io.kotest"
     const val assertions = "$group:kotest-assertions-core:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -35,7 +35,7 @@ object Kotlin {
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version = "1.8.0"
+    const val version = "1.8.10"
 
     private const val group = "org.jetbrains.kotlin"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.21.12"
+    const val version       = "3.22.0"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",
@@ -46,7 +46,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.9.1"
+        const val version = "0.9.2"
         const val id = "com.google.protobuf"
         const val lib = "${group}:protobuf-gradle-plugin:${version}"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,13 +61,13 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.7.2"
+        const val protoData = "0.7.3"
 
         /**
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.153"
+        const val base = "2.0.0-SNAPSHOT.161"
 
         /**
          * The default version of `core-java` to use.
@@ -91,7 +91,7 @@ class Spine(p: ExtensionAware) {
          * The version of `base-types` to use.
          * @see [Spine.baseTypes]
          */
-        const val baseTypes = "2.0.0-SNAPSHOT.113"
+        const val baseTypes = "2.0.0-SNAPSHOT.120"
 
         /**
          * The version of `time` to use.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -67,7 +67,7 @@ class Spine(p: ExtensionAware) {
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.161"
+        const val base = "2.0.0-SNAPSHOT.162"
 
         /**
          * The default version of `core-java` to use.

--- a/pull
+++ b/pull
@@ -99,6 +99,7 @@ rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependencies/AutoService.kt
 rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependencies/AutoValue.kt
 rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoLocators.kt
 rm -f ../buildSrc/src/main/kotlin/TaskDependencies.kt
+rm -f ../buildSrc/src/main/kotlin/Dependencies.kt
 rm -f ../buildSrc/src/main/kotlin/PluginAccessors.kt
 
 echo "Updating Gradle 'buildSrc' scripts"

--- a/pull
+++ b/pull
@@ -97,6 +97,9 @@ rm -rf ../buildSrc/src/main/kotlin/io/spine/internal/gradle/test
 rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependencies/AutoCommon.kt
 rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependencies/AutoService.kt
 rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependencies/AutoValue.kt
+rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoLocators.kt
+rm -f ../buildSrc/src/main/kotlin/TaskDependencies.kt
+rm -f ../buildSrc/src/main/kotlin/PluginAccessors.kt
 
 echo "Updating Gradle 'buildSrc' scripts"
 cp -R buildSrc ..


### PR DESCRIPTION
This PR:
 * Bumps some internal and external dependencies.
 * Updates the `pull` script to take care of removal of some outdated files under `buildSrc`.