### PR TITLE
Bump ProtoData

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,7 +61,7 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.7.3"
+        const val protoData = "0.7.6"
 
         /**
          * The default version of `base` to use.


### PR DESCRIPTION
This PR bumps ProtoData version to `0.7.6`.