### PR TITLE
Bump `PMD` -> `6.55.0`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -28,5 +28,5 @@ package io.spine.internal.dependency
 
 // https://pmd.github.io/
 object Pmd {
-    const val version = "6.51.0"
+    const val version = "6.55.0"
 }

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -71,8 +71,6 @@
     <rule ref="category/java/design.xml/AvoidThrowingNullPointerException"/>
     <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes"/>
     <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
-    <rule ref="category/java/design.xml/ExcessiveClassLength"/>
-    <rule ref="category/java/design.xml/ExcessiveMethodLength"/>
     <rule ref="category/java/design.xml/ExcessiveParameterList"/>
     <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
     <rule ref="category/java/design.xml/LogicInversion"/>


### PR DESCRIPTION
This PR bumps the version of PMD and  remove `ExcessiveClassLength` and `ExcessiveMethodLength` inspections because they are scheduled for removal in v7.0.