### PR TITLE
Add `spine-logging` and `spine-reflect`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -147,6 +147,8 @@ class Spine(p: ExtensionAware) {
     }
 
     val base = "$group:spine-base:${p.baseVersion}"
+    val logging = "$group:spine-logging:${p.baseVersion}"
+    val reflect = "$group:spine-reflect:${p.baseVersion}"
     val baseTypes = "$group:spine-base-types:${p.baseTypesVersion}"
     val time = "$group:spine-time:${p.timeVersion}"
     val change = "$group:spine-change:${p.changeVersion}"


### PR DESCRIPTION
This PR adds two properties for the `Spine` dependency object to address the appearance of new artifacts from `base`.