### PR TITLE
Simplify `Spine` dependency type

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         uses: mikepenz/action-junit-report@v3.5.2
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/*est/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found
 
       - name: Upload code coverage report

--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -27,5 +27,5 @@ jobs:
         uses: mikepenz/action-junit-report@v3.5.2
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: '**/build/test-results/*est/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -28,9 +28,9 @@
 
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.GradleDoctor
+import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
-import io.spine.internal.dependency.Spine.ProtoData
 import io.spine.internal.gradle.standardToSpineSdk
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -77,7 +77,7 @@ val PluginDependenciesSpec.mcJava: Spine.McJava
     get() = Spine.McJava
 
 /**
- * Shortcut to [Spine.ProtoData] dependency object.
+ * Shortcut to [ProtoData] dependency object.
  *
  * This plugin is in Gradle Portal. But when used in pair with [mcJava], it cannot be applied
  * directly to a project. It is so, because [mcJava] uses [protoData] as its dependency.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+/**
+ * Dependencies on ProtoData modules.
+ *
+ * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
+ */
+@Suppress("unused")
+object ProtoData {
+    const val version = "0.8.0"
+    const val group = "io.spine.protodata"
+    const val compiler = "$group:protodata-compiler:$version"
+
+    const val codegenJava = "io.spine.protodata:protodata-codegen-java:$version"
+
+    const val pluginId = "io.spine.protodata"
+    const val pluginLib = "${Spine.group}:protodata:$version"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -26,261 +26,122 @@
 
 package io.spine.internal.dependency
 
-import org.gradle.api.plugins.ExtensionAware
-import org.gradle.kotlin.dsl.extra
-
 /**
  * Dependencies on Spine modules.
- *
- * @constructor
- * Creates a new instance of `Spine` taking the property values
- * of versions from the given project's extra properties.
  */
 @Suppress("unused")
-class Spine(p: ExtensionAware) {
+object Spine {
+
+    const val group = "io.spine"
+    const val toolsGroup = "io.spine.tools"
 
     /**
-     * Default versions for the modules of Spine, unless they are
-     * configured in `versions.gradle.kts`.
+     * Versions for published Spine SDK artifacts.
      */
-    object DefaultVersion {
+    object ArtifactVersion {
 
-        /**
-         * The version of ProtoData to be used in the project.
-         *
-         * We do it here instead of `versions.gradle.kts` because we later use
-         * it in a `plugins` section in a build script.
-         *
-         * This version cannot be re-defined via `version.gradle.kts` like versions
-         * of other subprojects like [base] or [core]. So, if you want to use another version,
-         * please update this value in your `buildSrc.
-         *
-         * Development of ProtoData uses custom convention for using custom version
-         * of ProtoData in its integration tests. Please see `ProtoData/version.gradle.kts`
-         * for details.
-         *
-         * @see [ProtoData]
-         */
-        const val protoData = "0.8.0"
+        /** The version of [ProtoData]. */
+        @Deprecated("Please use `ProtoData.version` instead.")
+        const val protoData = ProtoData.version
 
-        /**
-         * The default version of `base` to use.
-         * @see [Spine.base]
-         */
+        /** The version of [Spine.base]. */
         const val base = "2.0.0-SNAPSHOT.170"
 
+        /** The version of [Spine.reflect]. */
+        const val reflect = "2.0.0-SNAPSHOT.170"
+
+        /** The version of [Spine.logging]. */
+        const val logging = "2.0.0-SNAPSHOT.170"
+        
         /**
-         * The default version of `core-java` to use.
+         * The version of `core-java`.
          * @see [Spine.CoreJava.client]
          * @see [Spine.CoreJava.server]
          */
         const val core = "2.0.0-SNAPSHOT.141"
 
-        /**
-         * The version of `model-compiler` to use.
-         * @see [Spine.modelCompiler]
-         */
+        /** The version of [Spine.modelCompiler]. */
         const val mc = "2.0.0-SNAPSHOT.130"
 
-        /**
-         * The version of `mc-java` to use.
-         */
+        /** The version of [McJava]. */
         const val mcJava = "2.0.0-SNAPSHOT.132"
 
-        /**
-         * The version of `base-types` to use.
-         * @see [Spine.baseTypes]
-         */
+        /** The version of [Spine.baseTypes]. */
         const val baseTypes = "2.0.0-SNAPSHOT.120"
 
-        /**
-         * The version of `time` to use.
-         * @see [Spine.time]
-         */
+        /** The version of [Spine.time]. */
         const val time = "2.0.0-SNAPSHOT.121"
 
-        /**
-         * The version of `change` to use.
-         * @see [Spine.change]
-         */
+        /** The version of [Spine.change]. */
         const val change = "2.0.0-SNAPSHOT.118"
 
-        /**
-         * The version of `text` to use.
-         *
-         * @see Spine.text
-         */
+        /** The version of [Spine.text]. */
         const val text = "2.0.0-SNAPSHOT.3"
 
-        /**
-         * The version of `tool-base` to use.
-         * @see [Spine.toolBase]
-         */
+        /** The version of [Spine.toolBase]. */
         const val toolBase = "2.0.0-SNAPSHOT.156"
 
-        /**
-         * The version of `validation` to use.
-         * @see [Spine.validation]
-         */
-        const val validation = "2.0.0-SNAPSHOT.81"
+        /** The version of [Spine.validation]. */
+        @Deprecated("Please use `Validation.version` instead.")
+        const val validation = Validation.version
 
-        /**
-         * The version of Javadoc Tools to use.
-         * @see [Spine.javadocTools]
-         */
+        /** The version of [Spine.javadocTools]. */
         const val javadocTools = "2.0.0-SNAPSHOT.75"
     }
 
-    companion object {
-        const val group = "io.spine"
-        const val toolsGroup = "io.spine.tools"
+    /** The version of ProtoData to be used in the project. */
+    @Deprecated("Please use `ProtoData.version` instead.")
+    const val protoDataVersion = ProtoData.version
 
-        /**
-         * The version of ProtoData to be used in the project.
-         *
-         * We do it here instead of `versions.gradle.kts` because we later use
-         * it in a `plugins` section in a build script.
-         *
-         * @see [ProtoData]
-         */
-        const val protoDataVersion = DefaultVersion.protoData
-    }
+    const val base = "$group:spine-base:${ArtifactVersion.base}"
+    const val logging = "$group:spine-logging:${ArtifactVersion.base}"
+    const val reflect = "$group:spine-reflect:${ArtifactVersion.base}"
+    const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
+    const val time = "$group:spine-time:${ArtifactVersion.time}"
+    const val change = "$group:spine-change:${ArtifactVersion.change}"
+    const val text = "$group:spine-text:${ArtifactVersion.text}"
 
-    val base = "$group:spine-base:${p.baseVersion}"
-    val logging = "$group:spine-logging:${p.baseVersion}"
-    val reflect = "$group:spine-reflect:${p.baseVersion}"
-    val baseTypes = "$group:spine-base-types:${p.baseTypesVersion}"
-    val time = "$group:spine-time:${p.timeVersion}"
-    val change = "$group:spine-change:${p.changeVersion}"
-    val text = "$group:spine-text:${p.textVersion}"
-
-    val testlib = "$toolsGroup:spine-testlib:${p.baseVersion}"
-    val testUtilTime = "$toolsGroup:spine-testutil-time:${p.timeVersion}"
-    val toolBase = "$toolsGroup:spine-tool-base:${p.toolBaseVersion}"
-    val pluginBase = "$toolsGroup:spine-plugin-base:${p.toolBaseVersion}"
-    val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${p.toolBaseVersion}"
-    val modelCompiler = "$toolsGroup:spine-model-compiler:${p.mcVersion}"
-
-    /**
-     * Coordinates of the McJava plugin bundle which uses version of the bundle
-     * from [ExtensionAware.mcJavaVersion] property.
-     *
-     * This property and [ExtensionAware.mcJavaVersion] are deprecated because
-     * we discourage using versions of Spine components outside of this dependency
-     * object class.
-     */
-    @Deprecated(message = "Please use `McJava.pluginLib` instead")
-    @Suppress("DEPRECATION")
-    val mcJavaPlugin = "$toolsGroup:spine-mc-java-plugins:${p.mcJavaVersion}:all"
+    const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.base}"
+    const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
+    const val toolBase = "$toolsGroup:spine-tool-base:${ArtifactVersion.toolBase}"
+    const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
+    const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"
+    const val modelCompiler = "$toolsGroup:spine-model-compiler:${ArtifactVersion.mc}"
 
     object McJava {
-        const val version = DefaultVersion.mcJava
+        const val version = ArtifactVersion.mcJava
         const val pluginId = "io.spine.mc-java"
         const val pluginLib = "$toolsGroup:spine-mc-java-plugins:${version}:all"
     }
 
     /**
      *  Does not allow re-definition via a project property.
-     *  Please change [DefaultVersion.javadocTools].
+     *  Please change [ArtifactVersion.javadocTools].
      */
-    val javadocTools = "$toolsGroup::${DefaultVersion.javadocTools}"
+    const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
 
     @Deprecated("Please use `validation.runtime`", replaceWith = ReplaceWith("validation.runtime"))
-    val validate = "$group:spine-validate:${p.baseVersion}"
+    val validate = "$group:spine-validate:${ArtifactVersion.base}"
 
-    val validation = Validation(p)
+    @Deprecated("Please use `Validation` instead.")
+    val validation = Validation
 
-    val coreJava = CoreJava(p)
-    val client = coreJava.client // Added for brevity.
-    val server = coreJava.server // Added for brevity.
+    @Suppress("MemberVisibilityCanBePrivate")
+    @Deprecated("Please use `CoreJava` instead.")
+    val coreJava = CoreJava
 
-    private val ExtensionAware.baseVersion: String
-        get() = "baseVersion".asExtra(this, DefaultVersion.base)
-
-    private val ExtensionAware.baseTypesVersion: String
-        get() = "baseTypesVersion".asExtra(this, DefaultVersion.baseTypes)
-
-    private val ExtensionAware.timeVersion: String
-        get() = "timeVersion".asExtra(this, DefaultVersion.time)
-
-    private val ExtensionAware.changeVersion: String
-        get() = "changeVersion".asExtra(this, DefaultVersion.change)
-
-    private val ExtensionAware.textVersion: String
-        get() = "textVersion".asExtra(this, DefaultVersion.text)
-
-    private val ExtensionAware.mcVersion: String
-        get() = "mcVersion".asExtra(this, DefaultVersion.mc)
-
-    @Deprecated(message = "Please use `Spine.McJava` dependency object instead.")
-    private val ExtensionAware.mcJavaVersion: String
-        get() = "mcJavaVersion".asExtra(this, DefaultVersion.mcJava)
-
-    private val ExtensionAware.toolBaseVersion: String
-        get() = "toolBaseVersion".asExtra(this, DefaultVersion.toolBase)
-
-    /**
-     * Dependencies on Spine validation modules.
-     *
-     * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
-     */
-    class Validation(p: ExtensionAware) {
-        companion object {
-            const val group = "io.spine.validation"
-        }
-        val runtime = "$group:spine-validation-java-runtime:${p.validationVersion}"
-        val java = "$group:spine-validation-java:${p.validationVersion}"
-        val model = "$group:spine-validation-model:${p.validationVersion}"
-        val config = "$group:spine-validation-configuration:${p.validationVersion}"
-
-        private val ExtensionAware.validationVersion: String
-            get() = "validationVersion".asExtra(this, DefaultVersion.validation)
-    }
-
-    /**
-     * Dependencies on ProtoData modules.
-     *
-     * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
-     */
-    object ProtoData {
-        const val group = "io.spine.protodata"
-        const val version = protoDataVersion
-        const val compiler = "$group:protodata-compiler:$version"
-
-        const val codegenJava = "io.spine.protodata:protodata-codegen-java:$version"
-
-        const val pluginId = "io.spine.protodata"
-        const val pluginLib = "${Spine.group}:protodata:$version"
-    }
+    const val client = CoreJava.client // Added for brevity.
+    const val server = CoreJava.server // Added for brevity.
 
     /**
      * Dependencies on `core-java` modules.
      *
      * See [`SpineEventEngine/core-java`](https://github.com/SpineEventEngine/core-java/).
      */
-    class CoreJava(p: ExtensionAware) {
-        val core = "$group:spine-core:${p.coreVersion}"
-        val client = "$group:spine-client:${p.coreVersion}"
-        val server = "$group:spine-server:${p.coreVersion}"
-        val testUtilServer = "$toolsGroup:spine-testutil-server:${p.coreVersion}"
-
-        private val ExtensionAware.coreVersion: String
-            get() = "coreVersion".asExtra(this, DefaultVersion.core)
-    }
-}
-
-/**
- * Obtains the value of the extension property named as this string from the given project.
- *
- * @param p the project declaring extension properties
- * @param defaultValue
- *         the default value to return, if the project does not have such a property.
- *         If `null` then rely on the property declaration, even if this would cause an error.
- */
-private fun String.asExtra(p: ExtensionAware, defaultValue: String? = null): String {
-    return if (p.extra.has(this) || defaultValue == null) {
-        p.extra[this] as String
-    } else {
-        defaultValue
+    object CoreJava {
+        const val core = "$group:spine-core:${ArtifactVersion.core}"
+        const val client = "$group:spine-client:${ArtifactVersion.core}"
+        const val server = "$group:spine-server:${ArtifactVersion.core}"
+        const val testUtilServer = "$toolsGroup:spine-testutil-server:${ArtifactVersion.core}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,14 +45,16 @@ object Spine {
         const val protoData = ProtoData.version
 
         /** The version of [Spine.base]. */
-        const val base = "2.0.0-SNAPSHOT.170"
+        const val base = "2.0.0-SNAPSHOT.180"
 
         /** The version of [Spine.reflect]. */
-        const val reflect = "2.0.0-SNAPSHOT.170"
+        const val reflect = "2.0.0-SNAPSHOT.181"
 
         /** The version of [Spine.logging]. */
-        const val logging = "2.0.0-SNAPSHOT.170"
-        
+        const val logging = "2.0.0-SNAPSHOT.182"
+
+        /** The version of [Spine.testlib]. */
+        const val testlib = "2.0.0-SNAPSHOT.183"
         /**
          * The version of `core-java`.
          * @see [Spine.CoreJava.client]
@@ -94,14 +96,14 @@ object Spine {
     const val protoDataVersion = ProtoData.version
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
-    const val logging = "$group:spine-logging:${ArtifactVersion.base}"
-    const val reflect = "$group:spine-reflect:${ArtifactVersion.base}"
+    const val logging = "$group:spine-logging:${ArtifactVersion.logging}"
+    const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
     const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
     const val time = "$group:spine-time:${ArtifactVersion.time}"
     const val change = "$group:spine-change:${ArtifactVersion.change}"
     const val text = "$group:spine-text:${ArtifactVersion.text}"
 
-    const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.base}"
+    const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.testlib}"
     const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
     const val toolBase = "$toolsGroup:spine-tool-base:${ArtifactVersion.toolBase}"
     const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+/**
+ * Dependencies on Spine Validation SDK.
+ *
+ * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
+ */
+object Validation {
+    const val version = "2.0.0-SNAPSHOT.81"
+    const val group = "io.spine.validation"
+    const val runtime = "$group:spine-validation-java-runtime:$version"
+    const val java = "$group:spine-validation-java:$version"
+    const val model = "$group:spine-validation-model:$version"
+    const val config = "$group:spine-validation-configuration:$version"
+}


### PR DESCRIPTION
This PR simplifies the way we treat dependencies on the SDK modules. 

Previously, `Spine` was a class so that an instance could handle dependency versions declared in `versions.gradle.kts`. We dropped using this approach some time ago in favor of using version numbers changed right under `Spine` class residing under `buildSrc`. So all the "wirings" require for handling module versions under `versions.gradle.kts` became unnecessary and were removed. Thus, `Spine` became a Kotlin object.

Also, `ProtoData` and `Validation` were pulled to the package level to make them more visible.

