### PR TITLE
Adjust Dokka publishing according to the latest Dokka changes

### DIFF
--- a/scripts/publish-documentation/README.md
+++ b/scripts/publish-documentation/README.md
@@ -172,6 +172,11 @@ After running the example, the following happens:
 The script was developed under and for the macOS. It should not have problems working on a Linux 
 distribution. However, it was not meant and tested to do so.
 
+### Samples
+
+See `sample-publishing-1.x-repos.sh.template` to get a general understanding
+how the publishing was made for 1.x branch last time.
+
 [jenv-repo]: https://github.com/jenv/jenv
 [jenv-add]: https://github.com/jenv/jenv#12-adding-your-java-environment
 [jenv-global]: https://github.com/jenv/jenv#13-setting-a-global-java-version

--- a/scripts/publish-documentation/sample-publishing-1.x-repos.sh.template
+++ b/scripts/publish-documentation/sample-publishing-1.x-repos.sh.template
@@ -58,4 +58,3 @@
 # Bootstrap
 ./publish.sh repositoryUrl='https://github.com/SpineEventEngine/bootstrap.git' tags='*v1.9.0' \
     paths='plugin'
-

--- a/scripts/publish-documentation/sample-publishing-1.x-repos.sh.template
+++ b/scripts/publish-documentation/sample-publishing-1.x-repos.sh.template
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2023, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This file lists the `publish.sh` examples,
+# which were last used for 1.x release.
+#
+# These should help end-users of `publish.sh` gather the required parameter values.
+
+# Base
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/base.git' tags='*v1.9.0' \
+    paths='base,testlib,tools/errorprone-checks,tools/javadoc-filter,tools/javadoc-prettifier,tools/model-compiler,tools/mute-logging,tools/plugin-base,tools/plugin-testlib,tools/proto-dart-plugin,tools/proto-js-plugin,tools/protoc-api,tools/protoc-plugin,tools/tool-base,tools/tools-api,tools/validation-generator'
+
+# Time
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/time.git' tags='*v1.9.0' \
+    paths='time,testutil-time'
+
+# Core Java
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/core-java.git' tags='*v1.9.0' \
+    paths='client,core,server,testutil-client,testutil-core,testutil-server'
+
+# Google Cloud Java
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/gcloud-java.git' tags='*v1.9.0' \
+    paths='datastore,pubsub,stackdriver-trace,testutil-gcloud'
+
+# Web
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/web.git' tags='*v1.9.0' \
+    paths='web,testutil-web,firebase-web'
+
+# JDBC Storage
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/jdbc-storage.git' tags='*v1.9.0' \
+    paths='rdbms'
+
+# Bootstrap
+./publish.sh repositoryUrl='https://github.com/SpineEventEngine/bootstrap.git' tags='*v1.9.0' \
+    paths='plugin'
+


### PR DESCRIPTION
This changeset updates Dokka publishing script.

Previously, Dokka output was always residing in `dokka` sub-folder. However, starting from some version of Dokka (and it's not too easy to tell from which exactly), the output for Java code is now located in `dokkaJava`.

This PR addresses this change in Dokka behaviour by modifying `publish.sh` script accordingly.

Other changes:

* More logging was added to the publishing script in order to better track potential failures.
* Samples on using `publish.sh` for `1.x` artifacts were added, so that end-users spend less time searching for proper parameter values.