### PR TITLE
Add job names

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   build:
+    name: Build under Ubuntu
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -4,6 +4,7 @@ on: pull_request
 
 jobs:
   build:
+    name: Build under Windows
     runs-on: windows-latest
 
     steps:

--- a/.github-workflows/ensure-reports-updated.yml
+++ b/.github-workflows/ensure-reports-updated.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Ensure license reports updated
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: Check version increment
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/detekt-code-analysis.yml
+++ b/.github/workflows/detekt-code-analysis.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   build:
+    name: Run Detekt code analysis
     runs-on: ubuntu-latest
 
     steps:

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -51,7 +51,7 @@ object Spine {
         const val reflect = "2.0.0-SNAPSHOT.182"
 
         /** The version of [Spine.logging]. */
-        const val logging = "2.0.0-SNAPSHOT.183"
+        const val logging = "2.0.0-SNAPSHOT.186"
 
         /** The version of [Spine.testlib]. */
         const val testlib = "2.0.0-SNAPSHOT.183"
@@ -64,25 +64,25 @@ object Spine {
         const val core = "2.0.0-SNAPSHOT.141"
 
         /** The version of [Spine.modelCompiler]. */
-        const val mc = "2.0.0-SNAPSHOT.130"
+        const val mc = "2.0.0-SNAPSHOT.132"
 
         /** The version of [McJava]. */
-        const val mcJava = "2.0.0-SNAPSHOT.132"
+        const val mcJava = "2.0.0-SNAPSHOT.147"
 
         /** The version of [Spine.baseTypes]. */
-        const val baseTypes = "2.0.0-SNAPSHOT.120"
+        const val baseTypes = "2.0.0-SNAPSHOT.121"
 
         /** The version of [Spine.time]. */
-        const val time = "2.0.0-SNAPSHOT.121"
+        const val time = "2.0.0-SNAPSHOT.131"
 
         /** The version of [Spine.change]. */
         const val change = "2.0.0-SNAPSHOT.118"
 
         /** The version of [Spine.text]. */
-        const val text = "2.0.0-SNAPSHOT.3"
+        const val text = "2.0.0-SNAPSHOT.5"
 
         /** The version of [Spine.toolBase]. */
-        const val toolBase = "2.0.0-SNAPSHOT.156"
+        const val toolBase = "2.0.0-SNAPSHOT.171"
 
         /** The version of [Spine.validation]. */
         @Deprecated("Please use `Validation.version` instead.")


### PR DESCRIPTION
This PR:
  — Add names for the GitHub Workflow jobs so that we can add them as required pre-merge checks.
  — Bumps versions of Spine modules in the dependency object.