### PR TITLE
Address warnings

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
@@ -28,9 +28,10 @@ package io.spine.internal.dependency
 
 /**
  * Okio is a transitive dependency which we don't use directly.
- * We `force` it in [DependencyResolution.forceConfiguration].
+ * We `force` it in [forceVersions] (see `DependencyResolution.kt`).
  */
 object Okio {
+
     // This is the last version before next major.
     private const val version = "1.17.5"
     const val lib = "com.squareup.okio:okio:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
@@ -26,6 +26,7 @@
 
 package io.spine.internal.dependency
 
+@Suppress("unused")
 object OsDetector {
     // https://github.com/google/osdetector-gradle-plugin
     const val version = "1.7.0"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 /**
  * Plexus Utils is a transitive dependency which we don't use directly.
- * We `force` it in [DependencyResolution.forceConfiguration].
+ * We `force` it in [forceVersions] (see `DependencyResolution.kt`).
  *
  * [Plexus Utils](https://codehaus-plexus.github.io/plexus-utils/)
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
@@ -33,8 +33,9 @@ package io.spine.internal.dependency
  * The primary purpose of having this dependency object is working in combination with
  * [Flogger.Runtime.slf4JBackend].
  *
- * Some third-party libraries may clash with different versions of the library. Thus, we specify
- * this version and force it via [io.spine.internal.gradle.forceVersions].
+ * Some third-party libraries may clash with different versions of the library.
+ * Thus, we specify this version and force it via [forceVersions].
+ * Please see `DependencyResolution.kt` for details.
  */
 @Suppress("unused")
 object Slf4J {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/IntegrationTest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/IntegrationTest.kt
@@ -71,6 +71,7 @@ val TaskContainer.integrationTest: TaskProvider<Exec>
  * }
  * ```
  */
+@Suppress("unused")
 fun DartTasks.integrationTest() =
     register(integrationTestName) {
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/github/pages/Update.kt
@@ -26,6 +26,7 @@
 
 package io.spine.internal.gradle.github.pages
 
+import io.spine.internal.gradle.git.Repository
 import java.io.File
 import java.nio.file.Path
 import org.gradle.api.Project
@@ -33,7 +34,6 @@ import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
-import io.spine.internal.gradle.git.Repository
 
 /**
  * Performs the update of GitHub pages.
@@ -90,25 +90,33 @@ private abstract class UpdateDocumentation(
         File("${repository.location}/${docsDestinationFolder}/${project.name}")
     }
 
+    private fun logDebug(message: () -> String) {
+        if (logger.isDebugEnabled) {
+            logger.debug(message())
+        }
+    }
+
     fun run() {
         val module = project.name
-        logger.debug("Update of the $toolName documentation for module `$module` started.")
+        logDebug {"Update of the $toolName documentation for module `$module` started." }
 
         val documentation = replaceMostRecentDocs()
         copyIntoVersionDir(documentation)
 
         val version = project.version
-        val updateMessage = "Update $toolName documentation for module `$module` as for " +
-                "version $version"
+        val updateMessage =
+            "Update `$toolName` documentation for module `$module` as for version $version"
         repository.commitAllChanges(updateMessage)
 
-        logger.debug("Update of the $toolName documentation for `$module` successfully finished.")
+        logDebug { "Update of the `$toolName` documentation for `$module` successfully finished." }
     }
 
     private fun replaceMostRecentDocs(): ConfigurableFileCollection {
         val generatedDocs = project.files(docsSourceFolder)
 
-        logger.debug("Replacing the most recent $toolName documentation in ${mostRecentFolder}.")
+        logDebug {
+            "Replacing the most recent `$toolName` documentation in `${mostRecentFolder}`."
+        }
         copyDocs(generatedDocs, mostRecentFolder)
 
         return generatedDocs
@@ -125,7 +133,9 @@ private abstract class UpdateDocumentation(
     private fun copyIntoVersionDir(generatedDocs: ConfigurableFileCollection) {
         val versionedDocDir = File("$mostRecentFolder/v/${project.version}")
 
-        logger.debug("Storing the new version of $toolName documentation in `${versionedDocDir}.")
+        logDebug {
+            "Storing the new version of `$toolName` documentation in `${versionedDocDir}`."
+        }
         copyDocs(generatedDocs, versionedDocDir)
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/IntegrationTest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/IntegrationTest.kt
@@ -26,10 +26,10 @@
 
 package io.spine.internal.gradle.javascript.task
 
+import io.spine.internal.gradle.TaskName
 import io.spine.internal.gradle.base.build
 import io.spine.internal.gradle.named
 import io.spine.internal.gradle.register
-import io.spine.internal.gradle.TaskName
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -74,6 +74,7 @@ val TaskContainer.integrationTest: TaskProvider<Task>
  * }
  * ```
  */
+@Suppress("unused")
 fun JsTasks.integrationTest() {
 
     linkSpineWebModule()

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/LicenseReport.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/LicenseReport.kt
@@ -54,6 +54,7 @@ import org.gradle.api.tasks.TaskProvider
  * }
  * ```
  */
+@Suppress("unused")
 fun JsTasks.licenseReport()  {
     npmLicenseReport().also {
         generateLicenseReport.configure {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/Webpack.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javascript/task/Webpack.kt
@@ -26,9 +26,9 @@
 
 package io.spine.internal.gradle.javascript.task
 
+import io.spine.internal.gradle.TaskName
 import io.spine.internal.gradle.named
 import io.spine.internal.gradle.register
-import io.spine.internal.gradle.TaskName
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -63,6 +63,7 @@ import org.gradle.api.tasks.TaskProvider
  * }
  * ```
  */
+@Suppress("unused")
 fun JsTasks.webpack() {
 
     assembleJs.configure {
@@ -92,6 +93,7 @@ private val copyBundledJsName = TaskName.of("copyBundledJs", Copy::class)
  *
  * The task copies bundled JavaScript sources to the publication directory.
  */
+@Suppress("unused")
 val TaskContainer.copyBundledJs: TaskProvider<Copy>
     get() = named(copyBundledJsName)
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/ModuleDataExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/ModuleDataExtensions.kt
@@ -49,7 +49,7 @@ internal fun MarkdownDocument.printSection(
 }
 
 /**
- * Prints the metadata of the module to the specified [Markdown document][out].
+ * Prints the module metadata to this [MarkdownDocument].
  */
 private fun MarkdownDocument.printModule(module: ModuleData) {
     ol()
@@ -105,7 +105,7 @@ private fun MarkdownDocument.printProjectUrl(projectUrl: String?, indent: Int) {
 }
 
 /**
- * Prints the links to the the source code licenses.
+ * Prints the links to the source code licenses.
  */
 @Suppress("SameParameterValue" /* Indentation is consistent across the list. */)
 private fun MarkdownDocument.printLicenses(licenses: Set<License>, indent: Int) {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/PomGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/pom/PomGenerator.kt
@@ -28,7 +28,6 @@ package io.spine.internal.gradle.report.pom
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin
-import org.gradle.kotlin.dsl.extra
 
 /**
  * Generates a `pom.xml` file that contains dependencies of the root project as


### PR DESCRIPTION
This PR addresses warnings reported in a project which uses `config` after applying the latest version. The goal is to minimise the analysis time required to dismiss these warnings as false flags.