### PR TITLE
Force JetBrains annotations

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -131,7 +131,8 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
         Jackson.dataformatYaml,
         Jackson.moduleKotlin,
         Jackson.bom,
-        Jackson.annotations
+        Jackson.annotations,
+        Kotlin.annotationsVersion
     )
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -35,7 +35,15 @@ object Kotlin {
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version = "1.8.10"
+    const val version = "1.9.0"
+
+    /**
+     * The version of the JetBrains annotations library, which is a transitive
+     * dependency for us.
+     *
+     * https://github.com/JetBrains/java-annotations
+     */
+    const val annotationsVersion = "23.0"
 
     private const val group = "org.jetbrains.kotlin"
 
@@ -53,4 +61,6 @@ object Kotlin {
 
     const val gradlePluginApi = "${group}:kotlin-gradle-plugin-api:$version"
     const val gradlePluginLib = "${group}:kotlin-gradle-plugin:${version}"
+
+    const val jetbrainsAnnotations = "${group}:annotations:$annotationsVersion"
 }


### PR DESCRIPTION
This PR forces JetBrains Annotations library, which is a transitive dependency for us. The version conflict arises when using Kotlin version 1.8.22 in `buildSrc/build.gradle.kts`.