### PR TITLE
Repo links in KDocs, bump dependencies

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,1 +1,0 @@
-ignoreRules=["SpreadOperator"]

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -35,7 +35,7 @@ package io.spine.internal.dependency
  */
 // https://github.com/google/guava
 object Guava {
-    private const val version = "31.1-jre"
+    private const val version = "32.1.1-jre"
     const val lib     = "com.google.guava:guava:${version}"
     const val testLib = "com.google.guava:guava-testlib:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object ProtoData {
-    const val version = "0.9.3"
+    const val version = "0.9.4"
     const val group = "io.spine.protodata"
     const val compiler = "$group:protodata-compiler:$version"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -31,9 +31,9 @@ package io.spine.internal.dependency
  *
  * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object ProtoData {
-    const val version = "0.8.0"
+    const val version = "0.9.3"
     const val group = "io.spine.protodata"
     const val compiler = "$group:protodata-compiler:$version"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -27,10 +27,13 @@
 package io.spine.internal.dependency
 
 // https://github.com/protocolbuffers/protobuf
-@Suppress("MemberVisibilityCanBePrivate") // used directly from outside
+@Suppress(
+    "MemberVisibilityCanBePrivate" /* used directly from outside */,
+    "ConstPropertyName"
+)
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.22.2"
+    const val version       = "3.23.4"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",
@@ -46,7 +49,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.9.2"
+        const val version = "0.9.4"
         const val id = "com.google.protobuf"
         const val lib = "${group}:protobuf-gradle-plugin:${version}"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 /**
  * Dependencies on Spine modules.
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Spine {
 
     const val group = "io.spine"
@@ -40,61 +40,97 @@ object Spine {
      */
     object ArtifactVersion {
 
-        /** The version of [ProtoData]. */
-        @Deprecated("Please use `ProtoData.version` instead.")
-        const val protoData = ProtoData.version
+        /**
+         * The version of [Spine.base].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
+         */
+        const val base = "2.0.0-SNAPSHOT.182"
 
-        /** The version of [Spine.base]. */
-        const val base = "2.0.0-SNAPSHOT.180"
-
-        /** The version of [Spine.reflect]. */
+        /**
+         * The version of [Spine.reflect].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
+         */
         const val reflect = "2.0.0-SNAPSHOT.182"
 
-        /** The version of [Spine.logging]. */
+        /**
+         * The version of [Spine.logging].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
+         */
         const val logging = "2.0.0-SNAPSHOT.186"
 
-        /** The version of [Spine.testlib]. */
-        const val testlib = "2.0.0-SNAPSHOT.183"
+        /**
+         * The version of [Spine.testlib].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/testlib">spine-testlib</a>
+         */
+        const val testlib = "2.0.0-SNAPSHOT.184"
 
         /**
          * The version of `core-java`.
+         *
          * @see [Spine.CoreJava.client]
          * @see [Spine.CoreJava.server]
+         * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.141"
+        const val core = "2.0.0-SNAPSHOT.150"
 
-        /** The version of [Spine.modelCompiler]. */
+        /**
+         * The version of [Spine.modelCompiler].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
+         */
         const val mc = "2.0.0-SNAPSHOT.132"
 
-        /** The version of [McJava]. */
+        /**
+         * The version of [McJava].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
+         */
         const val mcJava = "2.0.0-SNAPSHOT.147"
 
-        /** The version of [Spine.baseTypes]. */
-        const val baseTypes = "2.0.0-SNAPSHOT.121"
+        /**
+         * The version of [Spine.baseTypes].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
+         */
+        const val baseTypes = "2.0.0-SNAPSHOT.123"
 
-        /** The version of [Spine.time]. */
+        /**
+         * The version of [Spine.time].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
+         */
         const val time = "2.0.0-SNAPSHOT.131"
 
-        /** The version of [Spine.change]. */
+        /**
+         * The version of [Spine.change].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/change">spine-change</a>
+         */
         const val change = "2.0.0-SNAPSHOT.118"
 
-        /** The version of [Spine.text]. */
+        /**
+         * The version of [Spine.text].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
+         */
         const val text = "2.0.0-SNAPSHOT.5"
 
-        /** The version of [Spine.toolBase]. */
+        /**
+         * The version of [Spine.toolBase].
+         */
         const val toolBase = "2.0.0-SNAPSHOT.171"
 
-        /** The version of [Spine.validation]. */
-        @Deprecated("Please use `Validation.version` instead.")
-        const val validation = Validation.version
-
-        /** The version of [Spine.javadocTools]. */
+        /**
+         * The version of [Spine.javadocTools].
+         *
+         * @see <a href="https://github.com/SpineEventEngine/doc-tools">spine-javadoc-tools</a>
+         */
         const val javadocTools = "2.0.0-SNAPSHOT.75"
     }
-
-    /** The version of ProtoData to be used in the project. */
-    @Deprecated("Please use `ProtoData.version` instead.")
-    const val protoDataVersion = ProtoData.version
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
     const val logging = "$group:spine-logging:${ArtifactVersion.logging}"
@@ -125,16 +161,6 @@ object Spine {
     }
 
     const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
-
-    @Deprecated("Please use `validation.runtime`", replaceWith = ReplaceWith("validation.runtime"))
-    const val validate = "$group:spine-validate:${ArtifactVersion.base}"
-
-    @Deprecated("Please use `Validation` instead.")
-    val validation = Validation
-
-    @Suppress("MemberVisibilityCanBePrivate")
-    @Deprecated("Please use `CoreJava` instead.")
-    val coreJava = CoreJava
 
     const val client = CoreJava.client // Added for brevity.
     const val server = CoreJava.server // Added for brevity.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -31,8 +31,9 @@ package io.spine.internal.dependency
  *
  * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
  */
+@Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.81"
+    const val version = "2.0.0-SNAPSHOT.97"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"


### PR DESCRIPTION
This PR:
  * Bumps versions of internal dependencies.
  * Adds links to repositories in the `Spine` dependency object.
  * Removes Sonatype Lift configuration file.
  * Suppresses `ConstPropertyName` warning according to [our convention](https://github.com/SpineEventEngine/documentation/wiki/Kotlin-code-style#property-names-for-dependency-objects). 
  * Bumps dependencies on ProtoData and other internal SDK artifacts.
  * Bumps dependencies on Guava, Protobuf, and Protobuf Gradle Plugin.