### PR TITLE
Bump Roaster -> `2.28.0.Final`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -27,17 +27,10 @@
 package io.spine.internal.dependency
 
 // https://github.com/forge/roaster
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Roaster {
 
-    /**
-     * Do not advance this version further because it would break compatibility with Java 8
-     * projects. Starting from the following version Roaster has a shaded version of Eclipse JFace
-     * built with Java 11.
-     *
-     * Please see [this issue][https://github.com/SpineEventEngine/config/issues/220] for details.
-     */
-    private const val version = "2.24.0.Final"
+    private const val version = "2.28.0.Final"
 
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Since Spine no longer tied to Java 8, we can bump the version from `2.24.0.Final` (which was the last supporting Java 8 on the level of binaries) to the latest one. This resolves #220.

Gradle was also bumped to `7.6.2`.