### PR TITLE
Bump build script and internal dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -62,7 +62,7 @@ val grGitVersion = "4.1.1"
  * Please check that this value matches one defined in
  *  [io.spine.internal.dependency.Kotlin.version].
  */
-val kotlinVersion = "1.8.10"
+val kotlinVersion = "1.8.22"
 
 /**
  * The version of Guava used in `buildSrc`.
@@ -70,7 +70,7 @@ val kotlinVersion = "1.8.10"
  * Always use the same version as the one specified in [io.spine.internal.dependency.Guava].
  * Otherwise, when testing Gradle plugins, clashes may occur.
  */
-val guavaVersion = "31.1-jre"
+val guavaVersion = "32.1.1-jre"
 
 /**
  * The version of ErrorProne Gradle plugin.
@@ -90,7 +90,7 @@ val errorPronePluginVersion = "3.1.0"
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.9.2"
+val protobufPluginVersion = "0.9.4"
 
 /**
  * The version of Dokka Gradle Plugins.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object ProtoData {
-    const val version = "0.9.4"
+    const val version = "0.9.6"
     const val group = "io.spine.protodata"
     const val compiler = "$group:protodata-compiler:$version"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.182"
+        const val base = "2.0.0-SNAPSHOT.184"
 
         /**
          * The version of [Spine.reflect].
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.147"
+        const val mcJava = "2.0.0-SNAPSHOT.163"
 
         /**
          * The version of [Spine.baseTypes].


### PR DESCRIPTION
This PR:
 * Bumps build script dependencies declared in `buildSrc/src/build.gradle.kts`.
 * Bumps Spine and ProtoData.

The changes are tested under ProtoData and `mc-java`.
