### PR TITLE
Bump Spine Logging

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -25,6 +25,7 @@
  */
 
 import io.spine.internal.dependency.AnimalSniffer
+import io.spine.internal.dependency.Asm
 import io.spine.internal.dependency.AutoCommon
 import io.spine.internal.dependency.AutoService
 import io.spine.internal.dependency.AutoValue
@@ -116,6 +117,7 @@ private fun ResolutionStrategy.forceTestDependencies() {
  */
 private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
+        Asm.lib,
         AutoValue.annotations,
         Gson.lib,
         J2ObjC.annotations,

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Asm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Asm.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+// https://asm.ow2.io/
+@Suppress("unused")
+object Asm {
+    private const val version = "9.2"
+    const val lib = "org.ow2.asm:asm:$version"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.186"
+        const val logging = "2.0.0-SNAPSHOT.197"
 
         /**
          * The version of [Spine.testlib].

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -149,6 +149,9 @@ fun Module.addDependencies() = dependencies {
     compileOnlyApi(JavaX.annotations)
     ErrorProne.annotations.forEach { compileOnlyApi(it) }
 
+    implementation(Spine.Logging.lib)
+    runtimeOnly(Spine.Logging.backend)
+
     testImplementation(Guava.testLib)
     testImplementation(JUnit.runner)
     testImplementation(JUnit.pioneer)
@@ -159,8 +162,6 @@ fun Module.addDependencies() = dependencies {
     testImplementation(Kotest.datatest)
     testImplementation(Kotest.runnerJUnit5Jvm)
     testImplementation(JUnit.runner)
-
-    runtimeOnly(Flogger.Runtime.systemBackend)
 }
 
 fun Module.forceConfigurations() {


### PR DESCRIPTION
This PR bumps the version of `spine-logging` to the latest one, in which the published library is operational again.

Also, it substitutes a runtime dependency on Flogger's JUL backend with Spine Logging. In general, specifying of a backend makes no sense unless a facade is used. I think we can go with the following options:

1. Configure Spine logging by default with our facade and JUL backend. This option is employed in this PR.
2. Doesn't pre-configure logging at all. Remove specifying of Flogger's backend.

We **potentially can** detect which facade is used, and then specify the corresponding backend in `jvm-module`. But this will have to be done with `project.afterEvaluate { ... }` closure. Because if `jvm-module` doesn't dictate the used facade, then a concrete module is meant to dictate it. A script plugin is applied first, it can't obtain module-configured dependencies in advance. Thus, I would rather avoid this sort of tricks that tampers with Gradle configuration phases.

The version of `org.ow2.asm:asm` transitive dependency has been forced to prevent conflicts.