### PR TITLE
Configure page file for Windows build

### DIFF
--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -18,6 +18,9 @@ jobs:
           distribution: zulu
           cache: gradle
 
+      - name: Configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+
       - name: Build project and run tests
         shell: cmd
         # For the reason on `--no-daemon` see https://github.com/actions/cache/issues/454

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -49,6 +49,7 @@ import io.spine.internal.dependency.Okio
 import io.spine.internal.dependency.OpenTest4J
 import io.spine.internal.dependency.Plexus
 import io.spine.internal.dependency.Protobuf
+import io.spine.internal.dependency.Slf4J
 import io.spine.internal.dependency.Truth
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.Configuration
@@ -98,7 +99,7 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         Kotlin.stdLibJdk8,
         Protobuf.GradlePlugin.lib,
         Protobuf.libs,
-        io.spine.internal.dependency.Slf4J.lib
+        Slf4J.lib
     )
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object ProtoData {
-    const val version = "0.9.7"
+    const val version = "0.9.8"
     const val group = "io.spine.protodata"
     const val compiler = "$group:protodata-compiler:$version"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object ProtoData {
-    const val version = "0.9.8"
+    const val version = "0.9.9"
     const val group = "io.spine.protodata"
     const val compiler = "$group:protodata-compiler:$version"
 

--- a/pull
+++ b/pull
@@ -62,9 +62,6 @@ cp CODE_OF_CONDUCT.md ..
 echo "Updating Codecov settings"
 cp .codecov.yml ..
 
-echo "Updating Sonatype Lift settings"
-cp .lift.toml ..
-
 # Copies the file or directory passed as the first parameter to the upper directory,
 # only if such a file or directory does not exist there.
 function initialize() {


### PR DESCRIPTION
This PR adopts the pagefile configuration when building under Windows. It was recently adopted for `mc-java` because of memory issues during Windows build at GitHub.

Other changes:
 * Bump ProtoData -> `0.9.9`
 * Do not copy `.lyft.toml` on `pull`.
