### PR TITLE
Small fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="6">
+    <list size="7">
       <item index="0" class="java.lang.String" itemvalue="com.google.auto.service.AutoService" />
       <item index="1" class="java.lang.String" itemvalue="io.spine.core.Subscribe" />
       <item index="2" class="java.lang.String" itemvalue="io.spine.server.aggregate.Apply" />
       <item index="3" class="java.lang.String" itemvalue="io.spine.server.command.Assign" />
       <item index="4" class="java.lang.String" itemvalue="io.spine.server.command.Command" />
       <item index="5" class="java.lang.String" itemvalue="io.spine.server.event.React" />
+      <item index="6" class="java.lang.String" itemvalue="io.spine.server.route.Route" />
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -107,7 +107,7 @@ val dokkaVersion = "1.8.10"
  *
  * @see <a href="https://github.com/detekt/detekt/releases">Detekt Releases</a>
  */
-val detektVersion = "1.23.0"
+val detektVersion = "1.23.1"
 
 /**
  * @see [io.spine.internal.dependency.Kotest]

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -107,7 +107,7 @@ val dokkaVersion = "1.8.10"
  *
  * @see <a href="https://github.com/detekt/detekt/releases">Detekt Releases</a>
  */
-val detektVersion = "1.23.1"
+val detektVersion = "1.23.0"
 
 /**
  * @see [io.spine.internal.dependency.Kotest]

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused", "ConstPropertyName")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.56.1"
+    const val version        = "1.57.0"
     const val api            = "io.grpc:grpc-api:${version}"
     const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -103,7 +103,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
          */
-        const val time = "2.0.0-SNAPSHOT.132"
+        const val time = "2.0.0-SNAPSHOT.133"
 
         /**
          * The version of [Spine.change].
@@ -177,7 +177,9 @@ object Spine {
         const val pluginLib = "$toolsGroup:spine-mc-java-plugins:${version}:all"
     }
 
+    @Deprecated("Please use `javadocFilter` instead.", ReplaceWith("javadocFilter"))
     const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
+    const val javadocFilter = "$toolsGroup:spine-javadoc-filter:${ArtifactVersion.javadocTools}"
 
     const val client = CoreJava.client // Added for brevity.
     const val server = CoreJava.server // Added for brevity.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.184"
+        const val base = "2.0.0-SNAPSHOT.185"
 
         /**
          * The version of [Spine.reflect].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.150"
+        const val core = "2.0.0-SNAPSHOT.152"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -89,14 +89,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.163"
+        const val mcJava = "2.0.0-SNAPSHOT.166"
 
         /**
          * The version of [Spine.baseTypes].
          *
          * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
          */
-        const val baseTypes = "2.0.0-SNAPSHOT.123"
+        const val baseTypes = "2.0.0-SNAPSHOT.124"
 
         /**
          * The version of [Spine.time].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.152"
+        const val core = "2.0.0-SNAPSHOT.153"
 
         /**
          * The version of [Spine.modelCompiler].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -103,7 +103,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
          */
-        const val time = "2.0.0-SNAPSHOT.131"
+        const val time = "2.0.0-SNAPSHOT.132"
 
         /**
          * The version of [Spine.change].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.98"
+    const val version = "2.0.0-SNAPSHOT.99"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
@@ -33,11 +33,6 @@ import java.io.InputStream
 import java.io.StringWriter
 import java.util.*
 
-object Runtime {
-    @Suppress("unused")
-    val flogger = Flogger.Runtime
-}
-
 /**
  * Executor of CLI commands.
  *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
@@ -33,6 +33,12 @@ import java.io.StringWriter
 import java.util.*
 
 /**
+ * Utilities for working with processes from Gradle code.
+ */
+@Suppress("unused")
+private const val ABOUT = ""
+
+/**
  * Executor of CLI commands.
  *
  * Uses the passed [workingFolder] as the directory in which the commands are executed.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
@@ -26,10 +26,10 @@
 
 package io.spine.internal.gradle
 
-import com.google.common.base.Joiner
 import java.io.File
 import java.io.InputStream
 import java.io.StringWriter
+import java.lang.ProcessBuilder.Redirect.PIPE
 import java.util.*
 
 /**
@@ -60,23 +60,26 @@ class Cli(private val workingFolder: File) {
         val outWriter = StringWriter()
         val errWriter = StringWriter()
 
-        val process = ProcessBuilder(*command)
-            .directory(workingFolder)
-            .redirectOutput(ProcessBuilder.Redirect.PIPE)
-            .redirectError(ProcessBuilder.Redirect.PIPE)
-            .start()
+        val process = ProcessBuilder(*command).apply {
+            directory(workingFolder)
+            redirectOutput(PIPE)
+            redirectError(PIPE)
+        }.start()
 
-        process.inputStream!!.pourTo(outWriter)
-        process.errorStream!!.pourTo(errWriter)
-        val exitCode = process.waitFor()
+        val exitCode = process.run {
+            inputStream!!.pourTo(outWriter)
+            errorStream!!.pourTo(errWriter)
+            waitFor()
+        }
 
         if (exitCode == 0) {
             return outWriter.toString()
         } else {
-            val cmdAsString = Joiner.on(" ").join(command.iterator())
-            val errorMsg = "Command `$cmdAsString` finished with exit code $exitCode:" +
-                    " ${System.lineSeparator()}$errWriter" +
-                    " ${System.lineSeparator()}$outWriter."
+            val commandLine = command.joinToString(" ")
+            val nl = System.lineSeparator()
+            val errorMsg = "Command `$commandLine` finished with exit code $exitCode:" +
+                    "$nl$errWriter" +
+                    "$nl$outWriter."
             throw IllegalStateException(errorMsg)
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Runtime.kt
@@ -27,7 +27,6 @@
 package io.spine.internal.gradle
 
 import com.google.common.base.Joiner
-import io.spine.internal.dependency.Flogger
 import java.io.File
 import java.io.InputStream
 import java.io.StringWriter

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/ExcludeInternalDoclet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/ExcludeInternalDoclet.kt
@@ -26,6 +26,7 @@
 
 package io.spine.internal.gradle.javadoc
 
+import io.spine.internal.dependency.Spine
 import io.spine.internal.gradle.javadoc.ExcludeInternalDoclet.Companion.taskName
 import io.spine.internal.gradle.sourceSets
 import org.gradle.api.Project
@@ -36,9 +37,13 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions
 /**
  * The doclet which removes Javadoc for `@Internal` things in the Java code.
  */
-class ExcludeInternalDoclet(val version: String) {
+@Suppress("ConstPropertyName")
+class ExcludeInternalDoclet(
+    @Deprecated("`Spine.ArtifactVersion.javadocTools` is used instead.")
+    val version: String = Spine.ArtifactVersion.javadocTools
+) {
 
-    private val dependency = "io.spine.tools:spine-javadoc-filter:${version}"
+    private val dependency = Spine.javadocFilter
 
     companion object {
 

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -28,7 +28,6 @@ import BuildSettings.javaVersion
 import io.spine.internal.dependency.CheckerFramework
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
-import io.spine.internal.dependency.Flogger
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.JUnit
 import io.spine.internal.dependency.JavaX

--- a/pull
+++ b/pull
@@ -121,6 +121,9 @@ rm -f ../buildSrc/src/main/kotlin/kotlin-jvm-module.gradle.kts
 rm -f ../buildSrc/src/main/kotlin/jacoco-kmm-jvm.gradle.kts
 rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
 
+# 2023-07-30, remove outdated files.
+rm -f ../.lift.toml
+
 echo "Updating Gradle 'buildSrc' scripts"
 cp -R buildSrc ..
 


### PR DESCRIPTION
This PR:
  * Bumps gRPC.
  * Bumps internal dependencies.
  * Improves `Runtime.kt` file removing unused code and making it more idiomatic for Kotlin.
  * Makes `ExcludeInternalDoclet` class to use artifact declared in `Spine` object.
  * Extends `pull` script to take care of removal of `.lift.toml` file.
 