### PR TITLE
Add `smokeTest` lib to `Spone.Logging`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -164,6 +164,7 @@ object Spine {
         const val lib = "$group:spine-logging:$version"
         const val backend = "$group:spine-logging-backend:$version"
         const val context = "$group:spine-logging-context:$version"
+        const val smokeTest = "$group:spine-logging-smoke-test:$version"
     }
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.185"
+        const val base = "2.0.0-SNAPSHOT.186"
 
         /**
          * The version of [Spine.reflect].
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.197"
+        const val logging = "2.0.0-SNAPSHOT.198"
 
         /**
          * The version of [Spine.testlib].


### PR DESCRIPTION
This PR adds a newly created smoke test library to `Spine.Logging`. Spine modules can use this dependency to add logging smoke test to their own tests.

Take a look on [README](https://github.com/SpineEventEngine/logging/tree/master/tests/logging-smoke-test) to `logging-smoke-test` to know how to do that.