### PR TITLE
Fix environment variables for ProtoData local mode

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
  * Dependencies on ProtoData modules.
  *
  * In order to use locally published ProtoData version instead of the version from a public plugin
- * registry, set the `PROTO_DATA_VERSION` and/or the `PROTO_DATA_DF_VERSION` environment variables
+ * registry, set the `PROTODATA_VERSION` and/or the `PROTODATA_DF_VERSION` environment variables
  * and stop the Gradle daemons so that Gradle observes the env change:
  * ```
  * export PROTO_DATA_VERSION=0.43.0-local
@@ -43,15 +43,20 @@ package io.spine.internal.dependency
  * Then, in order to reset the console to run the usual versions again, remove the values of
  * the environment variables and stop the daemon:
  * ```
- * export PROTO_DATA_VERSION=""
- * export PROTO_DATA_DF_VERSION=""
+ * export PROTODATA_VERSION=""
+ * export PROTODATA_DF_VERSION=""
  *
  * ./gradle --stop
  * ```
  *
  * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
  */
-@Suppress("unused", "ConstPropertyName")
+@Suppress(
+    "unused" /* Some subprojects do not use ProtoData directly. */,
+    "ConstPropertyName" /* We use custom convention for artifact properties. */,
+    "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */,
+    "KDocUnresolvedReference" /* Referencing private properties in constructor KDoc. */
+)
 object ProtoData {
     const val group = "io.spine.protodata"
     const val pluginId = "io.spine.protodata"
@@ -76,6 +81,8 @@ object ProtoData {
      */
     val pluginLib: String
 
+    val api
+        get() = "$group:protodata-api:$version"
     val compiler
         get() = "$group:protodata-compiler:$version"
     val codegenJava
@@ -84,19 +91,19 @@ object ProtoData {
     /**
      * An env variable storing a custom [version].
      */
-    private const val VERSION_ENV = "PROTO_DATA_VERSION"
+    private const val VERSION_ENV = "PROTODATA_VERSION"
 
     /**
      * An env variable storing a custom [dogfoodingVersion].
      */
-    private const val DF_VERSION_ENV = "PROTO_DATA_DF_VERSION"
+    private const val DF_VERSION_ENV = "PROTODATA_DF_VERSION"
 
     /**
      * Sets up the versions and artifacts for the build to use.
      *
      * If either [VERSION_ENV] or [DF_VERSION_ENV] is set, those versions are used instead of
      * the hardcoded ones. Also, in this mode, the [pluginLib] coordinates are changed so that
-     * it points at a locally published artifact. Otherwise it points at an artifact that would be
+     * it points at a locally published artifact. Otherwise, it points at an artifact that would be
      * published to a public plugin registry.
      */
     init {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.209"
+        const val logging = "2.0.0-SNAPSHOT.225"
 
         /**
          * The version of [Spine.testlib].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.157"
+        const val core = "2.0.0-SNAPSHOT.159"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.168"
+        const val mcJava = "2.0.0-SNAPSHOT.170"
 
         /**
          * The version of [Spine.baseTypes].
@@ -103,7 +103,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
          */
-        const val time = "2.0.0-SNAPSHOT.133"
+        const val time = "2.0.0-SNAPSHOT.134"
 
         /**
          * The version of [Spine.change].
@@ -166,7 +166,13 @@ object Spine {
         const val lib = "$group:spine-logging:$version"
         const val backend = "$group:spine-logging-backend:$version"
         const val context = "$group:spine-logging-context:$version"
+        const val grpcContext = "$group:spine-logging-grpc-context:$version"
         const val floggerApi = "$group:spine-flogger-api:$version"
+
+        @Deprecated(
+            message = "Please use `grpcContext` instead.",
+            replaceWith = ReplaceWith("grpcContext")
+        )
         const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
         const val smokeTest = "$group:spine-logging-smoke-test:$version"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.101"
+    const val version = "2.0.0-SNAPSHOT.104"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"


### PR DESCRIPTION
This PR removes redundant underscore in the names of environment variables which ProtoData uses for running in a locally deployed version.

Other changes:
  * Internal dependencies were bumped.
  * `Spine.Logging` got `grpcContext` property, partially addressing #489.