### PR TITLE
Add Log4j2 backend to `Spine.Logging` dependency object

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -33,8 +33,8 @@ package io.spine.internal.dependency
  * registry, set the `PROTODATA_VERSION` and/or the `PROTODATA_DF_VERSION` environment variables
  * and stop the Gradle daemons so that Gradle observes the env change:
  * ```
- * export PROTO_DATA_VERSION=0.43.0-local
- * export PROTO_DATA_DF_VERSION=0.41.0
+ * export PROTODATA_VERSION=0.43.0-local
+ * export PROTODATA_DF_VERSION=0.41.0
  *
  * ./gradle --stop
  * ./gradle build   # Conduct the intended checks.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -168,6 +168,11 @@ object Spine {
         const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
         const val context = "$group:spine-logging-context:$version"
         const val grpcContext = "$group:spine-logging-grpc-context:$version"
+
+        @Deprecated(
+            message = "Please use `Logging.lib` instead.",
+            replaceWith = ReplaceWith("lib")
+        )
         const val floggerApi = "$group:spine-flogger-api:$version"
 
         @Deprecated(

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -165,6 +165,7 @@ object Spine {
         const val version = ArtifactVersion.logging
         const val lib = "$group:spine-logging:$version"
         const val backend = "$group:spine-logging-backend:$version"
+        const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
         const val context = "$group:spine-logging-context:$version"
         const val grpcContext = "$group:spine-logging-grpc-context:$version"
         const val floggerApi = "$group:spine-flogger-api:$version"


### PR DESCRIPTION
This PR does the following:

1. Adds Log4j2 backend to `Spine.Logging`.
2. Deprecates usage of `Spine.Logging.floggerApi`. Now, it is a transitive dependency for `spine-logging`. And I can't say why anyone would need it explicitly.
3. Fixes env names in a code snippet to `ProtoData`.