### PR TITLE
Rollback `Roaster`, bump `Logging`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -30,7 +30,14 @@ package io.spine.internal.dependency
 @Suppress("unused", "ConstPropertyName")
 object Roaster {
 
-    private const val version = "2.29.0.Final"
+    /**
+     * This is the last version build with Java 11.
+     *
+     * Starting from version
+     * [2.29.0.Final](https://github.com/forge/roaster/releases/tag/2.29.0.Final),
+     * Roaster requires Java 17.
+     */
+    private const val version = "2.28.0.Final"
 
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.183"
+        const val toolBase = "2.0.0-SNAPSHOT.186"
 
         /**
          * The version of [Spine.javadocTools].


### PR DESCRIPTION
This PR:
  * Rolls back Roaster to `2.28.0.Final`, which is the last version build with Java 11.
  * Bumps Spine Logging to `2.0.0-SNAPSHOT.186`.
