### PR TITLE
Bump `spine-logging`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,6 @@ repositories {
 }
 
 detekt {
-    source.from("buildSrc/src/main/kotlin")
-    config.from("quality/detekt-config.yml")
+    config.setFrom("quality/detekt-config.yml")
+    source.setFrom("buildSrc/src/main/kotlin")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,5 +36,5 @@ repositories {
 
 detekt {
     source.from("buildSrc/src/main/kotlin")
-    config = files("quality/detekt-config.yml")
+    config.from("quality/detekt-config.yml")
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -164,10 +164,18 @@ object Spine {
     object Logging {
         const val version = ArtifactVersion.logging
         const val lib = "$group:spine-logging:$version"
-        const val backend = "$group:spine-logging-backend:$version"
+
         const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
-        const val context = "$group:spine-logging-context:$version"
+        const val stdContext = "$group:spine-logging-std-context:$version"
         const val grpcContext = "$group:spine-logging-grpc-context:$version"
+        const val smokeTest = "$group:spine-logging-smoke-test:$version"
+
+        // Transitive dependencies.
+        // Make `public` and use them to force a version in a particular repository, if needed.
+        internal const val julBackend = "$group:spine-logging-jul-backend:$version"
+        internal const val middleware = "$group:spine-logging-middleware:$version"
+        internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
+        internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
 
         @Deprecated(
             message = "Please use `Logging.lib` instead.",

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.226"
+        const val logging = "2.0.0-SNAPSHOT.232"
 
         /**
          * The version of [Spine.testlib].
@@ -180,7 +180,6 @@ object Spine {
             replaceWith = ReplaceWith("grpcContext")
         )
         const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
-        const val smokeTest = "$group:spine-logging-smoke-test:$version"
     }
 
     /**

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -149,7 +149,6 @@ fun Module.addDependencies() = dependencies {
     ErrorProne.annotations.forEach { compileOnlyApi(it) }
 
     implementation(Spine.Logging.lib)
-    runtimeOnly(Spine.Logging.backend)
 
     testImplementation(Guava.testLib)
     testImplementation(JUnit.runner)


### PR DESCRIPTION
This PR bumps `spine-logging` to `2.0.0-SNAPSHOT.232` and updates its artifacts.