### PR TITLE
Apply dependencies tried in `core-java`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,8 +34,12 @@ plugins {
     java
     groovy
     `kotlin-dsl`
-    val licenseReportVersion = "2.1"
-    id("com.github.jk1.dependency-license-report").version(licenseReportVersion)
+
+    // https://github.com/jk1/Gradle-License-Report/releases
+    id("com.github.jk1.dependency-license-report").version("2.1")
+
+    // https://github.com/johnrengelman/shadow/releases
+    id("com.github.johnrengelman.shadow").version("7.1.2")
 }
 
 repositories {
@@ -50,17 +54,27 @@ repositories {
  * Please keep this value in sync. with `io.spine.internal.dependency.Jackson.version`.
  * It's not a requirement, but would be good in terms of consistency.
  */
-val jacksonVersion = "2.13.4"
+val jacksonVersion = "2.15.3"
 
-val googleAuthToolVersion = "2.1.2"
+/**
+ * The version of Google Artifact Registry used by `buildSrc`.
+ *
+ * The version `2.1.5` is the latest before `2.2.0`, which introduces breaking changes.
+ *
+ * @see <a href="https://mvnrepository.com/artifact/com.google.cloud.artifactregistry/artifactregistry-auth-common">
+ *     Google Artifact Registry at Maven</a>
+ */
+val googleAuthToolVersion = "2.1.5"
+
 val licenseReportVersion = "2.1"
+
 val grGitVersion = "4.1.1"
 
 /**
- * The version of the Kotlin Gradle plugin.
+ * The version of the Kotlin Gradle plugin and Kotlin binaries used by the build process.
  *
- * Please check that this value matches one defined in
- *  [io.spine.internal.dependency.Kotlin.version].
+ * This version may change from the [version of Kotlin][io.spine.internal.dependency.Kotlin.version]
+ * used by the project.
  */
 val kotlinVersion = "1.8.22"
 
@@ -70,7 +84,7 @@ val kotlinVersion = "1.8.22"
  * Always use the same version as the one specified in [io.spine.internal.dependency.Guava].
  * Otherwise, when testing Gradle plugins, clashes may occur.
  */
-val guavaVersion = "32.1.2-jre"
+val guavaVersion = "32.1.3-jre"
 
 /**
  * The version of ErrorProne Gradle plugin.
@@ -100,7 +114,7 @@ val protobufPluginVersion = "0.9.4"
  * @see <a href="https://github.com/Kotlin/dokka/releases">
  *     Dokka Releases</a>
  */
-val dokkaVersion = "1.8.20"
+val dokkaVersion = "1.9.10"
 
 /**
  * The version of Detekt Gradle Plugin.
@@ -122,6 +136,7 @@ val koverVersion = "0.7.2"
 configurations.all {
     resolutionStrategy {
         force(
+            "com.google.guava:guava:${guavaVersion}",
             "com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion",
 
             // Force Kotlin lib versions avoiding using those bundled with Gradle.
@@ -147,7 +162,9 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    implementation("com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion") {
+    implementation(
+        "com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion"
+    ) {
         exclude(group = "com.google.guava")
     }
     implementation("com.google.guava:guava:$guavaVersion")

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
@@ -31,6 +31,7 @@ package io.spine.internal.dependency
  *
  * [AssertK](https://github.com/willowtreeapps/assertk)
  */
+@Deprecated("Please use Kotest assertions instead.")
 @Suppress("unused", "ConstPropertyName")
 object AssertK {
     private const val version = "0.26.1"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -26,9 +26,21 @@
 
 package io.spine.internal.dependency
 
-// https://checkstyle.sourceforge.io/
-// See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
+/**
+ * Dependencies on Checkstyle Java linter.
+ *
+ * @see <a href="https://checkstyle.sourceforge.io/">Checkstyle</a>
+ * @see [io.spine.internal.gradle.checkstyle.CheckStyleConfig]
+ */
 @Suppress("unused", "ConstPropertyName")
 object CheckStyle {
-    const val version = "10.3.4"
+    /**
+     * The version to be used in the project.
+     *
+     * `10.12.1` is the last version in `10.12.0`, which does not introduce
+     * capability conflict over `google-collections` with Guava.
+     *
+     * @see <a href="https://checkstyle.sourceforge.io/releasenotes.html">Checkstyle</a>
+     */
+    const val version = "10.12.1"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://checkerframework.org/
 @Suppress("unused", "ConstPropertyName")
 object CheckerFramework {
-    private const val version = "3.37.0"
+    private const val version = "3.40.0"
     const val annotations = "org.checkerframework:checker-qual:${version}"
     @Suppress("unused")
     val dataflow = listOf(

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -35,14 +35,14 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.8.20"
+    const val version = "1.9.10"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"
 
         /**
          * The version of this plugin is already specified in `buildSrc/build.gradle.kts`
-         * file. Thus, when applying the plugin in project's build files, only the [id]
+         * file. Thus, when applying the plugin to project's build files, only the [id]
          * should be used.
          */
         const val lib = "${group}:dokka-gradle-plugin:${version}"
@@ -59,7 +59,7 @@ object Dokka {
     }
 
     /**
-     * To generate the documentation as seen from Java perspective use this plugin.
+     * To generate the documentation as seen from the Java perspective, please use this plugin.
      *
      * @see <a href="https://github.com/Kotlin/dokka#output-formats">
      *     Dokka output formats</a>

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused", "ConstPropertyName")
 object ErrorProne {
     // https://github.com/google/error-prone
-    private const val version = "2.21.1"
+    private const val version = "2.23.0"
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -48,9 +48,9 @@ object ErrorProne {
         const val id = "net.ltgt.errorprone"
         /**
          * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
-         * Thus, when applying the plugin in projects build files, only the [id] should be used.
+         * Thus, when applying the plugin to projects build files, only the [id] should be used.
          *
-         * When the plugin is used as a library (e.g. in tools), its version and the library
+         * When the plugin is used as a library (e.g., in tools), its version and the library
          * artifacts are of importance.
          */
         const val version = "3.1.0"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
@@ -27,11 +27,12 @@
 package io.spine.internal.dependency
 
 /**
- * The FindBugs project is dead since 2017. It has a successor called SpotBugs, but we don't use it.
- * We use ErrorProne for static analysis instead. The only reason for having this dependency is
- * the annotations for null-checking introduced by JSR-305. These annotations are troublesome,
- * but no alternatives are known for some of them so far.  Please see
- * [this issue](https://github.com/SpineEventEngine/base/issues/108) for more details.
+ * The FindBugs project has been dead since 2017. It has a successor called SpotBugs,
+ * but we don't use it. We use ErrorProne for static analysis instead.
+ * The only reason for having this dependency is the annotations for null-checking
+ * introduced by JSR-305. These annotations are troublesome,
+ * but no alternatives are known for some of them so far.
+ * Please see [this issue](https://github.com/SpineEventEngine/base/issues/108) for more details.
  */
 @Suppress("unused", "ConstPropertyName")
 object FindBugs {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.dependency
 
 // https://github.com/google/flogger
+@Deprecated("Please use Spine Logging library instead.")
 @Suppress("unused", "ConstPropertyName")
 object Flogger {
     internal const val version = "0.7.4"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,11 +30,12 @@ package io.spine.internal.dependency
 @Suppress("unused", "ConstPropertyName")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.57.2"
+    const val version        = "1.59.0"
     const val api            = "io.grpc:grpc-api:${version}"
     const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"
     const val context        = "io.grpc:grpc-context:${version}"
+    const val inProcess      = "io.grpc:grpc-inprocess:${version}"
     const val stub           = "io.grpc:grpc-stub:${version}"
     const val okHttp         = "io.grpc:grpc-okhttp:${version}"
     const val protobuf       = "io.grpc:grpc-protobuf:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 /**
- * Gson is a transitive dependency which we don't use directly.
+ * Gson is a transitive dependency, which we don't use directly.
  * We `force` it in [DependencyResolution.forceConfiguration()].
  *
  * [Gson](https://github.com/google/gson)

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -37,7 +37,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Guava {
-    private const val version = "32.1.2-jre"
+    private const val version = "32.1.3-jre"
     const val lib     = "com.google.guava:guava:${version}"
     const val testLib = "com.google.guava:guava-testlib:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -32,7 +32,7 @@ package io.spine.internal.dependency
 @Suppress("unused", "ConstPropertyName")
 object HttpClient {
     // https://github.com/googleapis/google-http-java-client
-    const val version  = "1.41.5"
+    const val version  = "1.43.3"
     const val google   = "com.google.http-client:google-http-client:${version}"
     const val jackson2 = "com.google.http-client:google-http-client-jackson2:${version}"
     const val gson     = "com.google.http-client:google-http-client-gson:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -27,15 +27,24 @@
 package io.spine.internal.dependency
 
 /**
- * [J2ObjC](https://developers.google.com/j2objc) is a transitive dependency
+ * [J2ObjC](https://developers.google.com/j2objc) is a transitive dependency,
  * which we don't use directly. This object is used for forcing the version.
  */
 @Suppress("unused", "ConstPropertyName")
 object J2ObjC {
-    // https://github.com/google/j2objc/releases
-    // `1.3.` is the latest version available from Maven Central.
-    // https://search.maven.org/artifact/com.google.j2objc/j2objc-annotations
-    private const val version = "1.3"
+    /**
+     * See [J2ObjC releases](https://github.com/google/j2objc/releases).
+     *
+     * `1.3.` was the latest version available from Maven Central.
+     * Now `2.8` is the latest version available.
+     * As [HttpClient]
+     * [migrated](https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3) to v2,
+     * we set the latest v2 version as well.
+     *
+     * @see <a href="https://search.maven.org/artifact/com.google.j2objc/j2objc-annotations">
+     *     J2ObjC on Maven Central</a>
+     */
+    private const val version = "2.8"
     const val annotations = "com.google.j2objc:j2objc-annotations:${version}"
     @Deprecated("Please use `annotations` instead.", ReplaceWith("annotations"))
     const val lib = annotations

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -29,8 +29,8 @@ package io.spine.internal.dependency
 // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
 @Suppress("unused", "ConstPropertyName")
 object Jackson {
-    const val version = "2.15.2"
-    private const val databindVersion = "2.15.2"
+    const val version = "2.15.3"
+    private const val databindVersion = "2.15.3"
 
     private const val coreGroup = "com.fasterxml.jackson.core"
     private const val dataformatGroup = "com.fasterxml.jackson.dataformat"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
@@ -37,7 +37,7 @@ object JavaJwt {
     /**
      * The last version in the v3.x.x series.
      *
-     * There's a v4.x.x series (e.g. https://github.com/auth0/java-jwt/releases/tag/4.4.0), but
+     * There's a v4.x.x series (e.g., https://github.com/auth0/java-jwt/releases/tag/4.4.0), but
      * it introduces breaking changes. Consider upgrading to it when we're ready to migrate.
      */
     private const val version = "3.19.4"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
@@ -35,7 +35,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Kotest {
-    const val version = "5.6.2"
+    const val version = "5.8.0"
     const val group = "io.kotest"
     const val assertions = "$group:kotest-assertions-core:$version"
     const val runnerJUnit5 = "$group:kotest-runner-junit5:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -35,15 +35,15 @@ object Kotlin {
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version = "1.9.0"
+    const val version = "1.9.20"
 
     /**
      * The version of the JetBrains annotations library, which is a transitive
      * dependency for us via Kotlin libraries.
      *
-     * https://github.com/JetBrains/java-annotations
+     * @see <a href="https://github.com/JetBrains/java-annotations">Java Annotations</a>
      */
-    private const val annotationsVersion = "23.0.0"
+    private const val annotationsVersion = "24.0.1"
 
     private const val group = "org.jetbrains.kotlin"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kover.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kover.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin/kotlinx-kover
 @Suppress("unused", "ConstPropertyName")
 object Kover {
-    const val version = "0.7.3"
+    const val version = "0.7.4"
     const val id = "org.jetbrains.kotlinx.kover"
     const val classpath = "org.jetbrains.kotlinx:kover-gradle-plugin:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
@@ -28,8 +28,8 @@ package io.spine.internal.dependency
 
 @Suppress("unused", "ConstPropertyName")
 object Netty {
-    // https://github.com/netty/netty/releases
-    private const val version = "4.1.96.Final"
+    // https://github.com/netty/netty/tags
+    private const val version = "4.1.100.Final"
     const val common = "io.netty:netty-common:${version}"
     const val buffer = "io.netty:netty-buffer:${version}"
     const val transport = "io.netty:netty-transport:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
@@ -27,13 +27,12 @@
 package io.spine.internal.dependency
 
 /**
- * Okio is a transitive dependency which we don't use directly.
- * We `force` it in [forceVersions] (see `DependencyResolution.kt`).
+ * Okio is a transitive dependency, which we don't use directly.
+ *
+ * https://github.com/square/okio/tags
  */
 @Suppress("unused", "ConstPropertyName")
 object Okio {
-
-    // This is the last version before next major.
-    private const val version = "1.17.5"
+    private const val version = "3.6.0"
     const val lib = "com.squareup.okio:okio:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
@@ -29,8 +29,7 @@
 package io.spine.internal.dependency
 
 /**
- * Plexus Utils is a transitive dependency which we don't use directly.
- * We `force` it in [forceVersions] (see `DependencyResolution.kt`).
+ * Plexus Utils is a transitive dependency, which we don't use directly.
  *
  * [Plexus Utils](https://github.com/codehaus-plexus/plexus-utils)
  */
@@ -44,6 +43,6 @@ object Plexus {
      *
      * @see <a href="https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-4.0.0">plexus-utils-4.0.0</a>
      */
-    private const val version = "3.5.1"
+    private const val version = "4.0.0"
     const val utils = "org.codehaus.plexus:plexus-utils:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.12.0"
+    private const val fallbackVersion = "0.14.2"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.9.11"
+    private const val fallbackDfVersion = "0.14.2"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -28,14 +28,18 @@ package io.spine.internal.dependency
 
 // https://github.com/protocolbuffers/protobuf
 @Suppress(
-    "MemberVisibilityCanBePrivate" /* used directly from outside */,
-    "ConstPropertyName"
+    "MemberVisibilityCanBePrivate" /* used directly from the outside */,
+    "ConstPropertyName" /* https://bit.ly/kotlin-prop-names */
 )
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.24.1"
+    const val version       = "3.25.0"
+    /**
+     * The Java library containing proto definitions of Google Protobuf.
+     */
+    const val protoSrcLib = "${group}:protobuf-java:${version}"
     val libs = listOf(
-        "${group}:protobuf-java:${version}",
+        protoSrcLib,
         "${group}:protobuf-java-util:${version}",
         "${group}:protobuf-kotlin:${version}"
     )
@@ -45,7 +49,7 @@ object Protobuf {
     object GradlePlugin {
         /**
          * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
-         * Thus, when applying the plugin in projects build files, only the [id] should be used.
+         * Thus, when applying the plugin to projects build files, only the [id] should be used.
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -103,7 +103,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
          */
-        const val time = "2.0.0-SNAPSHOT.134"
+        const val time = "2.0.0-SNAPSHOT.135"
 
         /**
          * The version of [Spine.change].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.232"
+        const val logging = "2.0.0-SNAPSHOT.233"
 
         /**
          * The version of [Spine.testlib].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.159"
+        const val core = "2.0.0-SNAPSHOT.173"
 
         /**
          * The version of [Spine.modelCompiler].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.189"
+        const val base = "2.0.0-SNAPSHOT.192"
 
         /**
          * The version of [Spine.reflect].
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.226"
+        const val logging = "2.0.0-SNAPSHOT.232"
 
         /**
          * The version of [Spine.testlib].
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.170"
+        const val mcJava = "2.0.0-SNAPSHOT.172"
 
         /**
          * The version of [Spine.baseTypes].
@@ -164,10 +164,18 @@ object Spine {
     object Logging {
         const val version = ArtifactVersion.logging
         const val lib = "$group:spine-logging:$version"
-        const val backend = "$group:spine-logging-backend:$version"
+
         const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"
-        const val context = "$group:spine-logging-context:$version"
+        const val stdContext = "$group:spine-logging-std-context:$version"
         const val grpcContext = "$group:spine-logging-grpc-context:$version"
+        const val smokeTest = "$group:spine-logging-smoke-test:$version"
+
+        // Transitive dependencies.
+        // Make `public` and use them to force a version in a particular repository, if needed.
+        internal const val julBackend = "$group:spine-logging-jul-backend:$version"
+        internal const val middleware = "$group:spine-logging-middleware:$version"
+        internal const val platformGenerator = "$group:spine-logging-platform-generator:$version"
+        internal const val jvmDefaultPlatform = "$group:spine-logging-jvm-default-platform:$version"
 
         @Deprecated(
             message = "Please use `Logging.lib` instead.",
@@ -180,7 +188,6 @@ object Spine {
             replaceWith = ReplaceWith("grpcContext")
         )
         const val floggerGrpcContext = "$group:spine-flogger-grpc-context:$version"
-        const val smokeTest = "$group:spine-logging-smoke-test:$version"
     }
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -195,10 +195,12 @@ object Spine {
      *
      * See [mc-java](https://github.com/SpineEventEngine/mc-java).
      */
+    @Suppress("MemberVisibilityCanBePrivate") // `pluginLib()` is used by subprojects.
     object McJava {
         const val version = ArtifactVersion.mcJava
         const val pluginId = "io.spine.mc-java"
-        const val pluginLib = "$toolsGroup:spine-mc-java-plugins:${version}:all"
+        val pluginLib = pluginLib(version)
+        fun pluginLib(version: String): String = "$toolsGroup:spine-mc-java-plugins:$version:all"
     }
 
     @Deprecated("Please use `javadocFilter` instead.", ReplaceWith("javadocFilter"))

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -37,6 +37,7 @@ object Validation {
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"
+    const val javaBundle = "$group:spine-validation-java-bundle:$version"
     const val model = "$group:spine-validation-model:$version"
     const val config = "$group:spine-validation-configuration:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.104"
+    const val version = "2.0.0-SNAPSHOT.110"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -149,7 +149,6 @@ fun Module.addDependencies() = dependencies {
     ErrorProne.annotations.forEach { compileOnlyApi(it) }
 
     implementation(Spine.Logging.lib)
-    runtimeOnly(Spine.Logging.backend)
 
     testImplementation(Guava.testLib)
     testImplementation(JUnit.runner)


### PR DESCRIPTION
This PR applies dependencies recently tried `core-java` with the aim of propagation these changes to other Spine SDK subprojects.
