### PR TITLE
Add Shadow plugin, force transitive dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -171,11 +171,29 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+
+    @Suppress(
+        "VulnerableLibrariesLocal", "RedundantSuppression" /*
+        `artifactregistry-auth-common` has transitive dependency on Gson and Apache `commons-codec`.
+
+        Gson from version `2.8.6` until `2.8.9` is vulnerable to Deserialization of Untrusted Data
+         (https://devhub.checkmarx.com/cve-details/CVE-2022-25647/).
+
+        Apache `commons-codec` before 1.13 is vulnerable to information exposure
+        (https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/).
+
+        We use Gson `2.10.1`and we force it in `forceProductionDependencies()`.
+        We use `commons-code` with version `1.16.0`, forcing it in `forceProductionDependencies()`.
+
+        So, we should be safe with the current version `artifactregistry-auth-common` until
+        we migrate to a later version. */
+    )
     implementation(
         "com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion"
     ) {
         exclude(group = "com.google.guava")
     }
+
     implementation("com.google.guava:guava:$guavaVersion")
     api("com.github.jk1:gradle-license-report:$licenseReportVersion")
     implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -133,6 +133,15 @@ val kotestJvmPluginVersion = "0.4.10"
  */
 val koverVersion = "0.7.2"
 
+/**
+ * The version of the Shadow Plugin.
+ *
+ * `7.1.2` is the last version compatible with Gradle 7.x. Newer versions require Gradle v8.x.
+ *
+ * @see <a href="https://github.com/johnrengelman/shadow/releases">Shadow Plugin releases</a>
+ */
+val shadowVersion = "7.1.2"
+
 configurations.all {
     resolutionStrategy {
         force(
@@ -180,6 +189,7 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}")
     implementation("org.jetbrains.dokka:dokka-base:${dokkaVersion}")
+    implementation("gradle.plugin.com.github.johnrengelman:shadow:${shadowVersion}")
 
     // https://github.com/srikanth-lingala/zip4j
     implementation("net.lingala.zip4j:zip4j:2.10.0")

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -31,11 +31,11 @@ import io.spine.internal.dependency.AutoService
 import io.spine.internal.dependency.AutoValue
 import io.spine.internal.dependency.CheckerFramework
 import io.spine.internal.dependency.CommonsCli
+import io.spine.internal.dependency.CommonsCodec
 import io.spine.internal.dependency.CommonsLogging
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.FindBugs
-import io.spine.internal.dependency.Flogger
 import io.spine.internal.dependency.Gson
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.Hamcrest
@@ -90,8 +90,7 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         ErrorProne.annotations,
         ErrorProne.core,
         FindBugs.annotations,
-        Flogger.Runtime.systemBackend,
-        Flogger.lib,
+        Gson.lib,
         Guava.lib,
         Kotlin.reflect,
         Kotlin.stdLib,
@@ -124,6 +123,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
         Asm.lib,
         AutoValue.annotations,
         CommonsCli.lib,
+        CommonsCodec.lib,
         CommonsLogging.lib,
         Gson.lib,
         Hamcrest.core,

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -35,7 +35,7 @@ object J2ObjC {
     /**
      * See [J2ObjC releases](https://github.com/google/j2objc/releases).
      *
-     * `1.3.` was the latest version available from Maven Central.
+     * `1.3` was the latest version available from Maven Central.
      * Now `2.8` is the latest version available.
      * As [HttpClient]
      * [migrated](https://github.com/googleapis/google-http-java-client/releases/tag/v1.43.3) to v2,


### PR DESCRIPTION
This PR adds the Shadow plugin to the `buildSrc/build.gradle.kts` so that it's not erased by `config` update in Validation and other subprojects.

Also this PR forces transitive dependencies of `com.google.cloud.artifactregistry:artifactregistry-auth-common`, we we cannot bump after `2.1.5` because of breaking changes. For now we're safe, but `artifactregistry-auth-common` needs to be updated sometime to minimise the "noise" in the build code.