### PR TITLE
Write dependency-license report to `dependencies.md`

### DIFF
--- a/.github-workflows/ensure-reports-updated.yml
+++ b/.github-workflows/ensure-reports-updated.yml
@@ -20,6 +20,6 @@ jobs:
           # Check out the `config` submodule to fetch the required script file.
           submodules: true
 
-      - name: Check that `pom.xml` and `license-report.md` are modified
+      - name: Check that both `pom.xml` and license report files are modified
         shell: bash
         run: chmod +x ./config/scripts/ensure-reports-updated.sh && ./config/scripts/ensure-reports-updated.sh

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/Paths.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/license/Paths.kt
@@ -40,7 +40,7 @@ internal object Paths {
      * Its contents describe the licensing information for each of the Java dependencies
      * which are referenced by Gradle projects in the repository.
      */
-    internal const val outputFilename = "license-report.md"
+    internal const val outputFilename = "dependencies.md"
 
     /**
      * The path to a directory, to which a per-project report is generated.

--- a/pull
+++ b/pull
@@ -124,6 +124,10 @@ rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.
 # 2023-07-30, remove outdated files.
 rm -f ../.lift.toml
 
+# 2023-11-24, remove `license-report.md` in favor of `dependencies.md`
+# See `config#498` for more.
+rm -f ../license-report.md
+
 echo "Updating Gradle 'buildSrc' scripts"
 cp -R buildSrc ..
 

--- a/scripts/ensure-reports-updated.sh
+++ b/scripts/ensure-reports-updated.sh
@@ -27,9 +27,13 @@
 
 # This script is a part of a GitHub Actions workflow.
 #
-# Its purpose is to prevent PRs from leaving `pom.xml` and `license-report.md` from being untouched.
-# In case any of these files are not updated, it exits with an error code 1.
+# Its purpose is to prevent PRs from leaving `pom.xml` and license report files
+# from being untouched. In case any of these files are not updated, it exits with an error code 1.
 # Otherwise, exits with a success code 0.
+#
+# According to https://github.com/SpineEventEngine/config/issues/498,
+# `license-report.md` is now renamed to `dependencies.md`. However, not every Spine repository
+# uses this convention yet, so this script ensures that either of files is modified.
 #
 # In its implementation, the script relies into the environment variables set by GitHub Actions.
 # See https://docs.github.com/en/actions/reference/environment-variables.
@@ -37,7 +41,7 @@
 
 # Detects if the file with the passed name has been updated in this changeset.
 #
-# Exists with the code 1, if such a file has NOT been modified.
+# Exits with the code 1, if such a file has NOT been modified.
 # Does nothing, if any modification was found.
 function ensureUpdated() {
 	modificationCount=$(git diff --name-only remotes/origin/$GITHUB_BASE_REF...remotes/origin/$GITHUB_HEAD_REF | grep $1 | wc -l)
@@ -50,11 +54,34 @@ function ensureUpdated() {
 	fi
 }
 
+# Detects if any of TWO files with the passed names has been updated in this changeset.
+#
+# Exits with the code 1, if NONE of the files have been modified.
+# Does nothing, if a modification in any of the files was found.
+function ensureEitherUpdated() {
+	firstModCount=$(git diff --name-only remotes/origin/$GITHUB_BASE_REF...remotes/origin/$GITHUB_HEAD_REF | grep $1 | wc -l)
+	if [ "$firstModCount" -eq "0" ];
+	then
+	   echo "'$1' file has not been updated in this PR. Checking '$2'...";
+	   secondModCount=$(git diff --name-only remotes/origin/$GITHUB_BASE_REF...remotes/origin/$GITHUB_HEAD_REF | grep $2 | wc -l)
+	   if [ "$secondModCount" -eq "0" ];
+	   then
+	       echo "ERROR: Neither '$1' nor '$2' files have been updated in this PR. Please re-check the changeset.";
+	       exit 1;
+	   else
+	       echo "Detected the modifications in '$2'."
+	   fi
+	else
+		echo "Detected the modifications in '$1'."
+	fi
+}
+
 echo "Starting to check if all required files were updated within this PR..."
 echo "Comparing \"remotes/origin/$GITHUB_HEAD_REF\" branch to \"remotes/origin/$GITHUB_BASE_REF\" contents."
 
 ensureUpdated "pom.xml"
-ensureUpdated "license-report.md"
+ensureEitherUpdated "license-report.md" "dependencies.md"
 
 echo "All good."
 exit 0;
+


### PR DESCRIPTION
According to #498, `license-report.md` is renamed to `dependencies.md` within this changeset.

Additionally, the CI workflows are now configured to check than either `license-report.md` (for non-migrated repos, which still use this file) or `dependencies.md` is modified within the changeset.

`pull` script has been modified to kill `license-report.md` file. 

:warning: `config` end-users will have to add a newly generated `dependencies.md` to Git themselves.