### PR TITLE
Force Kotlin `stdlib-jdk7` dependency version

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -80,7 +80,7 @@ fun NamedDomainObjectContainer<Configuration>.forceVersions() {
 }
 
 private fun ResolutionStrategy.forceProductionDependencies() {
-    @Suppress("DEPRECATION") // Force SLF4J version.
+    @Suppress("DEPRECATION") // Force versions of SLF4J and Kotlin libs.
     force(
         AnimalSniffer.lib,
         AutoCommon.lib,
@@ -95,6 +95,7 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         Kotlin.reflect,
         Kotlin.stdLib,
         Kotlin.stdLibCommon,
+        Kotlin.stdLibJdk7,
         Kotlin.stdLibJdk8,
         Protobuf.GradlePlugin.lib,
         Protobuf.libs,


### PR DESCRIPTION
This PR forces `kotlin-stdlib-jdk7` dependency version.

As it turns out, this dependency comes as conflicting in at least `base`, `reflect` (!), and `logging` libraries. Apparently, some of our direct dependencies brings the old version of this library with it.

After some attempts to find out, which dependency is "guilty", I gave up, as no clear answer is available. So it's easier to force its version.