### PR TITLE
Add PSI dependencies

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -4,10 +4,10 @@
     <option name="jvmTarget" value="11" />
   </component>
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.9.0" />
-    <option name="languageVersion" value="1.9.0" />
+    <option name="apiVersion" value="1.9.22" />
+    <option name="languageVersion" value="1.9.22" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("ConstPropertyName")
+
+package io.spine.internal.dependency
+
+/**
+ * The components of the IntelliJ Platform.
+ *
+ * Make sure to add the `intellijReleases` and `jetBrainsCacheRedirector`
+ * repositories to your project. See `kotlin/Repositories.kt` for details.
+ */
+@Suppress("unused")
+object IntelliJ {
+
+    /**
+     * The version of the IntelliJ platform.
+     *
+     * This is the version used by Kotlin compiler `1.9.21`.
+     * Advance this version with caution because it may break the setup of
+     * IntelliJ platform standalone execution.
+     */
+    const val version = "213.7172.53"
+
+    object Platform {
+        private const val group = "com.jetbrains.intellij.platform"
+        const val core = "$group:core:$version"
+        const val util = "$group:util:$version"
+    }
+
+    object JavaPsi {
+        private const val group = "com.jetbrains.intellij.java"
+        const val api = "$group:java-psi:$version"
+        const val impl = "$group:java-psi-impl:$version"
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -34,8 +34,8 @@ object Kotlin {
     /**
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
-    @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version = "1.9.20"
+    @Suppress("MemberVisibilityCanBePrivate") // used directly from the outside.
+    const val version = "1.9.22"
 
     /**
      * The version of the JetBrains annotations library, which is a transitive

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.14.2"
+    private const val fallbackVersion = "0.15.3"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.14.2"
+    private const val fallbackDfVersion = "0.15.3"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,14 +45,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.192"
+        const val base = "2.0.0-SNAPSHOT.194"
 
         /**
          * The version of [Spine.reflect].
          *
          * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
          */
-        const val reflect = "2.0.0-SNAPSHOT.182"
+        const val reflect = "2.0.0-SNAPSHOT.183"
 
         /**
          * The version of [Spine.logging].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.173"
+        const val core = "2.0.0-SNAPSHOT.175"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -89,14 +89,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.172"
+        const val mcJava = "2.0.0-SNAPSHOT.177"
 
         /**
          * The version of [Spine.baseTypes].
          *
          * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
          */
-        const val baseTypes = "2.0.0-SNAPSHOT.125"
+        const val baseTypes = "2.0.0-SNAPSHOT.126"
 
         /**
          * The version of [Spine.time].
@@ -117,14 +117,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
          */
-        const val text = "2.0.0-SNAPSHOT.5"
+        const val text = "2.0.0-SNAPSHOT.6"
 
         /**
          * The version of [Spine.toolBase].
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.186"
+        const val toolBase = "2.0.0-SNAPSHOT.191"
 
         /**
          * The version of [Spine.javadocTools].

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -38,6 +38,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.kotlin.dsl.ScriptHandlerScope
+import org.gradle.kotlin.dsl.maven
 
 /**
  * Applies [standard][doApplyStandard] repositories to this [ScriptHandlerScope]
@@ -214,6 +215,12 @@ fun RepositoryHandler.spineArtifacts(): MavenArtifactRepository = maven {
     }
 }
 
+val RepositoryHandler.intellijReleases: MavenArtifactRepository
+    get() = maven("https://www.jetbrains.com/intellij-repository/releases")
+
+val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
+    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+
 /**
  * Applies repositories commonly used by Spine Event Engine projects.
  */
@@ -235,6 +242,9 @@ fun RepositoryHandler.standardToSpineSdk() {
                 includeSpineOnly()
             }
         }
+
+    intellijReleases
+    jetBrainsCacheRedirector
 
     maven {
         url = URI(Repos.sonatypeSnapshots)


### PR DESCRIPTION
This PR extends `buildSrc` code with dependencies and repositories required to add IntelliJ PSI to a project.

Some other dependencies were also bumped.