### PR TITLE
Add `fatCli` property for ProtoData dependency object

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 /**
  * Dependencies on ProtoData modules.
  *
- * To use the locally published ProtoData version, instead of the version from a public plugin
+ * To use a locally published ProtoData version instead of the version from a public plugin
  * registry, set the `PROTODATA_VERSION` and/or the `PROTODATA_DF_VERSION` environment variables
  * and stop the Gradle daemons so that Gradle observes the env change:
  * ```
@@ -40,7 +40,7 @@ package io.spine.internal.dependency
  * ./gradle build   # Conduct the intended checks.
  * ```
  *
- * Then, in order to reset the console to run the usual versions again, remove the values of
+ * Then, to reset the console to run the usual versions again, remove the values of
  * the environment variables and stop the daemon:
  * ```
  * export PROTODATA_VERSION=""
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.15.4"
+    private const val fallbackVersion = "0.16.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.15.4"
+    private const val fallbackDfVersion = "0.16.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
@@ -104,6 +104,9 @@ object ProtoData {
 
     val codegenJava
         get() = codegenJava(version)
+
+    val fatCli
+        get() = "$group:protodata-fat-cli:$version"
 
     /**
      * An env variable storing a custom [version].


### PR DESCRIPTION
This PR adds `ProtoData.fatCli` property which is used in Validation to avoid accidental removal when updating `config`.

The version of ProtoDat dependency was also bumped to recently published `0.16.0`.