### PR TITLE
Update dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
 )
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.25.0"
+    const val version       = "3.25.1"
     /**
      * The Java library containing proto definitions of Google Protobuf.
      */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.194"
+        const val base = "2.0.0-SNAPSHOT.195"
 
         /**
          * The version of [Spine.reflect].


### PR DESCRIPTION
This changeset updates two dependencies to their latest versions:

* Protobuf (`protoc`, `protobuf-java`, etc) -> `3.25.1`;
* `spine-base` -> `2.0.0-SNAPSHOT.195`.
