### PR TITLE
Depend on `buildSrc.jar` in case `src` is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2023, TeamDev. All rights reserved.
+# Copyright 2024, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,9 @@
 
 # Gradle interim configs
 **/.gradle/**
+
+# Temp directory for Gradle TestKit runners
+**/.gradle-test-kit/**
 
 # Generated source code
 **/generated/**

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,6 +192,25 @@ dependencies {
         "org.jetbrains.kotlinx:kover-gradle-plugin:$koverVersion"
     ).forEach {
         implementation(it)
+    }
+}
+
+dependOnBuildSrcJar()
+
+/**
+ * Adds a dependency on a `buildSrc.jar`, iff `src` folder is missing,
+ * and `buildSrc.jar` is present in `buildSrc/` folder instead.
+ *
+ * This approach is used in scope of integration testing.
+ */
+fun Project.dependOnBuildSrcJar() {
+    val srcFolder = this.rootDir.resolve("src")
+    val buildSrcJar = rootDir.resolve("buildSrc.jar")
+    if(!srcFolder.exists() && buildSrcJar.exists()) {
+        logger.info("Adding the pre-compiled 'buildSrc.jar' to 'implementation' dependencies.")
+        dependencies {
+            implementation(files("buildSrc.jar"))
+        }
     }
 }
 


### PR DESCRIPTION
This changeset equips `buildSrc/build.gradle.kts` with another `implementation`-level dependency, which allows to shorten the build time for integration tests by re-using `buildSrc.jar` instead of re-compiling Kotlin sources in `buildSrc/src`.