### PR TITLE
Add recent changes to `buildSrc` from `tool-base`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -198,15 +198,16 @@ dependencies {
 dependOnBuildSrcJar()
 
 /**
- * Adds a dependency on a `buildSrc.jar`, iff `src` folder is missing,
- * and `buildSrc.jar` is present in `buildSrc/` folder instead.
+ * Adds a dependency on a `buildSrc.jar`, iff:
+ *  1) the `src` folder is missing, and
+ *  2) `buildSrc.jar` is present in `buildSrc/` folder instead.
  *
- * This approach is used in scope of integration testing.
+ * This approach is used in the scope of integration testing.
  */
 fun Project.dependOnBuildSrcJar() {
     val srcFolder = this.rootDir.resolve("src")
     val buildSrcJar = rootDir.resolve("buildSrc.jar")
-    if(!srcFolder.exists() && buildSrcJar.exists()) {
+    if (!srcFolder.exists() && buildSrcJar.exists()) {
         logger.info("Adding the pre-compiled 'buildSrc.jar' to 'implementation' dependencies.")
         dependencies {
             implementation(files("buildSrc.jar"))

--- a/buildSrc/src/main/kotlin/Repositories.kt
+++ b/buildSrc/src/main/kotlin/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/Repositories.kt
+++ b/buildSrc/src/main/kotlin/Repositories.kt
@@ -24,9 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.gradle.kotlin.dsl.maven
+@file:Suppress("unused")
+
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.kotlin.dsl.maven
 
 val RepositoryHandler.intellijReleases: MavenArtifactRepository
     get() = maven("https://www.jetbrains.com/intellij-repository/releases")

--- a/buildSrc/src/main/kotlin/Repositories.kt
+++ b/buildSrc/src/main/kotlin/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,20 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.dependency
+import org.gradle.kotlin.dsl.maven
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
-/**
- * Dependencies on Spine Validation SDK.
- *
- * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
- */
-@Suppress("unused", "ConstPropertyName")
-object Validation {
-    const val version = "2.0.0-SNAPSHOT.127"
-    const val group = "io.spine.validation"
-    const val runtime = "$group:spine-validation-java-runtime:$version"
-    const val java = "$group:spine-validation-java:$version"
-    const val javaBundle = "$group:spine-validation-java-bundle:$version"
-    const val model = "$group:spine-validation-model:$version"
-    const val config = "$group:spine-validation-configuration:$version"
-}
+val RepositoryHandler.intellijReleases: MavenArtifactRepository
+    get() = maven("https://www.jetbrains.com/intellij-repository/releases")
+
+val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
+    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies")

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ package io.spine.internal.dependency
  * 
  * @see <a href="https://github.com/Kotlin/kotlinx.coroutines">GitHub projecet</a>
  */
+@Suppress("unused")
 object Coroutines {
     public const val version = "1.6.4"
     public const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,17 +27,14 @@
 package io.spine.internal.dependency
 
 /**
- * Dependencies on Spine Validation SDK.
- *
- * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
+ * Kotlin Coroutines.
+ * 
+ * @see <a href="https://github.com/Kotlin/kotlinx.coroutines">GitHub projecet</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Validation {
-    const val version = "2.0.0-SNAPSHOT.127"
-    const val group = "io.spine.validation"
-    const val runtime = "$group:spine-validation-java-runtime:$version"
-    const val java = "$group:spine-validation-java:$version"
-    const val javaBundle = "$group:spine-validation-java-bundle:$version"
-    const val model = "$group:spine-validation-model:$version"
-    const val config = "$group:spine-validation-configuration:$version"
+object Coroutines {
+    public const val version = "1.6.4"
+    public const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"
+    public const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
+    public const val bom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:$version"
+    public const val coreJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Coroutines.kt
@@ -33,9 +33,9 @@ package io.spine.internal.dependency
  */
 @Suppress("unused")
 object Coroutines {
-    public const val version = "1.6.4"
-    public const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"
-    public const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
-    public const val bom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:$version"
-    public const val coreJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$version"
+    const val version = "1.6.4"
+    const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"
+    const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
+    const val bom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:$version"
+    const val coreJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GrpcKotlin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ package io.spine.internal.dependency
  *
  * @see <a href="https://github.com/grpc/grpc-kotlin">GitHub project</a>
  */
+@Suppress("unused")
 object GrpcKotlin {
     const val version = "1.3.0"
     const val stub = "io.grpc:grpc-kotlin-stub:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GrpcKotlin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2022, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,17 +27,16 @@
 package io.spine.internal.dependency
 
 /**
- * Dependencies on Spine Validation SDK.
+ * gRPC-Kotlin/JVM.
  *
- * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
+ * @see <a href="https://github.com/grpc/grpc-kotlin">GitHub project</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Validation {
-    const val version = "2.0.0-SNAPSHOT.127"
-    const val group = "io.spine.validation"
-    const val runtime = "$group:spine-validation-java-runtime:$version"
-    const val java = "$group:spine-validation-java:$version"
-    const val javaBundle = "$group:spine-validation-java-bundle:$version"
-    const val model = "$group:spine-validation-model:$version"
-    const val config = "$group:spine-validation-configuration:$version"
+object GrpcKotlin {
+    const val version = "1.3.0"
+    const val stub = "io.grpc:grpc-kotlin-stub:$version"
+
+    object ProtocPlugin {
+        const val id = "grpckt"
+        const val artifact = "io.grpc:protoc-gen-grpc-kotlin:$version:jdk8@jar"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -50,11 +50,38 @@ object IntelliJ {
         private const val group = "com.jetbrains.intellij.platform"
         const val core = "$group:core:$version"
         const val util = "$group:util:$version"
+        const val coreImpl = "$group:core-impl:$version"
+        const val codeStyle = "$group:code-style:$version"
+        const val codeStyleImpl = "$group:code-style-impl:$version"
+        const val projectModel = "$group:project-model:$version"
+        const val projectModelImpl = "$group:project-model-impl:$version"
+        const val lang = "$group:lang:$version"
+        const val langImpl = "$group:lang-impl:$version"
+        const val ideImpl = "$group:ide-impl:$version"
+        const val ideCoreImpl = "$group:ide-core-impl:$version"
+        const val analysisImpl = "$group:analysis-impl:$version"
+        const val indexingImpl = "$group:indexing-impl:$version"
+    }
+
+    object Jsp {
+        private const val group = "com.jetbrains.intellij.jsp"
+        const val jsp = "$group:jsp:$version"
+    }
+
+    object Xml {
+        private const val group = "com.jetbrains.intellij.xml"
+        const val xmlPsiImpl = "$group:xml-psi-impl:$version"
     }
 
     object JavaPsi {
         private const val group = "com.jetbrains.intellij.java"
         const val api = "$group:java-psi:$version"
         const val impl = "$group:java-psi-impl:$version"
+    }
+
+    object Java {
+        private const val group = "com.jetbrains.intellij.java"
+        const val java = "$group:java:$version"
+        const val impl = "$group:java-impl:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -65,6 +65,7 @@ object IntelliJ {
 
     object Jsp {
         private const val group = "com.jetbrains.intellij.jsp"
+        @Suppress("MemberNameEqualsClassName")
         const val jsp = "$group:jsp:$version"
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -81,6 +81,7 @@ object IntelliJ {
 
     object Java {
         private const val group = "com.jetbrains.intellij.java"
+        @Suppress("MemberNameEqualsClassName")
         const val java = "$group:java:$version"
         const val impl = "$group:java-impl:$version"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -53,4 +53,11 @@ object Jackson {
 
     // https://github.com/FasterXML/jackson-bom
     const val bom = "com.fasterxml.jackson:jackson-bom:${version}"
+
+    // https://github.com/FasterXML/jackson-jr
+    object Junior {
+        const val version = Jackson.version
+        const val group = "com.fasterxml.jackson.jr"
+        const val objects = "$group:jackson-jr-objects:$version"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.195"
+        const val base = "2.0.0-SNAPSHOT.198"
 
         /**
          * The version of [Spine.reflect].
@@ -89,7 +89,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.175"
+        const val mcJava = "2.0.0-SNAPSHOT.183"
 
         /**
          * The version of [Spine.baseTypes].

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publications.kt
@@ -80,13 +80,25 @@ internal sealed class PublicationHandler(
     }
 
     /**
-     * Takes a group name and a version from the given [project] and assigns
-     * them to this publication.
+     * Copies the attributes of Gradle [Project] to this [MavenPublication].
+     *
+     * The following project attributes are copied:
+     *  * [group][Project.getGroup];
+     *  * [version][Project.getVersion];
+     *  * [description][Project.getDescription].
+     *
+     * Also, this function adds the [artifactPrefix][SpinePublishing.artifactPrefix] to
+     * the [artifactId][MavenPublication.setArtifactId] of this publication,
+     * if the prefix is not added yet.
      */
-    protected fun MavenPublication.assignMavenCoordinates() {
+    protected fun MavenPublication.copyProjectAttributes() {
         groupId = project.group.toString()
-        artifactId = project.spinePublishing.artifactPrefix + artifactId
+        val prefix = project.spinePublishing.artifactPrefix
+        if (!artifactId.startsWith(prefix)) {
+            artifactId = prefix + artifactId
+        }
         version = project.version.toString()
+        pom.description.set(project.description)
     }
 }
 
@@ -110,7 +122,7 @@ private fun RepositoryHandler.register(project: Project, repository: Repository)
 /**
  * A publication for a typical Java project.
  *
- * In Gradle, in order to publish something somewhere one should create a publication.
+ * In Gradle, to publish something, one should create a publication.
  * A publication has a name and consists of one or more artifacts plus information about
  * those artifacts – the metadata.
  *
@@ -142,7 +154,7 @@ internal class StandardJavaPublicationHandler(
         val jars = project.artifacts(jarFlags)
         val publications = project.publications
         publications.create<MavenPublication>("mavenJava") {
-            assignMavenCoordinates()
+            copyProjectAttributes()
             specifyArtifacts(jars)
         }
     }
@@ -191,14 +203,14 @@ internal class StandardJavaPublicationHandler(
  *
  * Such publications should be treated differently than [StandardJavaPublicationHandler],
  * which is <em>created</em> for a module. Instead, since the publications are already declared,
- * this class only [assigns maven coordinates][assignMavenCoordinates].
+ * this class only [assigns maven coordinates][copyProjectAttributes].
  *
  * A module which declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.
  *
  * If a module with [publications] declared locally is not specified as one with custom publishing,
  * it may cause a name clash between an artifact produced by the [standard][MavenPublication]
- * publication, and custom ones. In order to have both standard and custom publications,
+ * publication, and custom ones. To have both standard and custom publications,
  * please specify custom artifact IDs or classifiers for each custom publication.
  */
 internal class CustomPublicationHandler(project: Project, destinations: Set<Repository>) :
@@ -206,7 +218,7 @@ internal class CustomPublicationHandler(project: Project, destinations: Set<Repo
 
     override fun handlePublications() {
         project.publications.forEach {
-            (it as MavenPublication).assignMavenCoordinates()
+            (it as MavenPublication).copyProjectAttributes()
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +142,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * Set of modules to be published.
      *
-     * Both module's name or path can be used.
+     * Both the module's name or path can be used.
      *
      * Use this property if the extension is configured from a root project's build file.
      *
@@ -180,7 +180,7 @@ open class SpinePublishing(private val project: Project) {
     /**
      * A prefix to be added before the name of each artifact.
      *
-     * Default value is "spine-".
+     * The default value is "spine-".
      */
     var artifactPrefix: String = "spine-"
 
@@ -188,7 +188,7 @@ open class SpinePublishing(private val project: Project) {
      * Allows disabling publishing of [protoJar] artifact, containing all Proto sources
      * from `sourceSets.main.proto`.
      *
-     * Here's an example of how to disable it for some of published modules:
+     * Here's an example of how to disable it for some of the published modules:
      *
      * ```
      * spinePublishing {
@@ -214,8 +214,8 @@ open class SpinePublishing(private val project: Project) {
      * }
      * ```
      *
-     * The resulting artifact is available under "proto" classifier. I.e., in Gradle 7+, one could
-     * depend on it like this:
+     * The resulting artifact is available under "proto" classifier.
+     * For example, in Gradle 7+, one could depend on it like this:
      *
      * ```
      * implementation("io.spine:spine-client:$version@proto")
@@ -227,7 +227,7 @@ open class SpinePublishing(private val project: Project) {
      * Allows enabling publishing of [testJar] artifact, containing compilation output
      * of "test" source set.
      *
-     * Here's an example of how to enable it for some of published modules:
+     * Here's an example of how to enable it for some of the published modules:
      *
      * ```
      * spinePublishing {

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -111,7 +111,7 @@ val exposeManifestForTests by tasks.creating {
         val manifest = Manifest()
 
         // The manifest version attribute is crucial for writing.
-        // It it's absent nothing would be written.
+        // If it's absent, nothing would be written.
         manifest.mainAttributes[MANIFEST_VERSION] = "1.0"
 
         manifestAttributes.forEach { entry ->


### PR DESCRIPTION
This PR brings changes recently introduced in `tool-base` ([1](https://github.com/SpineEventEngine/tool-base/pull/79), [2](https://github.com/SpineEventEngine/tool-base/pull/80)).