### PR TITLE
Add `psiJava` and `psiJavaBundle` properties to `Spine`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -55,7 +55,7 @@ object Spine {
         const val reflect = "2.0.0-SNAPSHOT.183"
 
         /**
-         * The version of [Spine.logging].
+         * The version of [Spine.Logging].
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -136,13 +136,6 @@ object Spine {
 
     const val base = "$group:spine-base:${ArtifactVersion.base}"
 
-    @Deprecated("Use `Logging.lib` instead.", ReplaceWith("Logging.lib"))
-    const val logging = "$group:spine-logging:${ArtifactVersion.logging}"
-    @Deprecated("Use `Logging.context` instead.", ReplaceWith("Logging.context"))
-    const val loggingContext = "$group:spine-logging-context:${ArtifactVersion.logging}"
-    @Deprecated("Use `Logging.backend` instead.", ReplaceWith("Logging.backend"))
-    const val loggingBackend = "$group:spine-logging-backend:${ArtifactVersion.logging}"
-
     const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
     const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
     const val time = "$group:spine-time:${ArtifactVersion.time}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -151,6 +151,8 @@ object Spine {
 
     const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.testlib}"
     const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
+    const val psiJava = "$toolsGroup:spine-psi-java:${ArtifactVersion.toolBase}"
+    const val psiJavaBundle = "$toolsGroup:spine-psi-java-bundle:${ArtifactVersion.toolBase}"
     const val toolBase = "$toolsGroup:spine-tool-base:${ArtifactVersion.toolBase}"
     const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
     const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"


### PR DESCRIPTION
This PR adds `psiJava` and `psiJavaBundle` properties to `Spine` dependency object. These properties were recently introduced in `tool-base` and then adopted in code generation subprojects.

Other notable changes:
  * Deprecated properties on Logging belonging to `Spine` object directly were eliminated.

