### PR TITLE
Bump third-party dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -122,6 +122,10 @@ private fun ResolutionStrategy.forceTestDependencies() {
 private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
         Asm.lib,
+        Asm.tree,
+        Asm.analysis,
+        Asm.util,
+        Asm.commons,
         AutoValue.annotations,
         CommonsCli.lib,
         CommonsCodec.lib,

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Asm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Asm.kt
@@ -29,6 +29,14 @@ package io.spine.internal.dependency
 // https://asm.ow2.io/
 @Suppress("unused", "ConstPropertyName")
 object Asm {
-    private const val version = "9.2"
+    private const val version = "9.6"
     const val lib = "org.ow2.asm:asm:$version"
+
+    // We use the following artifacts only to force the versions
+    // of the dependencies which are transitive for us.
+    //
+    const val tree = "org.ow2.asm:asm-tree:$version"
+    const val analysis = "org.ow2.asm:asm-analysis:$version"
+    const val util = "org.ow2.asm:asm-util:$version"
+    const val commons = "org.ow2.asm:asm-commons:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jacoco.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jacoco.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+/**
+ * Code coverage library for Java.
+ *
+ * @see <a href="https://www.eclemma.org/jacoco/">Releases</a>
+ */
+@Suppress("ConstPropertyName")
+object Jacoco {
+    const val version = "0.8.12"
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kover.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kover.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin/kotlinx-kover
 @Suppress("unused", "ConstPropertyName")
 object Kover {
-    const val version = "0.7.4"
+    const val version = "0.7.6"
     const val id = "org.jetbrains.kotlinx.kover"
     const val classpath = "org.jetbrains.kotlinx:kover-gradle-plugin:$version"
 }


### PR DESCRIPTION
This changeset updates the versions of our third-party dependencies:

* Kover -> `0.7.6`,
* Asm -> `9.6` — this version is the latest compatible with the latest released Kover.

Also, Jacoco artifact has been declared.