### PR TITLE
Do not use flag `-Xexpect-actual-classes` Kotlin compiler flag before 1.9.20

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -51,7 +51,7 @@ fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
 /**
  * Opts-in to experimental features that we use in our codebase.
  */
-@Suppress("unused")
+@Suppress("unused", "MagicNumber" /* Kotlin Compiler version. */)
 fun KotlinCompile.setFreeCompilerArgs() {
     // Avoid the "unsupported flag warning" for Kotlin compilers pre 1.9.20.
     // See: https://youtrack.jetbrains.com/issue/KT-61573

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -53,18 +53,22 @@ fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
  */
 @Suppress("unused")
 fun KotlinCompile.setFreeCompilerArgs() {
+    // Avoid the "unsupported flag warning" for Kotlin compilers pre 1.9.20.
+    // See: https://youtrack.jetbrains.com/issue/KT-61573
+    val expectActualClasses =
+        if (KotlinVersion.CURRENT.isAtLeast(1, 9, 20)) "-Xexpect-actual-classes" else ""
     kotlinOptions {
         freeCompilerArgs = listOf(
             "-Xskip-prerelease-check",
             "-Xjvm-default=all",
             "-Xinline-classes",
-            "-Xexpect-actual-classes",
+            expectActualClasses,
             "-opt-in=" +
                     "kotlin.contracts.ExperimentalContracts," +
                     "kotlin.io.path.ExperimentalPathApi," +
                     "kotlin.ExperimentalUnsignedTypes," +
                     "kotlin.ExperimentalStdlibApi," +
                     "kotlin.experimental.ExperimentalTypeInference",
-        )
+        ).filter { it.isNotBlank() }
     }
 }


### PR DESCRIPTION
This PR improves passing `freeCompilerArgs` in `KotlinCompile.setFreeCompilerArgs()` extension function. Previously, we always passed the flag, which resulted in "unsupported flag" warning emitted by Kotlin compilers before 1.9.20. 
Now the flag is added depending on the current Kotlin version.
