### PR TITLE
Migrate to Codecov v4, supply this action with a token

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -31,7 +31,8 @@ jobs:
           require_tests: true # will fail workflow if test reports not found
 
       - name: Upload code coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
This changeset updates the Codecov GitHub Actions to v4.

All the uploads made via the previous v3 version seem to work improperly, or just stumble across refusal to accept the coverage payload. This happened because the token-less uploads are no longer supported (see [their official docs on v4 release](https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release)). 

Therefore, this PR also includes the token value into the Actions script configuration.
The token is set up on the organizational level for all public repositories of SpineEventEngine.

Prior to creating this PR, the same code was successfully tested in our `base` repository. 