### PR TITLE
Propagate recent improvements from ToolBase and ProtoData. Use latest local dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Auto.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Auto.kt
@@ -53,7 +53,7 @@ object AutoServiceKsp {
     /**
      * The latest version compatible with Kotlin 1.8.22.
      *
-     * @see Ksp.version
+     * @see io.spine.dependency.build.Ksp.version
      */
     private const val version = "1.1.0"
     const val processor = "dev.zacsweers.autoservice:auto-service-ksp:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Log4j2.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Log4j2.kt
@@ -29,7 +29,7 @@ package io.spine.dependency.lib
 /**
  * An open-source logging framework.
  *
- * Spine uses its own [logging library][Spine.Logging], but also
+ * Spine uses its own [logging library][io.spine.dependency.local.Logging], but also
  * provides a backend implementation for [Log4j2]. This is why
  * this dependency is needed.
  *

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
@@ -80,6 +80,7 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
      */
+    @Suppress("unused")
     @Deprecated(
         message = "Please use `ModelCompiler.version` instead.",
         ReplaceWith("ModelCompiler.version")

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.224"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.224"
+    const val version = "2.0.0-SNAPSHOT.232"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.232"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.182"
+    const val version = "2.0.0-SNAPSHOT.191"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -46,6 +46,8 @@ object Logging {
     const val grpcContext = "$group:spine-logging-grpc-context:$version"
     const val smokeTest = "$group:spine-logging-smoke-test:$version"
 
+    const val testLib = "${Spine.toolsGroup}:spine-logging-testlib:$version"
+
     // Transitive dependencies.
     // Make `public` and use them to force a version in a particular repository, if needed.
     internal const val julBackend = "$group:spine-logging-jul-backend:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.70.1"
+    private const val fallbackVersion = "0.80.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.70.1"
+    private const val fallbackDfVersion = "0.80.1"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.234"
+    const val version = "2.0.0-SNAPSHOT.240"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -31,7 +31,7 @@ package io.spine.dependency.local
  *
  * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
  */
-@Suppress("ConstPropertyName")
+@Suppress("ConstPropertyName", "unused")
 object Validation {
     /**
      * The version of the Validation library artifacts.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/kotlin/KotlinConfig.kt
@@ -53,10 +53,12 @@ fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
  */
 @Suppress("unused", "MagicNumber" /* Kotlin Compiler version. */)
 fun KotlinCompile.setFreeCompilerArgs() {
-    // Avoid the "unsupported flag warning" for Kotlin compilers pre 1.9.20.
+    // Avoid the "unsupported flag warning" for Kotlin compilers pre 1.9.20 and after 2.0.0.
     // See: https://youtrack.jetbrains.com/issue/KT-61573
-    val expectActualClasses =
-        if (KotlinVersion.CURRENT.isAtLeast(1, 9, 20)) "-Xexpect-actual-classes" else ""
+    val expectActualClasses = KotlinVersion.CURRENT.run {
+        if (isAtLeast(1, 9, 20) && major < 2) "-Xexpect-actual-classes"
+        else ""
+    }
     kotlinOptions {
         freeCompilerArgs = listOf(
             "-Xskip-prerelease-check",

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CloudRepo.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CloudRepo.kt
@@ -33,7 +33,7 @@ import io.spine.gradle.Repository
  *
  * There is a special treatment for this repository. Usually, fetching and publishing of artifacts
  * is performed via the same URL. But it is not true for CloudRepo. Fetching is performed via
- * public repository, and publishing via private one. Their URLs differ in `/public` infix.
+ * the public repository, and publishing via the private one. Their URLs differ in `/public` infix.
  */
 internal object CloudRepo {
 


### PR DESCRIPTION
This PR propagates small improvements recently made under `buildSrc` in ToolBase and ProtoData projects. 

Also this PR promotes latest versions of Base, ToolBase, CoreJava, and ProtoData.
