### PR TITLE
Bump local dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/TestLib.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/TestLib.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object TestLib {
-    const val version = "2.0.0-SNAPSHOT.184"
+    const val version = "2.0.0-SNAPSHOT.185"
     const val group = Spine.toolsGroup
     const val artifact = "spine-testlib"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.240"
+    const val version = "2.0.0-SNAPSHOT.244"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"


### PR DESCRIPTION
This PR bumps versions of local dependencies that were advanced recently in relation code generation works in  ProtoData and Validation.