### PR TITLE
Adjust the Gradle config for `generatePom` task

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,20 +75,21 @@ object PomGenerator {
             plugin(BasePlugin::class.java)
         }
 
-        val task = project.tasks.create("generatePom")
-        task.doLast {
-            val pomFile = project.projectDir.resolve("pom.xml")
-            project.delete(pomFile)
+        val task = project.tasks.register("generatePom") {
+            doLast {
+                val pomFile = project.projectDir.resolve("pom.xml")
+                project.delete(pomFile)
 
-            val projectData = project.metadata()
-            val writer = PomXmlWriter(projectData)
-            writer.writeTo(pomFile)
+                val projectData = project.metadata()
+                val writer = PomXmlWriter(projectData)
+                writer.writeTo(pomFile)
+            }
+
+            val assembleTask = project.tasks.findByName("assemble")!!
+            dependsOn(assembleTask)
         }
 
         val buildTask = project.tasks.findByName("build")!!
         buildTask.finalizedBy(task)
-
-        val assembleTask = project.tasks.findByName("assemble")!!
-        task.dependsOn(assembleTask)
     }
 }


### PR DESCRIPTION
This PR addresses [base#855](https://github.com/SpineEventEngine/base/issues/855).

This changeset moves the declaration of the dependency between `generatePom` and `build` out of the lazy `Action` and into the explicitly called function. 

Starting Gradle 8.13, the lambda-`Action` of `tasks.register("foo") { ... }` block seems to not be executed like previously, without such an explicit dependency declared. Therefore, in its previous form, in Gradle 8.13 there were no `generatePom` task created.

This change was also tested with Gradle 7.6.4 in `core-java`.