### PR TITLE
Bring changes from McJava

### DIFF
--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -184,18 +184,36 @@ fun Project.configureTaskDependencies() {
         val launchTestProtoData = "launchTestProtoData"
         val generateProto = "generateProto"
         val createVersionFile = "createVersionFile"
-        "compileKotlin".dependOn(launchProtoData)
-        "compileTestKotlin".dependOn(launchTestProtoData)
+        val compileKotlin = "compileKotlin"
+        compileKotlin.dependOn(launchProtoData)
+        val compileTestKotlin = "compileTestKotlin"
+        compileTestKotlin.dependOn(launchTestProtoData)
         val sourcesJar = "sourcesJar"
-        sourcesJar.dependOn(generateProto)
-        sourcesJar.dependOn(launchProtoData)
-        sourcesJar.dependOn(createVersionFile)
-        sourcesJar.dependOn("prepareProtocConfigVersions")
+        val kspKotlin = "kspKotlin"
+        sourcesJar.run {
+            dependOn(generateProto)
+            dependOn(launchProtoData)
+            dependOn(kspKotlin)
+            dependOn(createVersionFile)
+            dependOn("prepareProtocConfigVersions")
+        }
         val dokkaHtml = "dokkaHtml"
-        dokkaHtml.dependOn(generateProto)
-        dokkaHtml.dependOn(launchProtoData)
-        "dokkaJavadoc".dependOn(launchProtoData)
+        dokkaHtml.run {
+            dependOn(generateProto)
+            dependOn(launchProtoData)
+            dependOn(kspKotlin)
+        }
+        val dokkaJavadoc = "dokkaJavadoc"
+        dokkaJavadoc.run {
+            dependOn(launchProtoData)
+            dependOn(kspKotlin)
+        }
         "publishPluginJar".dependOn(createVersionFile)
+        compileKotlin.dependOn(kspKotlin)
+        compileTestKotlin.dependOn("kspTestKotlin")
+        "compileTestFixturesKotlin".dependOn("kspTestFixturesKotlin")
+        "dokkaKotlinJar".dependOn(dokkaJavadoc)
+        "javadocJar".dependOn(dokkaHtml)
     }
 }
 

--- a/buildSrc/src/main/kotlin/BuildSettings.kt
+++ b/buildSrc/src/main/kotlin/BuildSettings.kt
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.gradle.api.JavaVersion
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -34,6 +35,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 object BuildSettings {
     private const val JVM_VERSION = 17
     val javaVersion: JavaLanguageVersion = JavaLanguageVersion.of(JVM_VERSION)
+    val javaVersionCompat = JavaVersion.toVersion(JVM_VERSION)
     val jvmTarget = JvmTarget.JVM_17
     const val REMOTE_DEBUG_PORT = 5566
 }

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -186,9 +186,7 @@ fun Project.dokkaKotlinJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaKotlin
  */
 fun AbstractDokkaTask.isInPublishingGraph(): Boolean =
     project.gradle.taskGraph.allTasks.any {
-        with(it.name) {
-            startsWith("publish") && !startsWith("publishToMavenLocal")
-        }
+        it.name == "publish"
     }
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -38,4 +38,6 @@ object Ksp {
     const val group = "com.google.devtools.ksp"
     const val symbolProcessingApi = "$group:symbol-processing-api:$version"
     const val symbolProcessing = "$group:symbol-processing:$version"
+    const val symbolProcessingAaEmb = "$group:symbol-processing-aa-embeddable:$version"
+    const val symbolProcessingCommonDeps = "$group:symbol-processing-common-deps:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -54,8 +54,11 @@ object Kotlin {
 
     private const val group = "org.jetbrains.kotlin"
 
+    const val scriptRuntime = "$group:kotlin-script-runtime:$runtimeVersion"
     const val stdLib       = "$group:kotlin-stdlib:$runtimeVersion"
     const val stdLibCommon = "$group:kotlin-stdlib-common:$runtimeVersion"
+
+    const val toolingCore = "$group:kotlin-tooling-core:$runtimeVersion"
 
     @Deprecated("Please use `stdLib` instead.")
     const val stdLibJdk7   = "$group:kotlin-stdlib-jdk7:$runtimeVersion"
@@ -66,12 +69,22 @@ object Kotlin {
     const val reflect    = "$group:kotlin-reflect:$runtimeVersion"
     const val testJUnit5 = "$group:kotlin-test-junit5:$runtimeVersion"
 
+    @Deprecated(message = "Please use `GradlePlugin.api` instead.", ReplaceWith("GradlePlugin.api"))
     const val gradlePluginApi = "$group:kotlin-gradle-plugin-api:$runtimeVersion"
+
+    @Deprecated(message = "Please use `GradlePlugin.lib` instead.", ReplaceWith("GradlePlugin.lib"))
     const val gradlePluginLib = "$group:kotlin-gradle-plugin:$runtimeVersion"
 
     const val jetbrainsAnnotations = "org.jetbrains:annotations:$annotationsVersion"
 
     object Compiler {
-        const val embeddable = "$group:kotlin-compiler-embeddable:$embeddedVersion"
+        const val embeddable = "$group:kotlin-compiler-embeddable:$runtimeVersion"
+    }
+
+    object GradlePlugin {
+        const val version = Kotlin.runtimeVersion
+        const val api = "$group:kotlin-gradle-plugin-api:$version"
+        const val lib = "$group:kotlin-gradle-plugin:$version"
+        const val model = "$group:kotlin-gradle-model:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
@@ -34,7 +34,7 @@ object KotlinX {
     object Coroutines {
 
         // https://github.com/Kotlin/kotlinx.coroutines
-        const val version = "1.9.0"
+        const val version = "1.10.1"
         const val bom = "$group:kotlinx-coroutines-bom:$version"
         const val core = "$group:kotlinx-coroutines-core:$version"
         const val coreJvm = "$group:kotlinx-coroutines-core-jvm:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.300"
+    const val version = "2.0.0-SNAPSHOT.301"
     const val versionForBuildScript = "2.0.0-SNAPSHOT.300"
     const val group = Spine.group
     const val artifact = "spine-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.262"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.266"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.262"
+    const val version = "2.0.0-SNAPSHOT.266"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.91.5"
+    private const val fallbackVersion = "0.92.11"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.91.4"
+    private const val fallbackDfVersion = "0.92.11"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
@@ -38,7 +38,7 @@ package io.spine.dependency.local
 )
 object ProtoTap {
     const val group = "io.spine.tools"
-    const val version = "0.8.7"
+    const val version = "0.9.1"
     const val gradlePluginId = "io.spine.prototap"
     const val api = "$group:prototap-api:$version"
     const val gradlePlugin = "$group:prototap-gradle-plugin:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.244"
+    const val version = "2.0.0-SNAPSHOT.300"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.192"
+    const val version = "2.0.0-SNAPSHOT.301"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/KotlinCompileTesting.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/KotlinCompileTesting.kt
@@ -29,12 +29,12 @@ package io.spine.dependency.test
 /**
  * A library for in-process compilation of Kotlin and Java code compilation.
  *
- * @see <a href="https://github.com/tschuchortdev/kotlin-compile-testing">GitHub repo</a>
+ * @see <a href="https://github.com/zacsweers/kotlin-compile-testing">GitHub repo</a>
  */
 @Suppress("unused", "ConstPropertyName")
 object KotlinCompileTesting {
-    private const val version = "1.5.0" // Compatible with Kotlin Compiler 1.8.22.
-    private const val group = "com.github.tschuchortdev"
-    const val lib = "$group:kotlin-compile-testing:$version"
-    const val libKsp = "$group:kotlin-compile-testing-ksp:$version"
+    private const val version = "0.7.0"
+    private const val group = "dev.zacsweers.kctfork"
+    const val libCore = "$group:core:$version"
+    const val libKsp = "$group:ksp:$version"
 }


### PR DESCRIPTION
This PR adds changes [recently made in McJava ](https://github.com/SpineEventEngine/mc-java/pull/186) for propagating to other projects.

## In details
 * `Project.configureTaskDependencies()` extension in `BuildExtensions.kt` was extended to support dependencies with KSP tasks.
 * `AbstractDokkaTask.isInPublishingGraph()` now considers only `publish` as the publishing task.
 * `BuildSettings` got a property for using with compatibility properties when configuring Java.
 * The `Kotlin` dependency object got more entries and deprecations.
 * `KotlinCompileTesting` now comes from [https://github.com/zacsweers/kotlin-compile-testing] instead of [https://github.com/tschuchortdev/kotlin-compile-testing] because the fork from Zac Sweers is maintained better.
