### PR TITLE
Make task action `public`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@
 #
 # Therefore, instructions below are superset of instructions required for all the projects.
 
-buildSrc/.kotlin/
+# Kotlin temp directories.
+**/.kotlin/**
 
 # IntelliJ IDEA modules and interim config files.
 *.iml

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Kotlin2JvmCompilerArguments">
-    <option name="jvmTarget" value="11" />
+    <option name="jvmTarget" value="17" />
   </component>
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.9.22" />
-    <option name="languageVersion" value="1.9.22" />
+    <option name="apiVersion" value="2.1.10" />
+    <option name="languageVersion" value="2.1.10" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.22" />
+    <option name="version" value="2.1.10" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -40,5 +40,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -212,7 +212,6 @@ fun Project.configureTaskDependencies() {
         compileKotlin.dependOn(kspKotlin)
         compileTestKotlin.dependOn("kspTestKotlin")
         "compileTestFixturesKotlin".dependOn("kspTestFixturesKotlin")
-        "dokkaKotlinJar".dependOn(dokkaJavadoc)
         "javadocJar".dependOn(dokkaHtml)
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName")
 object Base {
     const val version = "2.0.0-SNAPSHOT.301"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.300"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.301"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.201"
+    const val version = "2.0.0-SNAPSHOT.206"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.266"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.300"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.266"
+    const val version = "2.0.0-SNAPSHOT.300"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/RunBuild.kt
@@ -32,6 +32,6 @@ package io.spine.gradle
 open class RunBuild : RunGradle() {
 
     init {
-        task("build")
+        task("clean", "build")
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
@@ -100,7 +100,7 @@ open class RunGradle : DefaultTask() {
     }
 
     @TaskAction
-    private fun execute() {
+    public fun execute() {
         // Ensure build error output log.
         // Since we're executing this task in another process, we redirect error output to
         // the file under the `_out` directory. Using the `build` directory for this purpose

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -182,8 +182,8 @@ private fun Project.deduplicate(dependencies: Set<ModuleDependency>): List<Modul
     logDuplicates(groups)
 
     val filtered = groups.map { group ->
-        group.value.maxByOrNull { dep -> dep.version }!!
-    }
+        group.value.maxByOrNull { dep -> dep.version ?: "" }
+    }.filterNotNull()
     return filtered
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ModuleDependency.kt
@@ -40,7 +40,7 @@ internal class ModuleDependency(
     val project: Project,
     val configuration: Configuration,
     private val dependency: Dependency,
-    private val factualVersion: String = dependency.version!!
+    private val factualVersion: String? = dependency.version
 
 ) : Dependency by dependency, Comparable<ModuleDependency> {
 
@@ -52,7 +52,7 @@ internal class ModuleDependency(
             .thenBy { it.factualVersion }
     }
 
-    override fun getVersion(): String = factualVersion
+    override fun getVersion(): String? = factualVersion
 
     /**
      * A project dependency with its [scope][DependencyScope].


### PR DESCRIPTION
The major change this PR introduces is making the function `RunGradle.execute()` which is annotated `@TaskAction` `public`. This is a requirement of latest versions of Gradle. Previously the function was `private` without coplaints.

### Other notable changes
 * Add nullability of dependency version in `ModuleDependency.kt` with relevant changes in `DependencyWriter.kt`.
 * `RunBuild` now executes the `clean` task before `build`.
 * The dependency of `dokkaKotlinJar` on `dokkaJavdoc` was removed because it provide to be circular when building ProtoData.