### PR TITLE
Bring `buildSrc` updates from latest McJava

### DIFF
--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -225,15 +225,14 @@ fun Project.configureTaskDependencies() {
 val Project.productionModules: Iterable<Project>
     get() = rootProject.subprojects.filter { !it.name.contains("-tests") }
 
-
 /**
- * Sets the remote debug option for this task.
+ * Sets the remote debug option for this [JavaExec] task.
  *
  * The port number is [5566][BuildSettings.REMOTE_DEBUG_PORT].
  *
  * @param enabled If `true` the task will be suspended.
  */
-fun Task.remoteDebug(enabled: Boolean = true) { this as JavaExec
+fun JavaExec.remoteDebug(enabled: Boolean = true) {
     debugOptions {
         this@debugOptions.enabled.set(enabled)
         port.set(BuildSettings.REMOTE_DEBUG_PORT)
@@ -243,14 +242,24 @@ fun Task.remoteDebug(enabled: Boolean = true) { this as JavaExec
 }
 
 /**
- * Sets the remote debug option for the task with the given name.
+ * Sets the remote debug option for the task of [JavaExec] type with the given name.
  *
  * The port number is [5566][BuildSettings.REMOTE_DEBUG_PORT].
  *
  * @param enabled If `true` the task will be suspended.
+ * @throws IllegalStateException if the task with the given name is not found, or,
+ *  if the taks is not of [JavaExec] type.
  */
-public fun Project.setRemoteDebug(taskName: String, enabled: Boolean = true) =
-    tasks.findByName(taskName)?.remoteDebug(enabled)
+fun Project.setRemoteDebug(taskName: String, enabled: Boolean = true) {
+    val task = tasks.findByName(taskName)
+    check(task != null) {
+        "Could not find a task named `$taskName` in the project `$name`."
+    }
+    check(task is JavaExec) {
+        "The task `$taskName` is not of type `JavaExec`.`"
+    }
+    task.remoteDebug(enabled)
+}
 
 /**
  * Sets remote debug options for the `launchProtoData` task.
@@ -261,7 +270,6 @@ public fun Project.setRemoteDebug(taskName: String, enabled: Boolean = true) =
  */
 fun Project.protoDataRemoteDebug(enabled: Boolean = true) =
     setRemoteDebug("launchProtoData", enabled)
-
 
 /**
  * Sets remote debug options for the `launchTestProtoData` task.
@@ -282,4 +290,3 @@ fun Project.testProtoDataRemoteDebug(enabled: Boolean = true) =
  */
 fun Project.testFixturesProtoDataRemoteDebug(enabled: Boolean = true) =
     setRemoteDebug("launchTestFixturesProtoData", enabled)
-

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -256,7 +256,7 @@ fun Project.setRemoteDebug(taskName: String, enabled: Boolean = true) {
         "Could not find a task named `$taskName` in the project `$name`."
     }
     check(task is JavaExec) {
-        "The task `$taskName` is not of type `JavaExec`.`"
+        "The task `$taskName` is not of type `JavaExec`."
     }
     task.remoteDebug(enabled)
 }

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,6 +213,7 @@ fun Project.configureTaskDependencies() {
         compileTestKotlin.dependOn("kspTestKotlin")
         "compileTestFixturesKotlin".dependOn("kspTestFixturesKotlin")
         "javadocJar".dependOn(dokkaHtml)
+        "dokkaKotlinJar".dependOn(dokkaJavadoc)
     }
 }
 
@@ -242,15 +243,25 @@ fun Task.remoteDebug(enabled: Boolean = true) { this as JavaExec
 }
 
 /**
+ * Sets the remote debug option for the task with the given name.
+ *
+ * The port number is [5566][BuildSettings.REMOTE_DEBUG_PORT].
+ *
+ * @param enabled If `true` the task will be suspended.
+ */
+public fun Project.setRemoteDebug(taskName: String, enabled: Boolean = true) =
+    tasks.findByName(taskName)?.remoteDebug(enabled)
+
+/**
  * Sets remote debug options for the `launchProtoData` task.
  *
  * @param enabled if `true` the task will be suspended.
  *
  * @see remoteDebug
  */
-fun Project.protoDataRemoteDebug(enabled: Boolean = true) {
-    tasks.findByName("launchProtoData")?.remoteDebug(enabled)
-}
+fun Project.protoDataRemoteDebug(enabled: Boolean = true) =
+    setRemoteDebug("launchProtoData", enabled)
+
 
 /**
  * Sets remote debug options for the `launchTestProtoData` task.
@@ -259,6 +270,16 @@ fun Project.protoDataRemoteDebug(enabled: Boolean = true) {
  *
  * @see remoteDebug
  */
-fun Project.testProtoDataRemoteDebug(enabled: Boolean = true) {
-    tasks.findByName("launchTestProtoData")?.remoteDebug(enabled)
-}
+fun Project.testProtoDataRemoteDebug(enabled: Boolean = true) =
+    setRemoteDebug("launchTestProtoData", enabled)
+
+/**
+ * Sets remote debug options for the `launchTestFixturesProtoData` task.
+ *
+ * @param enabled if `true` the task will be suspended.
+ *
+ * @see remoteDebug
+ */
+fun Project.testFixturesProtoDataRemoteDebug(enabled: Boolean = true) =
+    setRemoteDebug("launchTestFixturesProtoData", enabled)
+

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -40,4 +40,5 @@ object Ksp {
     const val symbolProcessing = "$group:symbol-processing:$version"
     const val symbolProcessingAaEmb = "$group:symbol-processing-aa-embeddable:$version"
     const val symbolProcessingCommonDeps = "$group:symbol-processing-common-deps:$version"
+    const val gradlePlugin = "$group:symbol-processing-gradle-plugin:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.301"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.301"
+    const val version = "2.0.0-SNAPSHOT.303"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.303"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.300"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.303"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.300"
+    const val version = "2.0.0-SNAPSHOT.303"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.92.11"
+    private const val fallbackVersion = "0.93.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.92.11"
+    private const val fallbackDfVersion = "0.93.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.301"
+    const val version = "2.0.0-SNAPSHOT.302"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"


### PR DESCRIPTION
This PR copies updates to `buildSrc` recently made in McJava so that they are propagated to other subprojects.