### PR TITLE
Improve `GenerateProtoTask.setup()` under `buildSrc`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
@@ -105,10 +105,12 @@ private fun GenerateProtoTask.generatedDir(language: String = ""): File {
 fun GenerateProtoTask.setup() {
     builtins.maybeCreate("kotlin")
     setupDescriptorSetFileCreation()
+    doFirst {
+        excludeProtocOutput()
+    }
     doLast {
         copyGeneratedFiles()
     }
-    excludeProtocOutput()
     setupKotlinCompile()
     dependOnProcessResourcesTask()
     makeDirsForIdeaModule()


### PR DESCRIPTION
This PR brings the change made to the `GenerateProtoTask.setup()` extension recently adopted in Base. 

The change addresses the `ConcurrentModificationException`, which appeared recently when migrating to Gradle 8.13.