### PR TITLE
Bump Kotlin under `buildSrc`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -75,7 +75,7 @@ val grGitVersion = "4.1.1"
  * This version may change from the [version of Kotlin][io.spine.dependency.lib.Kotlin.version]
  * used by the project.
  */
-val kotlinVersion = "2.1.10"
+val kotlinVersion = "2.1.20"
 
 /**
  * The version of Guava used in `buildSrc`.


### PR DESCRIPTION
This PR bumps the version of Kotlin used for the build to `2.1.20`.