### PR TITLE
Updates from Base and ToolBase plus JSpecify annotations

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -24,6 +24,7 @@
       <w>handshaker</w>
       <w>hohpe</w>
       <w>idempotency</w>
+      <w>jspecify</w>
       <w>lempira</w>
       <w>liskov</w>
       <w>melnik</w>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -103,7 +103,7 @@ val errorPronePluginVersion = "4.1.0"
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.9.4"
+val protobufPluginVersion = "0.9.5"
 
 /**
  * The version of Dokka Gradle Plugins.
@@ -113,7 +113,7 @@ val protobufPluginVersion = "0.9.4"
  * @see <a href="https://github.com/Kotlin/dokka/releases">
  *     Dokka Releases</a>
  */
-val dokkaVersion = "1.9.20"
+val dokkaVersion = "2.0.0"
 
 /**
  * The version of Detekt Gradle Plugin.

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -229,6 +229,22 @@ val Project.productionModules: Iterable<Project>
     get() = rootProject.subprojects.filter { !it.name.contains("-tests") }
 
 /**
+ * Obtains the names of the [productionModules].
+ *
+ * The extension could be useful for excluding modules from standard publishing:
+ * ```kotlin
+ * spinePublishing {
+ *     val customModule = "my-custom-module"
+ *     modules = productionModuleNames.toSet().minus(customModule)
+ *     modulesWithCustomPublishing = setOf(customModule)
+ *     //...
+ * }
+ * ```
+ */
+val Project.productionModuleNames: List<String>
+    get() = productionModules.map { it.name }
+
+/**
  * Sets the remote debug option for this [JavaExec] task.
  *
  * The port number is [5566][BuildSettings.REMOTE_DEBUG_PORT].

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -221,7 +221,7 @@ fun Project.configureTaskDependencies() {
 }
 
 /**
- * Obtains all modules names of which do not have `"-tests"` as the suffix.
+ * Obtains all modules that do not haveg names ending with the "-tests"` suffix.
  *
  * By convention, such modules are for integration tests and should be treated differently.
  */

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -29,6 +29,7 @@ import io.spine.dependency.build.CheckerFramework
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.FindBugs
+import io.spine.dependency.build.JSpecify
 import io.spine.dependency.lib.Asm
 import io.spine.dependency.lib.AutoCommon
 import io.spine.dependency.lib.AutoService
@@ -97,6 +98,7 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         FindBugs.annotations,
         Gson.lib,
         Guava.lib,
+        JSpecify.annotations,
         Kotlin.reflect,
         Kotlin.stdLib,
         Kotlin.stdLibCommon,
@@ -145,8 +147,8 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
         Jackson.bom,
         Jackson.core,
         Jackson.databind,
-        Jackson.dataformatXml,
-        Jackson.dataformatYaml,
+        Jackson.DataFormat.xml,
+        Jackson.DataFormat.yaml,
         Jackson.moduleKotlin,
         JavaDiffUtils.lib,
         Kotlin.jetbrainsAnnotations,

--- a/buildSrc/src/main/kotlin/DocumentationSettings.kt
+++ b/buildSrc/src/main/kotlin/DocumentationSettings.kt
@@ -55,6 +55,4 @@ object DocumentationSettings {
          */
         const val lineSuffix: String = "#L"
     }
-
-
 }

--- a/buildSrc/src/main/kotlin/DocumentationSettings.kt
+++ b/buildSrc/src/main/kotlin/DocumentationSettings.kt
@@ -24,34 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.local
-
 /**
- * Dependencies on Spine Validation SDK.
+ * The documentation settings specific to this project.
  *
- * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
+ * @see <a href="https://kotlinlang.org/docs/dokka-gradle.html#source-link-configuration">
+ *     Dokka source link configuration</a>
  */
-@Suppress("ConstPropertyName", "unused")
-object Validation {
+@Suppress("ConstPropertyName")
+object DocumentationSettings {
+
     /**
-     * The version of the Validation library artifacts.
+     * Settings passed to Dokka for
+     * [sourceLink][[org.jetbrains.dokka.gradle.engine.parameters.DokkaSourceLinkSpec]
      */
-    const val version = "2.0.0-SNAPSHOT.312"
+    object SourceLink {
 
-    const val group = "io.spine.validation"
-    private const val prefix = "spine-validation"
+        /**
+         * The URL of the remote source code
+         * [location][org.jetbrains.dokka.gradle.engine.parameters.DokkaSourceLinkSpec.remoteUrl].
+         */
+        const val url: String = "https://github.com/SpineEventEngine/base/tree/master/src"
 
-    const val runtimeModule = "$group:$prefix-java-runtime"
-    const val runtime = "$runtimeModule:$version"
-    const val java = "$group:$prefix-java:$version"
+        /**
+         * The suffix used to append the source code line number to the URL.
+         *
+         * The suffix depends on the online code repository.
+         *
+         * @see <a href="https://kotlinlang.org/docs/dokka-gradle.html#fwor0d_534">
+         *     remoteLineSuffix</a>
+         */
+        const val lineSuffix: String = "#L"
+    }
 
-    const val javaBundleModule = "$group:$prefix-java-bundle"
 
-    /** Obtains the artifact for the `java-bundle` artifact of the given version. */
-    fun javaBundle(version: String) = "$javaBundleModule:$version"
-
-    val javaBundle = javaBundle(version)
-
-    const val model = "$group:$prefix-model:$version"
-    const val config = "$group:$prefix-configuration:$version"
 }

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -195,10 +195,13 @@ fun Project.dokkaKotlinJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaKotlin
 }
 
 /**
- * Tells if this task belongs to the execution graph which contains publishing tasks.
+ * Tells if this task belongs to the execution graph which contains
+ * the `publish` and `dokkaGenerate` tasks.
  *
- * The task `"publishToMavenLocal"` is excluded from the check because it is a part of
- * the local testing workflow.
+ * This predicate could be useful for disabling publishing tasks
+ * when doing, e.g., `publishToMavenLocal` for the purpose of the
+ * integration tests that (of course) do not test the documentation
+ * generation proces and its resuults.
  */
 fun AbstractDokkaTask.isInPublishingGraph(): Boolean =
     project.gradle.taskGraph.allTasks.any {

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -151,6 +151,7 @@ fun DokkaExtension.configureForKotlin(project: Project, sourceLinkRemoteUrl: Str
 /**
  * Configures this [DokkaTask] to accept only Java files.
  */
+@Suppress("unused")
 fun DokkaExtension.configureForJava(project: Project, sourceLinkRemoteUrl: String) {
     configureFor(project, "java", sourceLinkRemoteUrl)
 }

--- a/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
     id("org.jetbrains.dokka") // Cannot use `Dokka` dependency object here yet.
@@ -35,9 +35,17 @@ dependencies {
     useDokkaWithSpineExtensions()
 }
 
-tasks.withType<AbstractDokkaLeafTask>().configureEach {
-    configureForJava()
+afterEvaluate {
+    dokka {
+        configureForKotlin(
+            project,
+            DocumentationSettings.SourceLink.url
+        )
+    }
+}
+
+tasks.withType<DokkaTaskPartial>().configureEach {
     onlyIf {
-        (it as AbstractDokkaLeafTask).isInPublishingGraph()
+        isInPublishingGraph()
     }
 }

--- a/buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.jetbrains.dokka.gradle.AbstractDokkaLeafTask
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
     id("org.jetbrains.dokka") // Cannot use `Dokka` dependency object here yet.
@@ -34,9 +34,17 @@ dependencies {
     useDokkaWithSpineExtensions()
 }
 
-tasks.withType<AbstractDokkaLeafTask>().configureEach {
-    configureForKotlin()
+afterEvaluate {
+    dokka {
+        configureForKotlin(
+            project,
+            DocumentationSettings.SourceLink.url
+        )
+    }
+}
+
+tasks.withType<DokkaTaskPartial>().configureEach {
     onlyIf {
-        (it as AbstractDokkaLeafTask).isInPublishingGraph()
+        isInPublishingGraph()
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
@@ -35,7 +35,7 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "1.9.20"
+    const val version = "2.0.0"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"
@@ -78,7 +78,7 @@ object Dokka {
     object SpineExtensions {
         private const val group = "io.spine.tools"
 
-        const val version = "2.0.0-SNAPSHOT.6"
+        const val version = "2.0.0-SNAPSHOT.7"
         const val lib = "$group:spine-dokka-extensions:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/JSpecify.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/JSpecify.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.build
+
+/**
+ * An artifact of well-specified annotations to power static analysis
+ * checks and JVM language interop. Developed by consensus of the partner
+ * organizations listed at [the project site](https://jspecify.org).
+ *
+ * @see <a href="https://github.com/jspecify/jspecify">JSpecify at GitHub</a>
+ */
+@Suppress("ConstPropertyName")
+object JSpecify {
+    const val version = "1.0.0"
+    const val annotations = "org.jspecify:jspecify:$version"
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.build
  */
 @Suppress("ConstPropertyName", "unused")
 object Ksp {
-    const val version = "2.1.20-1.0.31"
+    const val version = "2.1.20-2.0.0"
     const val id = "com.google.devtools.ksp"
     const val group = "com.google.devtools.ksp"
     const val symbolProcessingApi = "$group:symbol-processing-api:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Pmd.kt
@@ -31,12 +31,5 @@ package io.spine.dependency.build
 // https://github.com/pmd/pmd/releases
 @Suppress("unused", "ConstPropertyName")
 object Pmd {
-    /**
-     * This is the last version in the 6.x series.
-     *
-     * There's a major update to 7.x series.
-     *
-     * @see <a href="https://docs.pmd-code.org/pmd-doc-7.0.0-rc3/pmd_release_notes_pmd7.html>PMD 7.0.0 release notes</a>
-     */
-    const val version = "6.55.0"
+    const val version = "7.12.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Aedile.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Aedile.kt
@@ -33,6 +33,6 @@ package io.spine.dependency.lib
  */
 @Suppress("unused")
 object Aedile {
-    private const val version = "1.3.1"
+    private const val version = "2.0.3"
     const val lib = "com.sksamuel.aedile:aedile-core:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Caffeine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Caffeine.kt
@@ -36,6 +36,6 @@ package io.spine.dependency.lib
  */
 @Suppress("unused")
 object Caffeine {
-    private const val version = "3.0.5"
+    private const val version = "3.2.0"
     const val lib = "com.github.ben-manes.caffeine:caffeine:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Clikt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Clikt.kt
@@ -29,6 +29,6 @@ package io.spine.dependency.lib
 // https://ajalt.github.io/clikt/
 @Suppress("unused")
 object Clikt {
-    private const val version = "3.5.2"
+    private const val version = "5.0.3"
     const val lib = "com.github.ajalt.clikt:clikt:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Coroutines.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object Coroutines {
     const val group = "org.jetbrains.kotlinx"
-    const val version = "1.10.1"
+    const val version = "1.10.2"
     const val bom = "$group:kotlinx-coroutines-bom:$version"
     const val core = "$group:kotlinx-coroutines-core:$version"
     const val coreJvm = "$group:kotlinx-coroutines-core-jvm:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
@@ -30,7 +30,7 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.59.0"
+    const val version        = "1.71.0"
     const val group          = "io.grpc"
     const val api            = "$group:grpc-api:$version"
     const val auth           = "$group:grpc-auth:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.lib
  */
 @Suppress("unused")
 object GrpcKotlin {
-    const val version = "1.3.0"
+    const val version = "1.4.2"
     const val stub = "io.grpc:grpc-kotlin-stub:$version"
 
     object ProtocPlugin {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Gson.kt
@@ -34,6 +34,6 @@ package io.spine.dependency.lib
  */
 @Suppress("unused", "ConstPropertyName")
 object Gson {
-    private const val version = "2.10.1"
+    private const val version = "2.13.0"
     const val lib = "com.google.code.gson:gson:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Guava.kt
@@ -37,7 +37,7 @@ package io.spine.dependency.lib
  */
 @Suppress("unused", "ConstPropertyName")
 object Guava {
-    private const val version = "32.1.3-jre"
+    private const val version = "33.4.8-jre"
     const val group = "com.google.guava"
     const val lib     = "$group:guava:$version"
     const val testLib = "$group:guava-testlib:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
@@ -29,24 +29,55 @@ package io.spine.dependency.lib
 // https://github.com/FasterXML/jackson/wiki/Jackson-Releases
 @Suppress("unused", "ConstPropertyName")
 object Jackson {
-    const val version = "2.15.3"
-    private const val databindVersion = "2.15.3"
+    const val version = "2.18.3"
+    private const val databindVersion = "2.18.3"
 
-    private const val coreGroup = "com.fasterxml.jackson.core"
-    private const val dataformatGroup = "com.fasterxml.jackson.dataformat"
-    private const val moduleGroup = "com.fasterxml.jackson.module"
+    private const val groupPrefix = "com.fasterxml.jackson"
+    private const val coreGroup = "$groupPrefix.core"
+    private const val moduleGroup = "$groupPrefix.module"
 
     // https://github.com/FasterXML/jackson-core
     const val core = "$coreGroup:jackson-core:$version"
+
     // https://github.com/FasterXML/jackson-databind
     const val databind = "$coreGroup:jackson-databind:$databindVersion"
+
     // https://github.com/FasterXML/jackson-annotations
     const val annotations = "$coreGroup:jackson-annotations:$version"
 
-    // https://github.com/FasterXML/jackson-dataformat-xml/releases
-    const val dataformatXml = "$dataformatGroup:jackson-dataformat-xml:$version"
-    // https://github.com/FasterXML/jackson-dataformats-text/releases
-    const val dataformatYaml = "$dataformatGroup:jackson-dataformat-yaml:$version"
+    object DataFormat {
+        private const val group = "$groupPrefix.dataformat"
+        private const val infix = "jackson-dataformat"
+
+        // https://github.com/FasterXML/jackson-dataformat-xml/releases
+        const val xml = "$group:$infix-xml:$version"
+
+        // https://github.com/FasterXML/jackson-dataformats-text/releases
+        const val yaml = "$group:$infix-yaml:$version"
+    }
+
+    object DataType {
+        private const val group = "$groupPrefix.datatype"
+        private const val infix = "jackson-datatype"
+
+        // https://github.com/FasterXML/jackson-modules-java8
+        const val jdk8 = "$group:$infix-jdk8:$version"
+
+        // https://github.com/FasterXML/jackson-modules-java8/tree/2.19/datetime
+        const val dateTime = "$group:$infix-jsr310:$version"
+
+        // https://github.com/FasterXML/jackson-datatypes-collections/blob/2.19/guava
+        const val guava = "$group:$infix-guava:$version"
+
+        // https://github.com/FasterXML/jackson-dataformats-binary/tree/2.19/protobuf
+        const val protobuf = "$group:$infix-protobuf:$version"
+
+        // https://github.com/FasterXML/jackson-datatypes-misc/tree/2.19/javax-money
+        const val javaXMoney = "$group:$infix-javax-money:$version"
+
+        // https://github.com/FasterXML/jackson-datatypes-misc/tree/2.19/moneta
+        const val moneta = "$group:jackson-datatype-moneta:$version"
+    }
 
     // https://github.com/FasterXML/jackson-module-kotlin/releases
     const val moduleKotlin = "$moduleGroup:jackson-module-kotlin:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
@@ -29,7 +29,7 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object JavaX {
     // This artifact, which used to be a part of J2EE, moved under the Eclipse EE4J project.
-    // https://github.com/eclipse-ee4j/common-annotations-api
+    // https://github.com/jakartaee/common-annotations-api
     const val annotationGroup = "javax.annotation"
     const val annotations = "$annotationGroup:javax.annotation-api:1.3.2"
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinSemver.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinSemver.kt
@@ -29,6 +29,6 @@ package io.spine.dependency.lib
 // https://github.com/z4kn4fein/kotlin-semver
 @Suppress("unused", "ConstPropertyName")
 object KotlinSemver {
-    private const val version = "1.4.2"
+    private const val version = "2.0.0"
     const val lib     = "io.github.z4kn4fein:semver:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.lib
 )
 object Protobuf {
     const val group = "com.google.protobuf"
-    const val version       = "3.25.1"
+    const val version = "4.30.2"
 
     /**
      * The Java library with Protobuf data types.
@@ -64,7 +64,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.9.4"
+        const val version = "0.9.5"
         const val id = "com.google.protobuf"
         const val lib = "$group:protobuf-gradle-plugin:$version"
     }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
@@ -37,7 +37,7 @@ object Roaster {
      * [2.29.0.Final](https://github.com/forge/roaster/releases/tag/2.29.0.Final),
      * Roaster requires Java 17.
      */
-    private const val version = "2.28.0.Final"
+    private const val version = "2.29.0.Final"
 
     const val group = "org.jboss.forge.roaster"
     const val api = "$group:roaster-api:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.307"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.307"
+    const val version = "2.0.0-SNAPSHOT.309"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.309"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.300"
+    const val version = "2.0.0-SNAPSHOT.301"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.93.7"
+    private const val fallbackVersion = "0.93.12"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.93.7"
+    private const val fallbackDfVersion = "0.93.12"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.93.12"
+    private const val fallbackDfVersion = "0.93.13"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Time {
-    const val version = "2.0.0-SNAPSHOT.200"
+    const val version = "2.0.0-SNAPSHOT.202"
     const val group = Spine.group
     const val artifact = "spine-time"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/AssertK.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/AssertK.kt
@@ -34,6 +34,6 @@ package io.spine.dependency.test
 @Deprecated("Please use Kotest assertions instead.")
 @Suppress("unused", "ConstPropertyName")
 object AssertK {
-    private const val version = "0.26.1"
+    private const val version = "0.28.1"
     const val libJvm = "com.willowtreeapps.assertk:assertk-jvm:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Hamcrest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Hamcrest.kt
@@ -35,6 +35,6 @@ package io.spine.dependency.test
 @Suppress("unused", "ConstPropertyName")
 object Hamcrest {
     // https://github.com/hamcrest/JavaHamcrest/releases
-    private const val version = "2.2"
+    private const val version = "3.0"
     const val core = "org.hamcrest:hamcrest-core:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -29,14 +29,14 @@ package io.spine.dependency.test
 // https://junit.org/junit5/
 @Suppress("unused", "ConstPropertyName")
 object JUnit {
-    const val version = "5.10.0"
+    const val version = "5.12.2"
     private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
     private const val apiGuardianVersion = "1.1.2"
 
     // https://github.com/junit-pioneer/junit-pioneer
-    private const val pioneerVersion = "2.0.1"
+    private const val pioneerVersion = "2.3.0"
 
     const val legacy = "junit:junit:$legacyVersion"
 
@@ -54,7 +54,7 @@ object JUnit {
 
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.10.0"
+        const val version = "1.12.2"
         internal const val group = "org.junit.platform"
         const val commons = "$group:junit-platform-commons:$version"
         const val launcher = "$group:junit-platform-launcher:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Jacoco.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Jacoco.kt
@@ -33,5 +33,5 @@ package io.spine.dependency.test
  */
 @Suppress("ConstPropertyName")
 object Jacoco {
-    const val version = "0.8.12"
+    const val version = "0.8.13"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Kover.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Kover.kt
@@ -29,7 +29,7 @@ package io.spine.dependency.test
 // https://github.com/Kotlin/kotlinx-kover
 @Suppress("unused", "ConstPropertyName")
 object Kover {
-    const val version = "0.7.6"
+    const val version = "0.9.1"
     const val id = "org.jetbrains.kotlinx.kover"
     const val classpath = "org.jetbrains.kotlinx:kover-gradle-plugin:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Truth.kt
@@ -29,7 +29,7 @@ package io.spine.dependency.test
 // https://github.com/google/truth
 @Suppress("unused", "ConstPropertyName")
 object Truth {
-    private const val version = "1.1.5"
+    private const val version = "1.4.4"
     val libs = listOf(
         "com.google.truth:truth:$version",
         "com.google.truth.extensions:truth-java8-extension:$version",

--- a/buildSrc/src/main/kotlin/io/spine/gradle/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/ProjectExtensions.kt
@@ -68,7 +68,7 @@ fun Project.applyPlugin(cls: Class<out Plugin<*>>) {
  * the generic parameter `T`.
  */
 @Suppress("UNCHECKED_CAST")     /* See the method docs. */
-fun <T : Task> Project.findTask(name: String): T {
+fun <T : Task> Project.getTask(name: String): T {
     val task = this.tasks.findByName(name)
         ?: error("Unable to find a task named `$name` in the project `${this.name}`.")
     return task as T

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/CodebaseFilter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/CodebaseFilter.kt
@@ -29,7 +29,6 @@ package io.spine.gradle.report.coverage
 import com.google.errorprone.annotations.CanIgnoreReturnValue
 import io.spine.gradle.report.coverage.FileFilter.generatedOnly
 import java.io.File
-import kotlin.streams.toList
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileTree

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/JacocoConfig.kt
@@ -28,7 +28,7 @@ package io.spine.gradle.report.coverage
 
 import io.spine.dependency.test.Jacoco
 import io.spine.gradle.applyPlugin
-import io.spine.gradle.findTask
+import io.spine.gradle.getTask
 import io.spine.gradle.report.coverage.TaskName.check
 import io.spine.gradle.report.coverage.TaskName.copyReports
 import io.spine.gradle.report.coverage.TaskName.jacocoRootReport
@@ -181,7 +181,7 @@ class JacocoConfig(
     private fun registerCopy(tasks: TaskContainer): TaskProvider<Copy> {
         val everyExecData = mutableListOf<ConfigurableFileCollection>()
         projects.forEach { project ->
-            val jacocoTestReport = project.findTask<JacocoReport>(jacocoTestReport.name)
+            val jacocoTestReport = project.getTask<JacocoReport>(jacocoTestReport.name)
             val executionData = jacocoTestReport.executionData
             everyExecData.add(executionData)
         }
@@ -194,7 +194,7 @@ class JacocoConfig(
             rename {
                 "${UUID.randomUUID()}.exec"
             }
-            dependsOn(projects.map { it.findTask<JacocoReport>(jacocoTestReport.name) })
+            dependsOn(projects.map { it.getTask<JacocoReport>(jacocoTestReport.name) })
         }
         return copyReports
     }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
@@ -30,7 +30,7 @@ import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.LicenseReportExtension.ALL
 import com.github.jk1.license.LicenseReportPlugin
 import io.spine.gradle.applyPlugin
-import io.spine.gradle.findTask
+import io.spine.gradle.getTask
 import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -98,7 +98,7 @@ object LicenseReporter {
     }
 
     /**
-     * Tells to merge all per-project reports which were previously [generated][generateReportIn]
+     * Tells to merge all per-project reports that were previously [generated][generateReportIn]
      * for each of the subprojects of the root Gradle project.
      *
      * The merge result is placed according to [Paths].
@@ -109,10 +109,10 @@ object LicenseReporter {
         val rootProject = project.rootProject
         val mergeTask = rootProject.tasks.register(mergeTaskName) {
             val consolidationTask = this
-            val assembleTask = project.findTask<Task>("assemble")
+            val assembleTask = project.getTask<Task>("assemble")
             val sourceProjects: Iterable<Project> = sourceProjects(rootProject)
             sourceProjects.forEach {
-                val perProjectTask = it.findTask<Task>(projectTaskName)
+                val perProjectTask = it.getTask<Task>(projectTaskName)
                 consolidationTask.dependsOn(perProjectTask)
                 perProjectTask.dependsOn(assembleTask)
             }
@@ -121,7 +121,7 @@ object LicenseReporter {
             }
             dependsOn(assembleTask)
         }
-        project.findTask<Task>("build")
+        project.getTask<Task>("build")
             .finalizedBy(mergeTask)
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
@@ -68,8 +68,10 @@ object PomGenerator {
     fun applyTo(project: Project) {
 
         /**
-         * In some cases, the `base` plugin, which is by default is added by e.g. `java`,
-         * is not yet added. `base` plugin defines the `build` task. This generator needs it.
+         * In some cases, the `base` plugin, which by default is added by e.g. `java`,
+         * is not yet added.
+         * The `base` plugin defines the `build` task.
+         * This generator needs it.
          */
         project.apply {
             plugin(BasePlugin::class.java)

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
@@ -70,6 +70,7 @@ object PomGenerator {
         /**
          * In some cases, the `base` plugin, which by default is added by e.g. `java`,
          * is not yet added.
+         * 
          * The `base` plugin defines the `build` task.
          * This generator needs it.
          */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/Tasks.kt
@@ -29,6 +29,7 @@ package io.spine.gradle.testing
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 
 /**
  * Registers [slowTest][SlowTest] and [fastTest][FastTest] tasks in this [TaskContainer].
@@ -45,10 +46,10 @@ import org.gradle.kotlin.dsl.register
  */
 @Suppress("unused")
 fun TaskContainer.registerTestTasks() {
-    withType(Test::class.java).configureEach {
+    withType<Test>().configureEach {
         filter {
-            // There could be cases with no matching tests. E.g. tests could be based on Kotest,
-            // which has custom task types and names.
+            // There could be cases with no matching tests.
+            // E.g., tests could be based on Kotest, which has custom task types and names.
             isFailOnNoMatchingTests = false
             includeTestsMatching("*Test")
             includeTestsMatching("*Spec")

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,8 @@
 #
 
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC
+
+# Enables the Dokka migration mode from v1 to v2.
+# For details please see:
+#   https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -39,12 +39,12 @@
     <!-- Best Practices       -->
     <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
     <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
-    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>
+    <rule ref="category/java/bestpractices.xml/JUnitTestShouldIncludeAssert"/>
     <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
     <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
     <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap"/>
     <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList"/>
-    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
+    <rule ref="category/java/bestpractices.xml/NonExhaustiveSwitch"/>
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -100,7 +100,6 @@ private val File.isExcluded: Boolean
  */
 private val extensions = arrayOf("java")
 
-@Suppress("Since15")
 private val nl = System.lineSeparator()
 
 fun applyClassReplacement() {

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -126,7 +126,16 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
     val lines = readText().lines()
     var anythingReplaced = false
     val result = StringBuilder()
+
     lines.forEachIndexed { index, line ->
+
+        fun StringBuilder.appendLine(l: String) {
+            append(l)
+            if (index < lines.size - 1) {
+                result.append(nl)
+            }
+        }
+
         // Replace the fully-qualified name first.
         var oldClassName = map.keys.find {
             line.contains(it.qualifiedName)
@@ -134,7 +143,7 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
         if (oldClassName != null) {
             val newClassName = map[oldClassName]!!
             val replaced = line.replace(oldClassName.qualifiedName, newClassName.qualifiedName)
-            result.append(replaced)
+            result.appendLine(replaced)
             anythingReplaced = true
             return@forEachIndexed
         }
@@ -147,21 +156,17 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
             val newClassName = map[oldClassName]!!
             // Do nothing if the simple names are the same.
             if (oldClassName.simpleName == newClassName.simpleName) {
-                result.append(line)
+                result.appendLine(line)
                 return@forEachIndexed
             }
             val replaced = line.replace(oldClassName.simpleName, newClassName.simpleName)
-            result.append(replaced)
+            result.appendLine(replaced)
             anythingReplaced = true
             return@forEachIndexed
         }
 
         // Nothing was replaced.
-        result.append(line)
-
-        if (index < lines.size - 1) {
-            result.append(nl)
-        }
+        result.appendLine(line)
     }
     if (anythingReplaced) {
         writeText(result.toString())

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -57,7 +57,7 @@ private val annotations = buildMap {
     )
     migrate(
         "org.checkerframework.checker.nullness.qual.NonNull",
-        "org.jspecify.annotations.NotNull"
+        "org.jspecify.annotations.NonNull"
     )
 }
 

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import java.io.File
+
+private data class ClassName(val qualifiedName: String) {
+    val simpleName: String = qualifiedName.substringAfterLast(".")
+}
+
+/**
+ * Creates a replacement API migration instruction
+ */
+private fun MutableMap<ClassName, ClassName>.migrate(
+    oldClass: String,
+    newClass: String
+) = put(ClassName(oldClass), ClassName(newClass))
+
+/**
+ * Annotations.
+ */
+private val annotations = buildMap {
+    migrate(
+        "javax.annotation.ParametersAreNonnullByDefault",
+        "org.jspecify.annotations.NullMarked"
+    )
+    migrate(
+        "import javax.annotation.Nullable",
+        "org.jspecify.annotations.Nullable"
+    )
+    migrate(
+        "import org.checkerframework.checker.nullness.qual.Nullable",
+        "org.jspecify.annotations.Nullable"
+    )
+    migrate(
+        "import org.checkerframework.checker.nullness.qual.NonNull",
+        "org.jspecify.annotations.NotNull"
+    )
+}
+
+/**
+ * Directories to be excluded from the traversal.
+ */
+private val excludedTopLevelDirs = setOf(
+    ".git",
+    ".github",
+    ".github-workflows",
+    ".gradle",
+    ".idea",
+    "build",
+    "gradle",
+    "quality",
+    "BuildSpeed",
+    "config"
+)
+
+private val excludedPaths = setOf(
+    "buildSrc/.gradle",
+    "buildSrc/build",
+    "scripts/publish-documentation/buildSrc",
+)
+
+/**
+ * Excludes from the traversal directories that should not be processed.
+ *
+ * 1. Top-level project directory with the names listed in [excludedTopLevelDirs].
+ * 2. `scripts/publish-documentation/buildSrc` directory, which is a symlink.
+ */
+private val File.isExcluded: Boolean
+    get() = if (parent == ".") {
+        name in excludedTopLevelDirs
+    } else {
+        excludedPaths.any { path.contains(it) }
+    }
+
+/**
+ * Extensions of files to be processed.
+ */
+private val extensions = arrayOf("java")
+
+@Suppress("Since15")
+private val nl = System.lineSeparator()
+
+fun applyClassReplacement() {
+    val projectRoot = File(".")
+    val allReplacements = annotations
+    projectRoot.walk()
+        .onEnter {
+            val enter = !it.isExcluded
+            if (enter) {
+                println("$it".removePrefix("./"))
+            }
+            enter
+        }
+        .filter { it.isFile && it.extension in extensions }
+        .forEach {
+            val fileUpdated = it.applyClassReplacement(allReplacements)
+            if (fileUpdated) {
+                println("  ${it.name} -> Modified.")
+            }
+        }
+}
+
+private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean {
+    val lines = readText().lines()
+    var anythingReplaced = false
+    val result = StringBuilder()
+    lines.forEachIndexed { index, line ->
+        // Replace the fully-qualified name first.
+        var oldClassName = map.keys.find {
+            line.contains(it.qualifiedName)
+        }
+        if (oldClassName != null) {
+            val newClassName = map[oldClassName]!!
+            val replaced = line.replace(oldClassName.qualifiedName, newClassName.qualifiedName)
+            result.append(replaced)
+            anythingReplaced = true
+            return@forEachIndexed
+        }
+
+        // See if we need to replace the simple name.
+        oldClassName = map.keys.find {
+            line.contains(it.simpleName)
+        }
+        if (oldClassName != null) {
+            val newClassName = map[oldClassName]!!
+            // Do nothing if the simple names are the same.
+            if (oldClassName.simpleName == newClassName.simpleName) {
+                result.append(line)
+                return@forEachIndexed
+            }
+            val replaced = line.replace(oldClassName.simpleName, newClassName.simpleName)
+            result.append(replaced)
+            anythingReplaced = true
+            return@forEachIndexed
+        }
+
+        // Nothing was replaced.
+        result.append(line)
+
+        if (index < lines.size - 1) {
+            result.append(nl)
+        }
+    }
+    if (anythingReplaced) {
+        writeText(result.toString())
+    }
+    return anythingReplaced
+}
+
+fun main() {
+    applyClassReplacement()
+}
+
+main()

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -28,6 +28,7 @@ import java.io.File
 
 private data class ClassName(val qualifiedName: String) {
     val simpleName: String = qualifiedName.substringAfterLast(".")
+    val asAnnotation = "@$simpleName"
 }
 
 /**
@@ -148,9 +149,9 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
             return@forEachIndexed
         }
 
-        // See if we need to replace the simple name.
+        // See if we need to replace the simple annotation name.
         oldClassName = map.keys.find {
-            line.contains(it.simpleName)
+            line.contains(it.asAnnotation)
         }
         if (oldClassName != null) {
             val newClassName = map[oldClassName]!!
@@ -159,7 +160,7 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
                 result.appendLine(line)
                 return@forEachIndexed
             }
-            val replaced = line.replace(oldClassName.simpleName, newClassName.simpleName)
+            val replaced = line.replace(oldClassName.asAnnotation, newClassName.asAnnotation)
             result.appendLine(replaced)
             anythingReplaced = true
             return@forEachIndexed

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -130,10 +130,13 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
 
     lines.forEachIndexed { index, line ->
 
-        fun StringBuilder.appendLine(l: String) {
+        fun StringBuilder.appendLine(l: String, replaced: Boolean = false) {
             append(l)
             if (index < lines.size - 1) {
                 result.append(nl)
+            }
+            if (replaced) {
+                anythingReplaced = true
             }
         }
 
@@ -144,8 +147,7 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
         if (oldClassName != null) {
             val newClassName = map[oldClassName]!!
             val replaced = line.replace(oldClassName.qualifiedName, newClassName.qualifiedName)
-            result.appendLine(replaced)
-            anythingReplaced = true
+            result.appendLine(replaced, true)
             return@forEachIndexed
         }
 
@@ -161,8 +163,7 @@ private fun File.applyClassReplacement(map: Map<ClassName, ClassName>): Boolean 
                 return@forEachIndexed
             }
             val replaced = line.replace(oldClassName.asAnnotation, newClassName.asAnnotation)
-            result.appendLine(replaced)
-            anythingReplaced = true
+            result.appendLine(replaced, true)
             return@forEachIndexed
         }
 

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -48,15 +48,15 @@ private val annotations = buildMap {
         "org.jspecify.annotations.NullMarked"
     )
     migrate(
-        "import javax.annotation.Nullable",
+        "javax.annotation.Nullable",
         "org.jspecify.annotations.Nullable"
     )
     migrate(
-        "import org.checkerframework.checker.nullness.qual.Nullable",
+        "org.checkerframework.checker.nullness.qual.Nullable",
         "org.jspecify.annotations.Nullable"
     )
     migrate(
-        "import org.checkerframework.checker.nullness.qual.NonNull",
+        "org.checkerframework.checker.nullness.qual.NonNull",
         "org.jspecify.annotations.NotNull"
     )
 }


### PR DESCRIPTION
This PR brings latest changes adopted in Base regarding using newer versions of external dependencies. 

The major challenge is migrating from `javax.annotations` to JSpecify. This PR adds the `scripts/JSpecify-migration.kts` script for automating the migration process.

### Bumped  external dependencies
 * Adile -> `2.0.3`
 * AssertK -> `0.28.1`
 * Caffeine -> `3.2.0`
 * Hamcrest -> `3.0` // We don't use it.
 * Kotlin Coroutines -> `1.10.2`
 * Clikt -> `5.0.3`
 * Dokka -> `2.0.0`
 * gRPC -> `1.71.0`
 * Gson -> `2.13.0`
 * Guava -> `33.4.8-jre`
 * gRPC Kotlin -> `1.4.2`
 * Jackson -> `2.18.3`
 * Jacoco -> `0.8.13`
 * JUnit -> 5.12.2`
 
 * **Protobuf** -> `4.30.2`
 * **Protobuf Gradle Plugin** -> `0.9.5`

 * KotlinSemver -> `2.0.0`
 * Kover -> 0.9.1`
 * KSP -> `2.1.20-2.0.0`
 * PMD -> `7.12.0`
 * Roaster -> `2.29.0.Final`
 * Truth -> `1.4.4`

### Other notable changes
 * The extension `Project.findTask(name)` was renamed to `Project.getTask()` to stress on the fact that it throws `ISE` if there is no such a task.
 * `Project.productionModuleNames` extension was added.
 * `DocumentationSettings` `object` was introduced for brining constants for Dokka tasks.
 * PMD settings warnings were addressed.
 * Added Gradle property for turning Dokka migration v1 -> v2 flag.
