### PR TITLE
Propagate `gradle.properties` and `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@
 .fleet/
 
 # Kotlin temp directories.
-**/.kotlin/**
+**/.kotlin/
 
 # IntelliJ IDEA modules and interim config files.
 *.iml

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -53,7 +53,7 @@ repositories {
  * Please keep this value in sync with [io.spine.dependency.lib.Jackson.version].
  * It is not a requirement but would be good in terms of consistency.
  */
-val jacksonVersion = "2.15.3"
+val jacksonVersion = "2.18.3"
 
 /**
  * The version of Google Artifact Registry used by `buildSrc`.
@@ -83,7 +83,7 @@ val kotlinVersion = "2.1.20"
  * Always use the same version as the one specified in [io.spine.dependency.lib.Guava].
  * Otherwise, when testing Gradle plugins, clashes may occur.
  */
-val guavaVersion = "32.1.3-jre"
+val guavaVersion = "33.4.8-jre"
 
 /**
  * The version of ErrorProne Gradle plugin.
@@ -130,7 +130,7 @@ val kotestJvmPluginVersion = "0.4.10"
 /**
  * @see [io.spine.dependency.test.Kover]
  */
-val koverVersion = "0.7.2"
+val koverVersion = "0.9.1"
 
 /**
  * The version of the Shadow Plugin.

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -29,6 +29,7 @@
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.GradleDoctor
 import io.spine.dependency.build.Ksp
+import io.spine.dependency.build.PluginPublishPlugin
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.McJava
 import io.spine.dependency.local.ProtoData
@@ -149,6 +150,9 @@ val PluginDependenciesSpec.kover: PluginDependencySpec
 
 val PluginDependenciesSpec.ksp: PluginDependencySpec
     get() = id(Ksp.id).version(Ksp.version)
+
+val PluginDependenciesSpec.`plugin-publish`: PluginDependencySpec
+    get() = id(PluginPublishPlugin.id).version(PluginPublishPlugin.version)
 
 /**
  * Configures the dependencies between third-party Gradle tasks

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/PluginPublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/PluginPublishPlugin.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("unused")
+
+package io.spine.dependency.build
+
+/**
+ * The Gradle plugin for publishing Gradle plugins to the Gradle Plugin Portal.
+ *
+ * @see <a href="https://plugins.gradle.org/plugin/com.gradle.plugin-publish">
+ *     The plugin page at the Portal</a>
+ * @see <a href="https://plugins.gradle.org/docs/publish-plugin">Publishing Rules</a>
+ */
+@Suppress("ConstPropertyName")
+object PluginPublishPlugin {
+    const val version = "1.3.1"
+    const val id = "com.gradle.plugin-publish"
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
@@ -46,6 +46,11 @@ object Grpc {
 
     object ProtocPlugin {
         const val id = "grpc"
+        const val kotlinPluginVersion = "1.4.1"
         const val artifact = "$group:protoc-gen-grpc-java:$version"
+
+        // https://github.com/grpc/grpc-kotlin
+        // https://repo.maven.apache.org/maven2/io/grpc/protoc-gen-grpc-kotlin/
+        const val artifactKotlin = "$group:protoc-gen-grpc-kotlin:$$kotlinPluginVersion"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.309"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.309"
+    const val version = "2.0.0-SNAPSHOT.311"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.311"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -26,13 +26,6 @@
 
 package io.spine.dependency.local
 
-import io.spine.dependency.local.ProtoData.DF_VERSION_ENV
-import io.spine.dependency.local.ProtoData.VERSION_ENV
-import io.spine.dependency.local.ProtoData.dogfoodingVersion
-import io.spine.dependency.local.ProtoData.pluginLib
-import io.spine.dependency.local.ProtoData.version
-
-
 /**
  * Dependencies on ProtoData modules.
  *

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -26,6 +26,13 @@
 
 package io.spine.dependency.local
 
+import io.spine.dependency.local.ProtoData.DF_VERSION_ENV
+import io.spine.dependency.local.ProtoData.VERSION_ENV
+import io.spine.dependency.local.ProtoData.dogfoodingVersion
+import io.spine.dependency.local.ProtoData.pluginLib
+import io.spine.dependency.local.ProtoData.version
+
+
 /**
  * Dependencies on ProtoData modules.
  *
@@ -55,7 +62,6 @@ package io.spine.dependency.local
     "unused" /* Some subprojects do not use ProtoData directly. */,
     "ConstPropertyName" /* We use custom convention for artifact properties. */,
     "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */,
-    "KDocUnresolvedReference" /* Referencing private properties in constructor KDoc. */
 )
 object ProtoData {
     const val pluginGroup = Spine.group

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -29,7 +29,7 @@ package io.spine.dependency.test
 // https://junit.org/junit5/
 @Suppress("unused", "ConstPropertyName")
 object JUnit {
-    const val version = "5.12.2"
+    const val version = "5.13.0-M2"
     private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
@@ -47,14 +47,18 @@ object JUnit {
     )
     const val bom = "org.junit:junit-bom:$version"
 
+    @Deprecated(message = "Please use `engine` instead.", replaceWith = ReplaceWith("engine"))
     const val runner = "org.junit.jupiter:junit-jupiter-engine:$version"
+
+    const val engine = "org.junit.jupiter:junit-jupiter-engine:$version"
+    const val launcher = "org.junit.jupiter:junit-jupiter-launcher:$version"
     const val params = "org.junit.jupiter:junit-jupiter-params:$version"
 
     const val pioneer = "org.junit-pioneer:junit-pioneer:$pioneerVersion"
 
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.12.2"
+        const val version = "1.13.0-M2"
         internal const val group = "org.junit.platform"
         const val commons = "$group:junit-platform-commons:$version"
         const val launcher = "$group:junit-platform-launcher:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -29,7 +29,7 @@ package io.spine.dependency.test
 // https://junit.org/junit5/
 @Suppress("unused", "ConstPropertyName")
 object JUnit {
-    const val version = "5.13.0-M2"
+    const val version = "5.11.4"
     private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
@@ -56,7 +56,7 @@ object JUnit {
 
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.13.0-M2"
+        const val version = "1.11.4"
         internal const val group = "org.junit.platform"
         const val commons = "$group:junit-platform-commons:$version"
         const val launcher = "$group:junit-platform-launcher:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -47,9 +47,7 @@ object JUnit {
     )
     const val bom = "org.junit:junit-bom:$version"
 
-    @Deprecated(message = "Please use `engine` instead.", replaceWith = ReplaceWith("engine"))
-    const val runner = "org.junit.jupiter:junit-jupiter-engine:$version"
-
+    const val runner = "org.junit.jupiter:junit-jupiter-runner:$version"
     const val engine = "org.junit.jupiter:junit-jupiter-engine:$version"
     const val launcher = "org.junit.jupiter:junit-jupiter-launcher:$version"
     const val params = "org.junit.jupiter:junit-jupiter-params:$version"

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -103,14 +103,17 @@ fun Module.configureKotlin(javaVersion: JavaLanguageVersion) {
         }
     }
 
-    kover {
-        useJacoco(version = Jacoco.version)
+    rootProject.dependencies {
+        kover(this)
     }
 
-    koverReport {
-        defaults {
-            xml {
-                onCheck = true
+    kover {
+        useJacoco(version = Jacoco.version)
+        reports {
+            total {
+                xml {
+                    onCheck = true
+                }
             }
         }
     }

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -103,6 +103,9 @@ fun Module.configureKotlin(javaVersion: JavaLanguageVersion) {
         }
     }
 
+    // See:
+    // https://github.com/Kotlin/kotlinx-kover?tab=readme-ov-file#to-create-report-combining-coverage-info-from-different-gradle-projects
+    // https://github.com/Kotlin/kotlinx-kover/blob/main/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
     rootProject.dependencies {
         kover(this)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC
+# Dokka plugin eats more memory than usual. Therefore, all builds should have enough.
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC
 
 # Enables the Dokka migration mode from v1 to v2.
 # For details please see:

--- a/pull
+++ b/pull
@@ -89,32 +89,15 @@ rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only 
 #rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
 #rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
 
+# 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
+cp -a gradle.properties ../
+
+# 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
+cp -a .gitignore ../
+
 # 2024-10-28
 echo "Removing old packages under 'buildSrc/src/main/kotin/'"
 rm -r ../buildSrc/src/main/kotlin/io/spine/internal/
-
-echo "Cleaning up outdated dependency objects in 'buildSrc'"
-# 2024-10-26, remove outdated files.
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependency/McJava.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoTap.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
-
-# 2023-04-13, remove outdated files.
-
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/dokka/DokkaExtensions.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/dokka/TaskContainerExtensions.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/publish/DokkaJar.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/publish/ProtoJar.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/publish/TestJar.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/publish/PublishingConfig.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/publish/Tasks.kt
-
-# 2023-05-20, remove outdated files.
-
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/DependencyResolution.kt
 
 # 2023-07-12, remove outdated files.
 

--- a/pull
+++ b/pull
@@ -90,10 +90,10 @@ rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only 
 #rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
 
 # 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
-cp -a gradle.properties ../
+cp -a gradle.properties ..
 
 # 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
-cp -a .gitignore ../
+cp -a .gitignore ..
 
 # 2024-10-28
 echo "Removing old packages under 'buildSrc/src/main/kotin/'"
@@ -114,7 +114,7 @@ rm -f ../.lift.toml
 # See `config#498` for more.
 rm -f ../license-report.md
 
-echo "Updating Gradle 'buildSrc' scripts"
+echo "Updating Gradle 'buildSrc'"
 cp -R buildSrc ..
 
 echo "Updating Gradle Wrapper"

--- a/quality/pmd.xml
+++ b/quality/pmd.xml
@@ -39,7 +39,7 @@
     <!-- Best Practices       -->
     <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
     <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
-    <rule ref="category/java/bestpractices.xml/JUnitTestShouldIncludeAssert"/>
+    <rule ref="category/java/bestpractices.xml/UnitTestShouldIncludeAssert"/>
     <rule ref="category/java/bestpractices.xml/LiteralsFirstInComparisons"/>
     <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
     <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap"/>

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -80,6 +80,9 @@ private val excludedTopLevelDirs = setOf(
 private val excludedPaths = setOf(
     "buildSrc/.gradle",
     "buildSrc/build",
+    "tmp/",
+    "/build/",
+    "/generated/",
     "scripts/publish-documentation/buildSrc",
 )
 

--- a/scripts/JSpecify-migration.kts
+++ b/scripts/JSpecify-migration.kts
@@ -77,6 +77,9 @@ private val excludedTopLevelDirs = setOf(
     "config"
 )
 
+/**
+ * The paths excluded from the traversal at all levels.
+ */
 private val excludedPaths = setOf(
     "buildSrc/.gradle",
     "buildSrc/build",


### PR DESCRIPTION
This PR updates the `pull` script to propagate `gradle.properties` and `.gitignore` to the subprojects.

Also, versions of Guava and Jackson used in the `buildSrc/build.gradle.kts` were sync'ed with versions in the dependency objects.

### Other notable changes
 * Kover DSL was updated to match the latest version.
 * Give more memory for Dokka in `gradle.properties`.
 * Remove removal instructions for long outdated scripts under the `pull` script.
 * Improve exclusions in `JSpecify-migration.kts`.
 * Added `PluginPublishPlugin` dependency object and `plugin-publish` extension.
 * `PublishingExts.kts` was copied from `tool-base`.


