### PR TITLE
Rollback gRPC Kotlin and force line separators to Unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@
 .fleet/
 
 # Kotlin temp directories.
-**/.kotlin/**
+**/.kotlin/
 
 # IntelliJ IDEA modules and interim config files.
 *.iml
@@ -51,7 +51,6 @@
 
 # Do not ignore the following IDEA settings
 !.idea/misc.xml
-!.idea/kotlinc.xml
 !.idea/codeStyleSettings.xml
 !.idea/codeStyles/
 !.idea/copyright/
@@ -64,13 +63,14 @@
 
 # Generated source code
 **/generated/**
+**/*.pb.dart
+**/*.pbenum.dart
+**/*.pbserver.dart
+**/*.pbjson.dart
 
 # Gradle build files
 **/build/**
 !**/src/**/build/**
-
-# Do not ignore `build` dependency objects under `buildSrc`.
-!**/buildSrc/src/main/kotlin/io/spine/dependency/build/**
 
 # Build files produced by the IDE
 **/out/**
@@ -89,9 +89,6 @@ gradle-app.setting
 
 # Spine internal directory for storing intermediate artifacts
 **/.spine/**
-
-# Spine model compiler auto-generated resources
-/tools/gradle-plugins/model-compiler/src/main/resources/spine-protoc.gradle
 
 # Login details to Maven repository.
 # Each workstation should have developer's login defined in this file.

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="RIGHT_MARGIN" value="100" />
     <DartCodeStyleSettings>
       <option name="DELEGATE_TO_DARTFMT" value="false" />

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -221,7 +221,7 @@ fun Project.configureTaskDependencies() {
 }
 
 /**
- * Obtains all modules that do not haveg names ending with the "-tests"` suffix.
+ * Obtains all modules names of which do not have `"-tests"` as the suffix.
  *
  * By convention, such modules are for integration tests and should be treated differently.
  */

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -40,7 +40,6 @@ import io.spine.dependency.lib.CommonsLogging
 import io.spine.dependency.lib.Gson
 import io.spine.dependency.lib.Guava
 import io.spine.dependency.lib.J2ObjC
-import io.spine.dependency.lib.Jackson
 import io.spine.dependency.lib.JavaDiffUtils
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Okio
@@ -50,7 +49,6 @@ import io.spine.dependency.lib.Slf4J
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.Spine
 import io.spine.dependency.test.Hamcrest
-import io.spine.dependency.test.JUnit
 import io.spine.dependency.test.Kotest
 import io.spine.dependency.test.OpenTest4J
 import io.spine.dependency.test.Truth
@@ -113,11 +111,6 @@ private fun ResolutionStrategy.forceProductionDependencies() {
 private fun ResolutionStrategy.forceTestDependencies() {
     force(
         Guava.testLib,
-        JUnit.api,
-        JUnit.bom,
-        JUnit.Platform.commons,
-        JUnit.Platform.launcher,
-        JUnit.legacy,
         Truth.libs,
         Kotest.assertions,
     )
@@ -140,16 +133,6 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
         Gson.lib,
         Hamcrest.core,
         J2ObjC.annotations,
-        JUnit.Platform.engine,
-        JUnit.Platform.suiteApi,
-        JUnit.runner,
-        Jackson.annotations,
-        Jackson.bom,
-        Jackson.core,
-        Jackson.databind,
-        Jackson.DataFormat.xml,
-        Jackson.DataFormat.yaml,
-        Jackson.moduleKotlin,
         JavaDiffUtils.lib,
         Kotlin.jetbrainsAnnotations,
         Okio.lib,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.lib
  */
 @Suppress("unused")
 object GrpcKotlin {
-    const val version = "1.4.2"
+    const val version = "1.4.1"
     const val stub = "io.grpc:grpc-kotlin-stub:$version"
 
     object ProtocPlugin {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
@@ -38,6 +38,7 @@ object GrpcKotlin {
 
     object ProtocPlugin {
         const val id = "grpckt"
-        const val artifact = "io.grpc:protoc-gen-grpc-kotlin:$version:jdk8@jar"
+        // https://central.sonatype.com/artifact/io.grpc/protoc-gen-grpc-kotlin
+        const val artifact = "io.grpc:protoc-gen-grpc-kotlin:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
@@ -30,30 +30,37 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object Jackson {
     const val version = "2.18.3"
-    private const val databindVersion = "2.18.3"
 
     private const val groupPrefix = "com.fasterxml.jackson"
     private const val coreGroup = "$groupPrefix.core"
     private const val moduleGroup = "$groupPrefix.module"
 
+    // https://github.com/FasterXML/jackson-bom
+    const val bom = "com.fasterxml.jackson:jackson-bom:$version"
+
+    // Constants coming below without `$version` are covered by the BOM.
+
     // https://github.com/FasterXML/jackson-core
-    const val core = "$coreGroup:jackson-core:$version"
+    const val core = "$coreGroup:jackson-core"
 
     // https://github.com/FasterXML/jackson-databind
-    const val databind = "$coreGroup:jackson-databind:$databindVersion"
+    const val databind = "$coreGroup:jackson-databind"
 
     // https://github.com/FasterXML/jackson-annotations
-    const val annotations = "$coreGroup:jackson-annotations:$version"
+    const val annotations = "$coreGroup:jackson-annotations"
+
+    // https://github.com/FasterXML/jackson-module-kotlin/releases
+    const val moduleKotlin = "$moduleGroup:jackson-module-kotlin"
 
     object DataFormat {
         private const val group = "$groupPrefix.dataformat"
         private const val infix = "jackson-dataformat"
 
         // https://github.com/FasterXML/jackson-dataformat-xml/releases
-        const val xml = "$group:$infix-xml:$version"
+        const val xml = "$group:$infix-xml"
 
         // https://github.com/FasterXML/jackson-dataformats-text/releases
-        const val yaml = "$group:$infix-yaml:$version"
+        const val yaml = "$group:$infix-yaml"
     }
 
     object DataType {
@@ -61,34 +68,28 @@ object Jackson {
         private const val infix = "jackson-datatype"
 
         // https://github.com/FasterXML/jackson-modules-java8
-        const val jdk8 = "$group:$infix-jdk8:$version"
+        const val jdk8 = "$group:$infix-jdk8"
 
         // https://github.com/FasterXML/jackson-modules-java8/tree/2.19/datetime
-        const val dateTime = "$group:$infix-jsr310:$version"
+        const val dateTime = "$group:$infix-jsr310"
 
         // https://github.com/FasterXML/jackson-datatypes-collections/blob/2.19/guava
-        const val guava = "$group:$infix-guava:$version"
+        const val guava = "$group:$infix-guava"
 
         // https://github.com/FasterXML/jackson-dataformats-binary/tree/2.19/protobuf
-        const val protobuf = "$group:$infix-protobuf:$version"
+        const val protobuf = "$group:$infix-protobuf"
 
         // https://github.com/FasterXML/jackson-datatypes-misc/tree/2.19/javax-money
-        const val javaXMoney = "$group:$infix-javax-money:$version"
+        const val javaXMoney = "$group:$infix-javax-money"
 
         // https://github.com/FasterXML/jackson-datatypes-misc/tree/2.19/moneta
-        const val moneta = "$group:jackson-datatype-moneta:$version"
+        const val moneta = "$group:jackson-datatype-moneta"
     }
-
-    // https://github.com/FasterXML/jackson-module-kotlin/releases
-    const val moduleKotlin = "$moduleGroup:jackson-module-kotlin:$version"
-
-    // https://github.com/FasterXML/jackson-bom
-    const val bom = "com.fasterxml.jackson:jackson-bom:$version"
 
     // https://github.com/FasterXML/jackson-jr
     object Junior {
         const val version = Jackson.version
         const val group = "com.fasterxml.jackson.jr"
-        const val objects = "$group:jackson-jr-objects:$version"
+        const val objects = "$group:jackson-jr-objects"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -55,7 +55,6 @@ package io.spine.dependency.local
     "unused" /* Some subprojects do not use ProtoData directly. */,
     "ConstPropertyName" /* We use custom convention for artifact properties. */,
     "MemberVisibilityCanBePrivate" /* The properties are used directly by other subprojects. */,
-    "KDocUnresolvedReference" /* Referencing private properties in constructor KDoc. */
 )
 object ProtoData {
     const val pluginGroup = Spine.group

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -30,6 +30,20 @@ package io.spine.dependency.test
 @Suppress("unused", "ConstPropertyName")
 object JUnit {
     const val version = "5.12.2"
+
+    /**
+     * The BOM of JUnit.
+     *
+     * This one should be forced in a project via:
+     *
+     * ```kotlin
+     * dependencies {
+     *     testImplementation(enforcedPlatform(JUnit.bom))
+     * }
+     * ```
+     */
+    const val bom = "org.junit:junit-bom:$version"
+
     private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
@@ -37,28 +51,40 @@ object JUnit {
 
     // https://github.com/junit-pioneer/junit-pioneer
     private const val pioneerVersion = "2.3.0"
+    const val pioneer = "org.junit-pioneer:junit-pioneer:$pioneerVersion"
 
     const val legacy = "junit:junit:$legacyVersion"
 
+    @Deprecated("Use JUnit.Jupiter.api instead", ReplaceWith("JUnit.Jupiter.api"))
     val api = listOf(
         "org.apiguardian:apiguardian-api:$apiGuardianVersion",
         "org.junit.jupiter:junit-jupiter-api:$version",
         "org.junit.jupiter:junit-jupiter-params:$version"
     )
-    const val bom = "org.junit:junit-bom:$version"
 
+    @Deprecated("Use JUnit.Jupiter.engine instead", ReplaceWith("JUnit.Jupiter.engine"))
     const val runner = "org.junit.jupiter:junit-jupiter-engine:$version"
+
+    @Deprecated("Use JUnit.Jupiter.params instead", ReplaceWith("JUnit.Jupiter.params"))
     const val params = "org.junit.jupiter:junit-jupiter-params:$version"
 
-    const val pioneer = "org.junit-pioneer:junit-pioneer:$pioneerVersion"
+    object Jupiter {
+        const val group = "org.junit.jupiter"
+        private const val infix = "junit-jupiter"
+
+        // We do not use versions because they are forced via BOM.
+        const val api = "$group:$infix-api"
+        const val params = "$group:$infix-params"
+        const val engine = "$group:$infix-engine"
+    }
 
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.12.2"
         internal const val group = "org.junit.platform"
-        const val commons = "$group:junit-platform-commons:$version"
-        const val launcher = "$group:junit-platform-launcher:$version"
-        const val engine = "$group:junit-platform-engine:$version"
-        const val suiteApi = "$group:junit-platform-suite-api:$version"
+        private const val infix = "junit-platform"
+        const val commons = "$group:$infix-commons"
+        const val launcher = "$group:$infix-launcher"
+        const val engine = "$group:$infix-engine"
+        const val suiteApi = "$group:$infix-suite-api"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -140,6 +140,11 @@ private fun TaskContainer.getOrCreatePublishTask(): TaskProvider<Task> =
         register(PUBLISH_TASK)
     }
 
+@Suppress(
+    /* Several types of exceptions may be thrown,
+       and Kotlin does not have a multi-catch support yet. */
+    "TooGenericExceptionCaught"
+)
 private fun TaskContainer.registerCheckCredentialsTask(
     destinations: Set<Repository>,
 ): TaskProvider<Task> {
@@ -157,7 +162,7 @@ private fun TaskContainer.registerCheckCredentialsTask(
         val toConfigure = replace(checkCredentials)
         toConfigure.doLastCredentialsCheck(destinations)
         return named(checkCredentials)
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         return register(checkCredentials) { doLastCredentialsCheck(destinations) }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
@@ -70,7 +70,7 @@ object PomGenerator {
         /**
          * In some cases, the `base` plugin, which by default is added by e.g. `java`,
          * is not yet added.
-         * 
+         *
          * The `base` plugin defines the `build` task.
          * This generator needs it.
          */

--- a/buildSrc/src/main/kotlin/module-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/module-testing.gradle.kts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.dependency.lib.Guava
+import io.spine.dependency.local.TestLib
+import io.spine.dependency.test.JUnit
+import io.spine.dependency.test.Kotest
+import io.spine.dependency.test.Truth
+import io.spine.gradle.testing.configureLogging
+import io.spine.gradle.testing.registerTestTasks
+
+plugins {
+    `java-library`
+}
+
+project.run {
+    setupTests()
+    forceTestDependencies()
+}
+
+dependencies {
+    forceJunitPlatform()
+
+    testImplementation(JUnit.Jupiter.api)
+    testImplementation(JUnit.pioneer)
+
+    testImplementation(Guava.testLib)
+
+    testImplementation(TestLib.lib)
+    testImplementation(Kotest.assertions)
+    testImplementation(Kotest.datatest)
+
+    testRuntimeOnly(JUnit.Jupiter.engine)
+}
+
+/**
+ * Forces the version of [JUnit] platform and its dependencies via [JUnit.bom].
+ */
+private fun DependencyHandlerScope.forceJunitPlatform() {
+    testImplementation(enforcedPlatform(JUnit.bom))
+}
+
+typealias Module = Project
+
+/**
+ * Configure this module to run JUnit-based tests.
+ */
+fun Module.setupTests() {
+    tasks {
+        registerTestTasks()
+        test.configure {
+            useJUnitPlatform {
+                includeEngines("junit-jupiter")
+            }
+            configureLogging()
+        }
+    }
+}
+
+/**
+ * Forces the versions of task dependencies that are used _in addition_ to
+ * the forced JUnit platform.
+ */
+@Suppress(
+    /* We're OK with incubating API for configurations. It does not seem to change recently. */
+    "UnstableApiUsage"
+)
+fun Module.forceTestDependencies() {
+    configurations {
+        all {
+            resolutionStrategy {
+                forceTestDependencies()
+            }
+        }
+    }
+}
+
+private fun ResolutionStrategy.forceTestDependencies() {
+    force(
+        Guava.testLib,
+        Truth.libs,
+        Kotest.assertions,
+    )
+}


### PR DESCRIPTION
This PR rolls back the version of gRPC for Kotlin to 1.4.1 becuse 1.4.2 is not available from public Maven repositories.

Also this PR forces the line separators in the settings because pulling `config` recently gives many warnings about encountered Windows line separators. Let's stick to Unix separators to avoid the noise.

### Changes to `buildSrc`
 * `JUnit` and `Jackson` dependency objects were updated assuming we are going to force them as platforms.
 * `DependencyResolution` was updated accordingly to the previous item.
 * `module-testing` conventions plugin was added for being used for configuring testing in a JVM module.

### `.gitignore` updates
 * Ignore `**/.kotlin/` directories instead of only files under them.
 * Ignore generated Dart code. This is brought from `base`.
 * Remove redundant entries in `.gitignore`.