### PR TITLE
Restore gRPC `protoc` plugin artifact suffix

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/GrpcKotlin.kt
@@ -39,6 +39,6 @@ object GrpcKotlin {
     object ProtocPlugin {
         const val id = "grpckt"
         // https://central.sonatype.com/artifact/io.grpc/protoc-gen-grpc-kotlin
-        const val artifact = "io.grpc:protoc-gen-grpc-kotlin:$version"
+        const val artifact = "io.grpc:protoc-gen-grpc-kotlin:$version:jdk8@jar"
     }
 }


### PR DESCRIPTION
This PR restores the suffix, which was accidentally removed in the previous PR.