### PR TITLE
Separate migration code from `pull`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 *.xml text
 *.css text
 *.scss text
+*.svg text
 *.js text
 *.properties text
 *.rtf text
@@ -23,6 +24,10 @@ LICENSE text
 
 # Java sources
 *.java text
+
+# Kotlin sources
+*.kt text
+*.kts text
 
 # Python sources
 *.py text

--- a/buildSrc/src/main/kotlin/module-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/module-testing.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
  * Forces the version of [JUnit] platform and its dependencies via [JUnit.bom].
  */
 private fun DependencyHandlerScope.forceJunitPlatform() {
-    testImplementation(enforcedPlatform(JUnit.bom))
+    testImplementation(platform(JUnit.bom))
 }
 
 typealias Module = Project

--- a/migrate
+++ b/migrate
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Update the module with reference to the latest version.
+# In this state there is no current branch.
+git submodule update
+
+# Make the `config` dir current.
+cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
+
+# Set the current branch to `master`.
+git checkout master
+
+echo "Pulling changes from remote repo"
+git pull
+
+echo "Updating IDEA configuration"
+cp -R .idea ..
+
+echo "Updating Contributor's Guide"
+cp CONTRIBUTING.md ..
+
+echo "Updating Contributor Covenant"
+cp CODE_OF_CONDUCT.md ..
+
+echo "Updating Codecov settings"
+cp .codecov.yml ..
+
+# Copies the file or directory passed as the first parameter to the upper directory,
+# only if such a file or directory does not exist there.
+function initialize() {
+  if [ ! -e ../"$1" ]; then
+      echo "Creating $1"
+      cp -R "$1" ..
+  fi
+}
+
+initialize .gitattributes
+initialize .gitignore
+initialize .github
+
+# Update existing workflows with more recent versions
+echo "Updating GitHub workflows"
+cp -a .github-workflows/. ../.github/workflows
+cp -a .github/workflows/. ../.github/workflows
+rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
+
+# echo "Cleaning up GitHub workflows"
+#rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
+#rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
+
+# echo "Cleaning up Gradle 'buildSrc' scripts"
+#rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
+#rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
+
+# 2025-04-22 Remove the refactored file to avoid "duplicated declarations" error.
+rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/publish/Publications.kt
+
+# 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
+cp -a gradle.properties ..
+
+# 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
+cp -a .gitignore ..
+
+# 2024-10-28
+echo "Removing old packages under 'buildSrc/src/main/kotin/'"
+rm -r ../buildSrc/src/main/kotlin/io/spine/internal/
+
+# 2023-07-12, remove outdated files.
+
+rm -f ../buildSrc/src/main/kotlin/java-module.gradle.kts
+rm -f ../buildSrc/src/main/kotlin/kotlin-jvm-module.gradle.kts
+rm -f ../buildSrc/src/main/kotlin/jacoco-kmm-jvm.gradle.kts
+rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+rm -f ../buildSrc/src/main/kotlin/Repositories.kt
+
+# 2023-07-30, remove outdated files.
+rm -f ../.lift.toml
+
+# 2023-11-24, remove `license-report.md` in favor of `dependencies.md`
+# See `config#498` for more.
+rm -f ../license-report.md
+
+echo "Updating Gradle 'buildSrc'"
+cp -R buildSrc ..
+
+echo "Updating Gradle Wrapper"
+cp -R ./gradle ..
+cp gradlew ..
+cp gradlew.bat ..
+
+cd ..
+
+echo "Adding 'buildSrc' sources to Git..."
+git add ./buildSrc/src

--- a/migrate
+++ b/migrate
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
 
-# Update the module with reference to the latest version.
-# In this state there is no current branch.
-git submodule update
-
-# Make the `config` dir current.
-cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
-
-# Set the current branch to `master`.
-git checkout master
-
-echo "Pulling changes from remote repo"
-git pull
-
 echo "Updating IDEA configuration"
 cp -R .idea ..
 

--- a/pull
+++ b/pull
@@ -13,6 +13,19 @@
 #
 ################################################################################
 
+# Update the module with reference to the latest version.
+# In this state there is no current branch.
+git submodule update
+
+# Make the `config` dir current.
+cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
+
+# Set the current branch to `master`.
+git checkout master
+
+echo "Pulling changes from remote repo"
+git pull
+
 # Handle file operations related to the migration from the previous version(s).
 source migrate
 

--- a/pull
+++ b/pull
@@ -1,130 +1,19 @@
 #!/usr/bin/env bash
 
-#
-# Copyright 2025, TeamDev. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# Redistribution and use in source and/or binary forms, with or without
-# modification, must retain the above copyright notice and the following
-# disclaimer.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 ################################################################################
 #
-# The script to update the project configuration files.
+# This script pulls the project configuration files from a remote Git repository.
 #
 # The code of the script assumes that:
+#
 #   1. The project uses this code as a Git sub-module installed in the `config`
 #      directory under the project root.
+#
 #   2. The script is called from the root of the project.
 #
 ################################################################################
 
-# Update the module with reference to the latest version.
-# In this state there is no current branch.
-git submodule update
-
-# Make the `config` dir current.
-cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
-
-# Set the current branch to `master`.
-git checkout master
-
-echo "Pulling changes from remote repo"
-git pull
-
-echo "Updating IDEA configuration"
-cp -R .idea ..
-
-echo "Updating Contributor's Guide"
-cp CONTRIBUTING.md ..
-
-echo "Updating Contributor Covenant"
-cp CODE_OF_CONDUCT.md ..
-
-echo "Updating Codecov settings"
-cp .codecov.yml ..
-
-# Copies the file or directory passed as the first parameter to the upper directory,
-# only if such a file or directory does not exist there.
-function initialize() {
-  if [ ! -e ../"$1" ]; then
-      echo "Creating $1"
-      cp -R "$1" ..
-  fi
-}
-
-initialize .gitattributes
-initialize .gitignore
-initialize .github
-
-# Update existing workflows with more recent versions
-echo "Updating GitHub workflows"
-cp -a .github-workflows/. ../.github/workflows
-cp -a .github/workflows/. ../.github/workflows
-rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
-
-# echo "Cleaning up GitHub workflows"
-#rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
-#rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
-
-# echo "Cleaning up Gradle 'buildSrc' scripts"
-#rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
-#rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
-
-# 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
-cp -a gradle.properties ..
-
-# 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
-cp -a .gitignore ..
-
-# 2024-10-28
-echo "Removing old packages under 'buildSrc/src/main/kotin/'"
-rm -r ../buildSrc/src/main/kotlin/io/spine/internal/
-
-# 2023-07-12, remove outdated files.
-
-rm -f ../buildSrc/src/main/kotlin/java-module.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/kotlin-jvm-module.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/jacoco-kmm-jvm.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
-rm -f ../buildSrc/src/main/kotlin/Repositories.kt
-
-# 2023-07-30, remove outdated files.
-rm -f ../.lift.toml
-
-# 2023-11-24, remove `license-report.md` in favor of `dependencies.md`
-# See `config#498` for more.
-rm -f ../license-report.md
-
-echo "Updating Gradle 'buildSrc'"
-cp -R buildSrc ..
-
-echo "Updating Gradle Wrapper"
-cp -R ./gradle ..
-cp gradlew ..
-cp gradlew.bat ..
-
-cd ..
-
-echo "Adding 'buildSrc' sources to Git..."
-git add ./buildSrc/src
+# Handle file operations related to the migration from the previous version(s).
+source migrate
 
 echo "Done."


### PR DESCRIPTION
This PR extract the migration code from the `pull` script into a separate `migrate` script so that it does not take running `pull` two times to execute the migration part removing old files etc.

### Other notable changes
 * `.gitattributes` file was updated so that it knows about Kotlin, Kotlin Script, and SVG formats.
 * Forcing JUnit via BOM now is done using `platform()` instead of `enforcePlatform()` which proved to be too hard.

