### PR TITLE
Apply improved `SpinePublishing` from `tool-base`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -75,7 +75,7 @@ val grGitVersion = "4.1.1"
  * This version may change from the [version of Kotlin][io.spine.dependency.lib.Kotlin.version]
  * used by the project.
  */
-val kotlinVersion = "2.1.20"
+val kotlinEmbeddedVersion = "2.1.20"
 
 /**
  * The version of Guava used in `buildSrc`.
@@ -148,9 +148,9 @@ configurations.all {
             "com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion",
 
             // Force Kotlin lib versions avoiding using those bundled with Gradle.
-            "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
-            "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion",
-            "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+            "org.jetbrains.kotlin:kotlin-stdlib:$kotlinEmbeddedVersion",
+            "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinEmbeddedVersion",
+            "org.jetbrains.kotlin:kotlin-reflect:$kotlinEmbeddedVersion"
         )
     }
 }
@@ -167,6 +167,7 @@ kotlin {
 
 dependencies {
     api("com.github.jk1:gradle-license-report:$licenseReportVersion")
+    api(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinEmbeddedVersion"))
     dependOnAuthCommon()
 
     listOf(
@@ -175,17 +176,17 @@ dependencies {
         "com.github.jk1:gradle-license-report:$licenseReportVersion",
         "com.google.guava:guava:$guavaVersion",
         "com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion",
-        "gradle.plugin.com.github.johnrengelman:shadow:${shadowVersion}",
+        "gradle.plugin.com.github.johnrengelman:shadow:$shadowVersion",
         "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion",
         "io.kotest:kotest-gradle-plugin:$kotestJvmPluginVersion",
         // https://github.com/srikanth-lingala/zip4j
         "net.lingala.zip4j:zip4j:2.10.0",
-        "net.ltgt.gradle:gradle-errorprone-plugin:${errorPronePluginVersion}",
-        "org.ajoberstar.grgit:grgit-core:${grGitVersion}",
-        "org.jetbrains.dokka:dokka-base:${dokkaVersion}",
+        "net.ltgt.gradle:gradle-errorprone-plugin:$errorPronePluginVersion",
+        "org.ajoberstar.grgit:grgit-core:$grGitVersion",
+        "org.jetbrains.dokka:dokka-base:$dokkaVersion",
         "org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}",
-        "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
-        "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion",
+        "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinEmbeddedVersion",
+        "org.jetbrains.kotlin:kotlin-reflect:$kotlinEmbeddedVersion",
         "org.jetbrains.kotlinx:kover-gradle-plugin:$koverVersion"
     ).forEach {
         implementation(it)

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
@@ -26,6 +26,9 @@
 
 package io.spine.dependency.lib
 
+import io.spine.dependency.lib.Protobuf.GradlePlugin.id
+
+
 // https://github.com/protocolbuffers/protobuf
 @Suppress(
     "MemberVisibilityCanBePrivate" /* used directly from the outside */,
@@ -33,7 +36,7 @@ package io.spine.dependency.lib
 )
 object Protobuf {
     const val group = "com.google.protobuf"
-    const val version = "4.30.2"
+    const val version = "3.25.7"
 
     /**
      * The Java library with Protobuf data types.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
@@ -26,9 +26,6 @@
 
 package io.spine.dependency.lib
 
-import io.spine.dependency.lib.Protobuf.GradlePlugin.id
-
-
 // https://github.com/protocolbuffers/protobuf
 @Suppress(
     "MemberVisibilityCanBePrivate" /* used directly from the outside */,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.314"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.314"
+    const val version = "2.0.0-SNAPSHOT.315"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.315"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -26,13 +26,6 @@
 
 package io.spine.dependency.local
 
-import io.spine.dependency.local.ProtoData.DF_VERSION_ENV
-import io.spine.dependency.local.ProtoData.VERSION_ENV
-import io.spine.dependency.local.ProtoData.dogfoodingVersion
-import io.spine.dependency.local.ProtoData.pluginLib
-import io.spine.dependency.local.ProtoData.version
-
-
 /**
  * Dependencies on ProtoData modules.
  *

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -26,6 +26,13 @@
 
 package io.spine.dependency.local
 
+import io.spine.dependency.local.ProtoData.DF_VERSION_ENV
+import io.spine.dependency.local.ProtoData.VERSION_ENV
+import io.spine.dependency.local.ProtoData.dogfoodingVersion
+import io.spine.dependency.local.ProtoData.pluginLib
+import io.spine.dependency.local.ProtoData.version
+
+
 /**
  * Dependencies on ProtoData modules.
  *
@@ -72,7 +79,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.93.12"
+    private const val fallbackVersion = "0.93.13"
 
     /**
      * The distinct version of ProtoData used by other build tools.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.302"
+    const val version = "2.0.0-SNAPSHOT.321"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.312"
+    const val version = "2.0.0-SNAPSHOT.316"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"


### PR DESCRIPTION
This PR adds new version of `SpinePublishing` project extension which was recently adopted in `tool-base`.

### Dependency changes
 * Local dependencies were bumped to latests versions.
 * Protobuf library version was revered from `4.30.2` to `3.25.7` so that we can migrate tools which depend on `GeneratedVersionV3` API.
 * The version of Protobuf Gradle Plugin was kept at `0.9.5` because latest `tool-base` provides backward compatibility support.
