### PR TITLE
Fix `kover` dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -93,7 +93,7 @@ val guavaVersion = "33.4.8-jre"
  * @see <a href="https://github.com/tbroyer/gradle-errorprone-plugin/releases">
  *     Error Prone Gradle Plugin Releases</a>
  */
-val errorPronePluginVersion = "4.1.0"
+val errorPronePluginVersion = "4.2.0"
 
 /**
  * The version of Protobuf Gradle Plugin.

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -105,7 +105,7 @@ fun Module.configureKotlin(javaVersion: JavaLanguageVersion) {
     // https://github.com/Kotlin/kotlinx-kover?tab=readme-ov-file#to-create-report-combining-coverage-info-from-different-gradle-projects
     // https://github.com/Kotlin/kotlinx-kover/blob/main/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
     rootProject.dependencies {
-        kover(this)
+        kover(this@configureKotlin)
     }
 
     kover {


### PR DESCRIPTION
This PR fixes the dependency passed in the `jvm-module` conventions plugin to `kover()`. 

Previously it was used just `this`, which in context of `rootProject.dependencies` was of the type `DependencyHandlerScope`. This resulted in the build failure in the project to which `config` was applied.

The correct `this` is `this@configureKotlin` which refers to the `Project` to which the `configureKotlin()` extension function is applied.

### Other notable changes
 * The version of ErrorProne Gradle Plugin was bumped to [`4.2.0`](https://github.com/tbroyer/gradle-errorprone-plugin/releases/tag/v4.2.0) because of the following reason:
 
     > This is [in preparation for Gradle 8.14](https://docs.gradle.org/8.14-rc-2/release-notes.html#configurations-are-initialized-lazily) which will no longer realize all configurations in the base plugin, allowing truly lazily-initialized configurations.