### PR TITLE
Bring updates from `base`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -26,6 +26,7 @@
 
 package io.spine.dependency.boms
 
+import io.spine.dependency.kotlinx.Coroutines
 import io.spine.dependency.lib.Kotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -67,35 +68,18 @@ class BomsPlugin : Plugin<Project>  {
 
     override fun apply(project: Project) = with(project) {
 
-        fun log(message: () -> String) {
-            val logger = project.logger
-            if (logger.isInfoEnabled) {
-                logger.info(message.invoke())
-            }
-        }
-
-        fun Configuration.applyBoms(boms: List<String>) {
-            boms.forEach { bom ->
-                withDependencies {
-                    val platform = project.dependencies.enforcedPlatform(bom)
-                    addLater(provider { platform })
-                    log { "Applied BOM: `$bom` to the configuration: `${this@applyBoms.name}`." }
-                }
-            }
-        }
-
         configurations.run {
             matching { isCompilationConfig(it.name) }.all {
-                applyBoms(Boms.core)
+                applyBoms(project, Boms.core)
             }
             matching { isKspConfig(it.name) }.all {
-                applyBoms(Boms.core)
+                applyBoms(project, Boms.core)
             }
             matching { it.name in productionConfigs }.all {
-                applyBoms(Boms.core)
+                applyBoms(project, Boms.core)
             }
             matching { isTestConfig(it.name) }.all {
-                applyBoms(Boms.core + Boms.testing)
+                applyBoms(project, Boms.core + Boms.testing)
             }
 
             fun Configuration.diagSuffix(): String =
@@ -111,38 +95,79 @@ class BomsPlugin : Plugin<Project>  {
                 }
             }
 
+            matching { it.isDetekt }
+                .configureEach {
+                    resolutionStrategy.eachDependency {
+                        if (requested.group == Kotlin.group) {
+                            val supportedVersion =
+                                io.gitlab.arturbosch.detekt.getSupportedKotlinVersion()
+                            useVersion(supportedVersion)
+                            because("Force Kotlin version in Detekt configurations.")
+                        }
+                    }
+                }
+
             all {
                 resolutionStrategy {
-                    // The versions for Kotlin are resoled above correctly.
-                    // But that does not guarantees that Gradle picks up a correct `variant`.
-                    Kotlin.StdLib.artefacts.forEach { artefact ->
+                    fun forceWithLoggign(artefact: String) {
                         force(artefact)
                         log { "Forced the version of `$artefact` in " + this@all.diagSuffix() }
                     }
-                }
+                    fun forceAll(artefacts: Iterable<String>) = artefacts.forEach { artefact ->
+                        forceWithLoggign(artefact)
+                    }
+
+                    // The versions for Kotlin are resoled above correctly.
+                    // But that does not guarantees that Gradle picks up a correct `variant`.
+                    if (!isDetekt) {
+                        forceAll(Kotlin.artefacts)
+                        forceAll(Kotlin.StdLib.artefacts)
+                        forceAll(Coroutines.artefacts)
+                    }                }
             }
         }
     }
 
-    private fun isCompilationConfig(name: String) =
-        name.contains("compile", ignoreCase = true) &&
-                // `comileProtoPath` or `compileTestProtoPath`.
-                !name.contains("ProtoPath", ignoreCase = true)
-
-    private fun isKspConfig(name: String) =
-        name.startsWith("ksp", ignoreCase = true)
-
-    private fun isTestConfig(name: String) =
-        name.startsWith("test", ignoreCase = true)
-
-    /**
-     * Tells if the configuration with the given [name] supports forcing
-     * versions via the BOM mechanism.
-     *
-     * Not all configurations supports forcing via BOM. E.g., the configurations created
-     * by Protobuf Gradle Plugin such as `compileProtoPath` or `extractIncludeProto` do
-     * not pick up versions of dependencies set via `enforcedPlatform(myBom)`.
-     */
-    private fun supportsBom(name: String) =
-        (isCompilationConfig(name) || isKspConfig(name) || isTestConfig(name))
 }
+
+private fun Configuration.applyBoms(project: Project, boms: List<String>) {
+    boms.forEach { bom ->
+        withDependencies {
+            val platform = project.dependencies.platform(bom)
+            addLater(project.provider { platform })
+            project.log { "Applied BOM: `$bom` to the configuration: `${this@applyBoms.name}`." }
+        }
+    }
+}
+
+private fun Project.log(message: () -> String) {
+    if (logger.isInfoEnabled) {
+        logger.info(message.invoke())
+    }
+}
+
+private fun isCompilationConfig(name: String) =
+    name.contains("compile", ignoreCase = true) &&
+            // `comileProtoPath` or `compileTestProtoPath`.
+            !name.contains("ProtoPath", ignoreCase = true)
+
+private fun isKspConfig(name: String) =
+    name.startsWith("ksp", ignoreCase = true)
+
+private fun isTestConfig(name: String) =
+    name.startsWith("test", ignoreCase = true)
+
+/**
+ * Tells if the configuration with the given [name] supports forcing
+ * versions via the BOM mechanism.
+ *
+ * Not all configurations supports forcing via BOM. E.g., the configurations created
+ * by Protobuf Gradle Plugin such as `compileProtoPath` or `extractIncludeProto` do
+ * not pick up versions of dependencies set via `enforcedPlatform(myBom)`.
+ */
+private fun supportsBom(name: String) =
+    (isCompilationConfig(name) || isKspConfig(name) || isTestConfig(name))
+
+private val Configuration.isDetekt: Boolean
+    get() = name.contains("detekt", ignoreCase = true)
+

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -121,7 +121,7 @@ class BomsPlugin : Plugin<Project>  {
                     // The versions for Kotlin are resolved above correctly.
                     // But that does not guarantee that Gradle picks up a correct `variant`.
                     if (!isDetekt) {
-                        forceAll(Kotlin.artefacts)
+                        forceAll(Kotlin.artifacts)
                         forceAll(Kotlin.StdLib.artifacts)
                         forceAll(Coroutines.artifacts)
                     }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -50,7 +50,7 @@ import org.gradle.api.artifacts.Configuration
  *
  *  In addition to forcing BOM-based dependencies,
  *  the plugin [forces][org.gradle.api.artifacts.ResolutionStrategy.force] the versions
- *  of [Kotlin.StdLib.artefacts] for all configurations because even through Kotlin
+ *  of [Kotlin.StdLib.artifacts] for all configurations because even through Kotlin
  *  artefacts are forced with BOM, the `variants` in the dependencies cannot be
  *  picked by Gradle.
  *
@@ -109,21 +109,23 @@ class BomsPlugin : Plugin<Project>  {
 
             all {
                 resolutionStrategy {
-                    fun forceWithLoggign(artefact: String) {
+                    fun forceWithLogging(artefact: String) {
                         force(artefact)
                         log { "Forced the version of `$artefact` in " + this@all.diagSuffix() }
                     }
+
                     fun forceAll(artefacts: Iterable<String>) = artefacts.forEach { artefact ->
-                        forceWithLoggign(artefact)
+                        forceWithLogging(artefact)
                     }
 
-                    // The versions for Kotlin are resoled above correctly.
-                    // But that does not guarantees that Gradle picks up a correct `variant`.
+                    // The versions for Kotlin are resolved above correctly.
+                    // But that does not guarantee that Gradle picks up a correct `variant`.
                     if (!isDetekt) {
                         forceAll(Kotlin.artefacts)
-                        forceAll(Kotlin.StdLib.artefacts)
-                        forceAll(Coroutines.artefacts)
-                    }                }
+                        forceAll(Kotlin.StdLib.artifacts)
+                        forceAll(Coroutines.artifacts)
+                    }
+                }
             }
         }
     }
@@ -161,7 +163,7 @@ private fun isTestConfig(name: String) =
  * Tells if the configuration with the given [name] supports forcing
  * versions via the BOM mechanism.
  *
- * Not all configurations supports forcing via BOM. E.g., the configurations created
+ * Not all configurations support forcing via BOM. E.g., the configurations created
  * by Protobuf Gradle Plugin such as `compileProtoPath` or `extractIncludeProto` do
  * not pick up versions of dependencies set via `enforcedPlatform(myBom)`.
  */
@@ -170,4 +172,3 @@ private fun supportsBom(name: String) =
 
 private val Configuration.isDetekt: Boolean
     get() = name.contains("detekt", ignoreCase = true)
-

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -109,13 +109,13 @@ class BomsPlugin : Plugin<Project>  {
 
             all {
                 resolutionStrategy {
-                    fun forceWithLogging(artefact: String) {
-                        force(artefact)
-                        log { "Forced the version of `$artefact` in " + this@all.diagSuffix() }
+                    fun forceWithLogging(artifact: String) {
+                        force(artifact)
+                        log { "Forced the version of `$artifact` in " + this@all.diagSuffix() }
                     }
 
-                    fun forceAll(artefacts: Iterable<String>) = artefacts.forEach { artefact ->
-                        forceWithLogging(artefact)
+                    fun forceAll(artifacts: Iterable<String>) = artifacts.forEach { artifact ->
+                        forceWithLogging(artifact)
                     }
 
                     // The versions for Kotlin are resolved above correctly.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -51,7 +51,7 @@ import org.gradle.api.artifacts.Configuration
  *  In addition to forcing BOM-based dependencies,
  *  the plugin [forces][org.gradle.api.artifacts.ResolutionStrategy.force] the versions
  *  of [Kotlin.StdLib.artifacts] for all configurations because even through Kotlin
- *  artefacts are forced with BOM, the `variants` in the dependencies cannot be
+ *  artifacts are forced with BOM, the `variants` in the dependencies cannot be
  *  picked by Gradle.
  *
  *  Run Gradle with the [INFO][org.gradle.api.logging.Logger.isInfoEnabled] logging level

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -150,7 +150,7 @@ private fun Project.log(message: () -> String) {
 
 private fun isCompilationConfig(name: String) =
     name.contains("compile", ignoreCase = true) &&
-            // `comileProtoPath` or `compileTestProtoPath`.
+            // `compileProtoPath` or `compileTestProtoPath`.
             !name.contains("ProtoPath", ignoreCase = true)
 
 private fun isKspConfig(name: String) =

--- a/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Coroutines.kt
@@ -28,7 +28,7 @@ package io.spine.dependency.kotlinx
 
 /**
  * Kotlin Coroutines.
- * 
+ *
  * @see <a href="https://github.com/Kotlin/kotlinx.coroutines">GitHub project</a>
  */
 @Suppress("unused", "ConstPropertyName")
@@ -40,8 +40,11 @@ object Coroutines {
 
     const val core = "$group:$infix-core"
     const val coreJvm = "$group:$infix-core-jvm"
+    const val jdk7 = "$group:$infix-jdk7"
     const val jdk8 = "$group:$infix-jdk8"
     const val debug = "$group:$infix-debug"
     const val test = "$group:$infix-test"
     const val testJvm = "$group:$infix-test-jvm"
+
+    val artefacts = listOf(core, coreJvm, jdk8, debug, test, testJvm).map { "$it:$version"}
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Coroutines.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/kotlinx/Coroutines.kt
@@ -46,5 +46,5 @@ object Coroutines {
     const val test = "$group:$infix-test"
     const val testJvm = "$group:$infix-test-jvm"
 
-    val artefacts = listOf(core, coreJvm, jdk8, debug, test, testJvm).map { "$it:$version"}
+    val artifacts = listOf(core, coreJvm, jdk8, debug, test, testJvm).map { "$it:$version"}
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -65,7 +65,7 @@ object Kotlin {
         const val jdk7 = "$group:$infix-jdk7"
         const val jdk8 = "$group:$infix-jdk8"
 
-        val artefacts = setOf(itself, common, jdk7, jdk8).map { "$it:$runtimeVersion" }
+        val artifacts = setOf(itself, common, jdk7, jdk8).map { "$it:$runtimeVersion" }
     }
 
     @Deprecated("Please use `StdLib.itself` instead.", ReplaceWith("StdLib.itself"))

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -81,9 +81,13 @@ object Kotlin {
     const val stdLibJdk8   = StdLib.jdk8
 
     const val toolingCore = "$group:kotlin-tooling-core"
-
     const val reflect    = "$group:kotlin-reflect"
     const val testJUnit5 = "$group:kotlin-test-junit5"
+
+    /**
+     * The artefacts that do not belong to [StdLib].
+     */
+    val artefacts = listOf(reflect, testJUnit5).map { "$it:$runtimeVersion" }
 
     @Deprecated(message = "Please use `GradlePlugin.api` instead.", ReplaceWith("GradlePlugin.api"))
     const val gradlePluginApi = "$group:kotlin-gradle-plugin-api"
@@ -94,7 +98,7 @@ object Kotlin {
     const val jetbrainsAnnotations = "org.jetbrains:annotations:$annotationsVersion"
 
     object Compiler {
-        const val embeddable = "$group:kotlin-compiler-embeddable:$runtimeVersion"
+        const val embeddable = "$group:kotlin-compiler-embeddable:$embeddedVersion"
     }
 
     object GradlePlugin {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -87,7 +87,7 @@ object Kotlin {
     /**
      * The artefacts that do not belong to [StdLib].
      */
-    val artefacts = listOf(reflect, testJUnit5).map { "$it:$runtimeVersion" }
+    val artifacts = listOf(reflect, testJUnit5).map { "$it:$runtimeVersion" }
 
     @Deprecated(message = "Please use `GradlePlugin.api` instead.", ReplaceWith("GradlePlugin.api"))
     const val gradlePluginApi = "$group:kotlin-gradle-plugin-api"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -85,7 +85,7 @@ object Kotlin {
     const val testJUnit5 = "$group:kotlin-test-junit5"
 
     /**
-     * The artefacts that do not belong to [StdLib].
+     * The artifacts that do not belong to [StdLib].
      */
     val artifacts = listOf(reflect, testJUnit5).map { "$it:$runtimeVersion" }
 


### PR DESCRIPTION
This PR brings latest updates to the `buildSrc` content that were [adopted in the Base subproject](https://github.com/SpineEventEngine/base/pull/876).