### PR TITLE
Bump KSP and Protobuf Gradle Plugin of the build

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -103,7 +103,7 @@ val errorPronePluginVersion = "4.2.0"
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.9.4"
+val protobufPluginVersion = "0.9.5"
 
 /**
  * The version of Dokka Gradle Plugins.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.build
  */
 @Suppress("ConstPropertyName", "unused")
 object Ksp {
-    const val version = "2.1.20-2.0.0"
+    const val version = "2.1.21-2.0.1"
     const val id = "com.google.devtools.ksp"
     const val group = "com.google.devtools.ksp"
     const val symbolProcessingApi = "$group:symbol-processing-api:$version"


### PR DESCRIPTION
This PR advances the version of KSP to be compatible with the latest version of Kotlin. 

Also the PR bumps the version of Protobuf Gradle Plugin used by the build via the `classpath` dependency of `buildSrc` to `0.9.5`.