### PR TITLE
Updates from ProtoData

### DIFF
--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -74,6 +74,12 @@ fun ScriptHandlerScope.standardSpineSdkRepositories() {
 }
 
 /**
+ * Shortcut to [Protobuf] dependency object for using under `buildScript`.
+ */
+val ScriptHandlerScope.protobuf: Protobuf
+    get() = Protobuf
+
+/**
  * Shortcut to [McJava] dependency object for using under `buildScript`.
  */
 val ScriptHandlerScope.mcJava: McJava

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -26,19 +26,31 @@
 
 package io.spine.dependency.build
 
+import io.spine.dependency.Dependency
+
 /**
  * Kotlin Symbol Processing API.
  *
  * @see <a href="https://github.com/google/ksp">KSP GitHub repository</a>
  */
-@Suppress("ConstPropertyName", "unused")
-object Ksp {
-    const val version = "2.1.21-2.0.1"
+@Suppress("unused")
+object Ksp : Dependency() {
+    override val version = "2.1.21-2.0.1"
+    override val group = "com.google.devtools.ksp"
+
     const val id = "com.google.devtools.ksp"
-    const val group = "com.google.devtools.ksp"
-    const val symbolProcessingApi = "$group:symbol-processing-api:$version"
-    const val symbolProcessing = "$group:symbol-processing:$version"
-    const val symbolProcessingAaEmb = "$group:symbol-processing-aa-embeddable:$version"
-    const val symbolProcessingCommonDeps = "$group:symbol-processing-common-deps:$version"
-    const val gradlePlugin = "$group:symbol-processing-gradle-plugin:$version"
+
+    val symbolProcessingApi = "$group:symbol-processing-api"
+    val symbolProcessing = "$group:symbol-processing"
+    val symbolProcessingAaEmb = "$group:symbol-processing-aa-embeddable"
+    val symbolProcessingCommonDeps = "$group:symbol-processing-common-deps"
+    val gradlePlugin = "$group:symbol-processing-gradle-plugin"
+
+    override val modules = listOf(
+        symbolProcessingApi,
+        symbolProcessing,
+        symbolProcessingAaEmb,
+        symbolProcessingCommonDeps,
+        gradlePlugin,
+    )
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.317"
+    const val version = "2.0.0-SNAPSHOT.320"
     const val versionForBuildScript = "2.0.0-SNAPSHOT.317"
     const val group = Spine.group
     const val artifact = "spine-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.313"
+    const val version = "2.0.0-SNAPSHOT.314"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -72,7 +72,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.95.0"
+    private const val fallbackVersion = "0.96.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -81,7 +81,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.95.0"
+    private const val fallbackDfVersion = "0.96.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Time {
-    const val version = "2.0.0-SNAPSHOT.202"
+    const val version = "2.0.0-SNAPSHOT.203"
     const val group = Spine.group
     const val artifact = "spine-time"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.321"
+    const val version = "2.0.0-SNAPSHOT.330"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.333"
+    const val version = "2.0.0-SNAPSHOT.335"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+org.gradle.parallel=true
+
 # Dokka plugin eats more memory than usual. Therefore, all builds should have enough.
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC
 


### PR DESCRIPTION
This PR brings changes in `buildSrc` recently adopted in ProtoData. Also, it adds the flag in `gradle.properties` turning on parallel build task execution.
