### PR TITLE
Improve Agent guidelines and ToolBase structure

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,165 @@
+# Spine Tool-Base Project Guidelines
+
+This document provides concise guidance for developers working on the Spine Tool-Base project
+with Junie AI assistance.
+
+## Project Overview
+
+Spine Tool-Base is a collection of modules that provide foundational code for development tools
+in the Spine SDK ecosystem. It primarily uses Kotlin with some Java components and is
+built with Gradle using Kotlin DSL for build configuration.
+
+## Tech Stack
+
+- **Languages**: Kotlin (primary), Java (secondary)
+- **Build System**: Gradle with Kotlin DSL
+- **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS)
+- **Testing**: JUnit 5, Kotest Assertions
+- **Code Quality**: detekt, ErrorProne, Checkstyle, PMD, Codecov
+- **Documentation**: Dokka
+- **Tools**: IntelliJ IDEA Platform, KSP, KotlinPoet
+
+## Project Structure
+
+```
+.
+├── `buildSrc`/                  # Build configuration and dependencies
+├── `config`/                    # Project configuration files
+├── `gradle-plugin-api`/         # API for tool/library authors
+├── `gradle-root-plugin`/        # Gradle plugins with root extensions
+├── `jvm-util`/                  # Utilities for JVM project tools
+├── `plugin-base`/               # Abstractions for Gradle plugins
+├── `plugin-testlib`/            # Test fixtures for Gradle plugins
+├── `psi`/                       # Utilities for IntelliJ Platform PSI
+├── `tool-base`/                 # Common components for build-time tools
+├── `build.gradle.kts`           # Root build configuration
+├── `settings.gradle.kts`        # Project structure and settings
+├── `version.gradle.kts`         # Project version declaration
+└── `README.md`                  # Project overview
+```
+
+Each module follows a standard structure:
+```
+`module-name`/
+├── `src`/
+│   ├── `main`/
+│   │   ├── `kotlin`/           # Kotlin source files
+│   │   └── `java`/             # Java source files (if any)
+│   └── `test`/
+│       └── `kotlin`/           # Test files
+└── `build.gradle.kts`          # Module-specific build configuration
+```
+
+## Running Tests
+
+- **Run all tests**:
+  ```bash
+  ./gradlew test
+  ```
+
+- **Run tests for a specific module**:
+  ```bash
+  ./gradlew :`module-name`:test
+  ```
+
+- **Run a specific test class**:
+  ```bash
+  ./gradlew :`module-name`:test --tests "fully.qualified.TestClassName"
+  ```
+
+## Building the Project
+
+- **Regular build**:
+  ```bash
+  ./gradlew build
+  ```
+
+- **Clean build (required after Protobuf changes)**:
+  ```bash
+  ./gradlew clean build
+  ```
+
+- **Documentation only**:
+  ```bash
+  ./gradlew dokka
+  ```
+
+## Version Management
+
+- Version follows semantic versioning (semver) and is stored in `version.gradle.kts`
+- Increment the patch version for each PR (e.g., `2.0.0-SNAPSHOT.009` → `2.0.0-SNAPSHOT.010`)
+- After version changes, run `./gradlew clean build` and commit updated `pom.xml` and
+  `dependencies.md`
+
+## Naming Guidelines
+
+### Avoid using type names in variable names 
+| DO                                 | DON'T                                        |
+|------------------------------------|----------------------------------------------|
+| `val user = getUser()`             | `val userObject = getUser()`                 |
+| `val items = getItems()`           | `val itemList = getItems()`                  | 
+| `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
+
+## Coding Best Practices
+
+- Prefer Kotlin idioms over Java-style approaches.
+- Use immutable data structures.
+- Apply Java interop only when needed.
+- Use Kotlin DSL for Gradle files.
+- Write clear, incremental commits with descriptive messages.
+- Include automated tests for functionality changes.
+- Keep pull requests focused and small.
+
+### Avoid duplication of strings in the code
+- Use constants in companion objects instead.
+- If a string contains Kotlin interpolation, it should be a property instead.
+
+### Prefer generic parameters over explicit variable types
+| DO                                      | DON'T                                               |
+|-----------------------------------------|-----------------------------------------------------|
+| `val list = mutableList<Deppendency>()` | `val list: MutableList<Dependency> = mutableList()` |
+
+## Code Formatting Guidelines
+- Start parameter descriptions with a capital letter.
+- In-line code fragments are always surrounded with back ticks. E.g., `code`.
+- File and directory names are code and should be formatted as such.
+- Block code fragments in documentation and diagnostic messages must be surrounded
+  with code fences (```).
+- Code fences that are part of the code come with extra backtick:
+  ```text
+     Here's how you put the nested code fences:
+     ````kotlin
+     // Nested code example.
+     ````
+  ```
+- Descriptions of parameters, properties, and exceptions in KDoc must be terminated with a comma.
+- When creating `.md` files wrap the text so that it is not wider than 80 characters.
+- Put periods at the end of sentences.
+- Do not put periods if a line of text is a fragment.
+- Avoid in-place comments in the code unless specifically asked.
+
+## Testing Guidelines
+
+- Use stubs instead of mocks for test doubles.
+- Prefer Kotest assertions over JUnit or Google Truth.
+- Ensure tests cover edge cases and typical scenarios.
+- When writing tests, avoid comments that explain the code. Prefer self-explanatory code.
+
+## Junie Assistance Tips
+
+When working with Junie AI on the Spine Tool-Base project:
+
+1. **Project Navigation**: Use `search_project` to find relevant files and code segments.
+2. **Code Understanding**: Request file structure with `get_file_structure` before editing.
+3. **Code Editing**: Make minimal changes with `search_replace` to maintain project consistency.
+4. **Testing**: Verify changes with `run_test` on relevant test files.
+5. **Documentation**: Follow KDoc style for documentation.
+6. **Kotlin Idioms**: Prefer Kotlin-style solutions over Java-style approaches.
+7. **Version Updates**: Remember to update `version.gradle.kts` for PRs.
+
+## Common Tasks
+
+- **Adding a new dependency**: Update relevant files in `buildSrc` directory.
+- **Creating a new module**: Follow existing module structure patterns.
+- **Documentation**: Use KDoc style for public and internal APIs.
+- **Testing**: Create comprehensive tests using Kotest assertions.

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,4 +1,4 @@
-## General Guidelines for Jnunie and AI Assistant
+## Guidelines for Junie and AI Agent from JetBrains
 
 Read the `AGENTS.md` file at the root of the project to understand:
  - the agent responsibilities,
@@ -6,44 +6,7 @@ Read the `AGENTS.md` file at the root of the project to understand:
  - coding guidelines, 
  - other relevant topics.
 
-Also follow the rules described below.
-
-## Naming Guidelines
-
-### Avoid using type names in variable names 
-| DO                                 | DON'T                                        |
-|------------------------------------|----------------------------------------------|
-| `val user = getUser()`             | `val userObject = getUser()`                 |
-| `val items = getItems()`           | `val itemList = getItems()`                  | 
-| `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
-
-### Avoid duplication of strings in the code
-- Use constants in companion objects instead.
-- If a string contains Kotlin interpolation, it should be a property instead.
-
-### Prefer generic parameters over explicit variable types
-| DO                                      | DON'T                                               |
-|-----------------------------------------|-----------------------------------------------------|
-| `val list = mutableList<Deppendency>()` | `val list: MutableList<Dependency> = mutableList()` |
-
-## Code Formatting Guidelines
-- Start parameter descriptions with a capital letter.
-- In-line code fragments are always surrounded with back ticks. E.g., `code`.
-- File and directory names are code and should be formatted as such.
-- Block code fragments in documentation and diagnostic messages must be surrounded
-  with code fences (```).
-- Code fences that are part of the code come with extra backtick:
-  ```text
-     Here's how you put the nested code fences:
-     ````kotlin
-     // Nested code example.
-     ````
-  ```
-- Descriptions of parameters, properties, and exceptions in KDoc must be terminated with a comma.
-- When creating `.md` files wrap the text so that it is not wider than 80 characters.
-- Put periods at the end of sentences.
-- Do not put periods if a line of text is a fragment.
-- Avoid in-place comments in the code unless specifically asked.
+Also follow the Junie-specific rules described below.
 
 ## Junie Assistance Tips
 
@@ -56,10 +19,3 @@ When working with Junie AI on the Spine Tool-Base project:
 5. **Documentation**: Follow KDoc style for documentation.
 6. **Kotlin Idioms**: Prefer Kotlin-style solutions over Java-style approaches.
 7. **Version Updates**: Remember to update `version.gradle.kts` for PRs.
-
-## Common Tasks
-
-- **Adding a new dependency**: Update relevant files in `buildSrc` directory.
-- **Creating a new module**: Follow existing module structure patterns.
-- **Documentation**: Use KDoc style for public and internal APIs.
-- **Testing**: Create comprehensive tests using Kotest assertions.

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,95 +1,12 @@
-# Spine Tool-Base Project Guidelines
+## General Guidelines for Jnunie and AI Assistant
 
-This document provides concise guidance for developers working on the Spine Tool-Base project
-with Junie AI assistance.
+Read the `AGENTS.md` file at the root of the project to understand:
+ - the agent responsibilities,
+ - project overview, 
+ - coding guidelines, 
+ - other relevant topics.
 
-## Project Overview
-
-Spine Tool-Base is a collection of modules that provide foundational code for development tools
-in the Spine SDK ecosystem. It primarily uses Kotlin with some Java components and is
-built with Gradle using Kotlin DSL for build configuration.
-
-## Tech Stack
-
-- **Languages**: Kotlin (primary), Java (secondary)
-- **Build System**: Gradle with Kotlin DSL
-- **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS)
-- **Testing**: JUnit 5, Kotest Assertions
-- **Code Quality**: detekt, ErrorProne, Checkstyle, PMD, Codecov
-- **Documentation**: Dokka
-- **Tools**: IntelliJ IDEA Platform, KSP, KotlinPoet
-
-## Project Structure
-
-```
-.
-├── `buildSrc`/                  # Build configuration and dependencies
-├── `config`/                    # Project configuration files
-├── `gradle-plugin-api`/         # API for tool/library authors
-├── `gradle-root-plugin`/        # Gradle plugins with root extensions
-├── `jvm-util`/                  # Utilities for JVM project tools
-├── `plugin-base`/               # Abstractions for Gradle plugins
-├── `plugin-testlib`/            # Test fixtures for Gradle plugins
-├── `psi`/                       # Utilities for IntelliJ Platform PSI
-├── `tool-base`/                 # Common components for build-time tools
-├── `build.gradle.kts`           # Root build configuration
-├── `settings.gradle.kts`        # Project structure and settings
-├── `version.gradle.kts`         # Project version declaration
-└── `README.md`                  # Project overview
-```
-
-Each module follows a standard structure:
-```
-`module-name`/
-├── `src`/
-│   ├── `main`/
-│   │   ├── `kotlin`/           # Kotlin source files
-│   │   └── `java`/             # Java source files (if any)
-│   └── `test`/
-│       └── `kotlin`/           # Test files
-└── `build.gradle.kts`          # Module-specific build configuration
-```
-
-## Running Tests
-
-- **Run all tests**:
-  ```bash
-  ./gradlew test
-  ```
-
-- **Run tests for a specific module**:
-  ```bash
-  ./gradlew :`module-name`:test
-  ```
-
-- **Run a specific test class**:
-  ```bash
-  ./gradlew :`module-name`:test --tests "fully.qualified.TestClassName"
-  ```
-
-## Building the Project
-
-- **Regular build**:
-  ```bash
-  ./gradlew build
-  ```
-
-- **Clean build (required after Protobuf changes)**:
-  ```bash
-  ./gradlew clean build
-  ```
-
-- **Documentation only**:
-  ```bash
-  ./gradlew dokka
-  ```
-
-## Version Management
-
-- Version follows semantic versioning (semver) and is stored in `version.gradle.kts`
-- Increment the patch version for each PR (e.g., `2.0.0-SNAPSHOT.009` → `2.0.0-SNAPSHOT.010`)
-- After version changes, run `./gradlew clean build` and commit updated `pom.xml` and
-  `dependencies.md`
+Also follow the rules described below.
 
 ## Naming Guidelines
 
@@ -99,16 +16,6 @@ Each module follows a standard structure:
 | `val user = getUser()`             | `val userObject = getUser()`                 |
 | `val items = getItems()`           | `val itemList = getItems()`                  | 
 | `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
-
-## Coding Best Practices
-
-- Prefer Kotlin idioms over Java-style approaches.
-- Use immutable data structures.
-- Apply Java interop only when needed.
-- Use Kotlin DSL for Gradle files.
-- Write clear, incremental commits with descriptive messages.
-- Include automated tests for functionality changes.
-- Keep pull requests focused and small.
 
 ### Avoid duplication of strings in the code
 - Use constants in companion objects instead.
@@ -137,13 +44,6 @@ Each module follows a standard structure:
 - Put periods at the end of sentences.
 - Do not put periods if a line of text is a fragment.
 - Avoid in-place comments in the code unless specifically asked.
-
-## Testing Guidelines
-
-- Use stubs instead of mocks for test doubles.
-- Prefer Kotest assertions over JUnit or Google Truth.
-- Ensure tests cover edge cases and typical scenarios.
-- When writing tests, avoid comments that explain the code. Prefer self-explanatory code.
 
 ## Junie Assistance Tips
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,9 @@ Tagging PRs helps the team:
 ---
 ## Version policy
 
+<details>
+<summary>Click to expand versioning guidelines</summary>
+
 ### We use semver
 The version of the project is kept in the `version.gradle.kts` file in the root of the project.
 
@@ -169,9 +172,14 @@ A branch conflict over the version number should be resolved as described below.
    the current branch stays.
  * If the merged branch has the number which is greater or equal to that of the current branch,
    the number should be increased by one.
+
+</details>
 ---
 
 ## Running builds
+
+<details>
+<summary>Click to expand build instructions</summary>
 
 1. When modifying code, run:
    ```bash
@@ -188,6 +196,8 @@ A branch conflict over the version number should be resolved as described below.
    ./gradlew dokka
    ```
    Documentation-only changes do not require running tests!
+
+</details>
 ---
 
 ## 📁 Project structure expectations
@@ -220,6 +230,9 @@ version.gradle.kts # Declares the project version.
 
 ## 📄 Documentation tasks
 
+<details>
+<summary>Click to expand documentation guidelines</summary>
+
 - Suggest better **names** and **abstractions**.
 
 #### Documentation Checklist
@@ -227,6 +240,8 @@ version.gradle.kts # Declares the project version.
 2. Add in-line code blocks for clarity.
 3. Use `TODO` comments with agent names for unresolved logic sections:
     - Example: `// TODO(chatgpt): Refactor `EventStore` for better CQRS compliance.`
+
+</details>
 
 ---
 
@@ -259,11 +274,20 @@ version.gradle.kts # Declares the project version.
 ---
 
 ## ⚙️ Refactoring Guidelines
+
+<details>
+<summary>Click to expand refactoring guidelines</summary>
+
 - Do not replace Kotest assertions with standard Kotlin's Built-In Test Assertions.
+
+</details>
 
 ---
 
 ## 💬 Interaction tips – key to effective collaboration!
+
+<details>
+<summary>Click to expand collaboration guidelines</summary>
 
 - Human programmers may use inline comments to guide agents:
   ```kotlin
@@ -282,6 +306,8 @@ version.gradle.kts # Declares the project version.
 - When agents or humans add TODO comments, they **must** follow the format described on
   the [dedicated page][todo-comments].
 
+</details>
+
 ---
 
 ## 🧭 LLM Goals
@@ -296,10 +322,15 @@ These goals guide how agents (ChatGPT, Codex) are used in this project to:
 
 ## 📋 Common Tasks
 
+<details>
+<summary>Click to expand common task instructions</summary>
+
 - **Adding a new dependency**: Update relevant files in `buildSrc` directory.
 - **Creating a new module**: Follow existing module structure patterns.
 - **Documentation**: Use KDoc style for public and internal APIs.
 - **Testing**: Create comprehensive tests using Kotest assertions.
+
+</details>
 
 --- 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,22 @@
-## Table of Contents
+
+## 📝 Quick Reference Card
+
+```
+🔑 Key Information:
+- Kotlin/Java project with CQRS architecture
+- Use ChatGPT for documentation, Codex for code generation, GPT-4o for complex analysis
+- Follow coding guidelines in Spine Event Engine docs
+- Always include tests with code changes
+- Version bump required for all PRs
+```
+
 ## Table of Contents
 1. [Purpose](#-purpose)
 2. [Project overview](#-project-overview)
 3. [Agent responsibilities](#-agent-responsibilities)
+   - [Agent Collaboration Workflow](#agent-collaboration-workflow)
+   - [Tagging pull request messages](#tagging-pull-request-messages)
+   - [Selecting the Right Agent](#selecting-the-right-agent)
 4. [Coding guidelines for Agents](#-coding-guidelines-for-agents)
 5. [Running builds](#running-builds)
 6. [Version policy](#version-policy)
@@ -10,9 +24,13 @@
 8. [Documentation tasks](#-documentation-tasks)
 9. [Testing](#-testing)
 10. [Safety rules for Agents](#-safety-rules-for-agents)
-11. [Interaction tips – key to effective collaboration!](#-interaction-tips--key-to-effective-collaboration)
-12. [LLM Goals](#-llm-goals)
-13. [Welcome, Agents!](#-welcome-agents)
+11. [Refactoring Guidelines](#️-refactoring-guidelines)
+12. [Interaction tips – key to effective collaboration!](#-interaction-tips--key-to-effective-collaboration)
+13. [LLM Goals](#-llm-goals)
+    - [Problem-Solving Framework](#problem-solving-framework-for-complex-tasks)
+    - [GPT-4o Advanced Capabilities](#-gpt-4o-advanced-capabilities)
+14. [Common Tasks](#-common-tasks)
+15. [Welcome, Agents!](#-welcome-agents)
 
 ## 🧠 Purpose
 
@@ -381,6 +399,40 @@ When faced with complex tasks, follow this framework:
 
 *This framework helps maintain consistency across contributions from different agents.*
 
+### 🚀 GPT-4o Advanced Capabilities
+
+GPT-4o excels at these high-value tasks in our CQRS architecture:
+
+1. **Architecture-Level Insights**
+   - Suggesting architectural improvements in CQRS pattern implementation
+   - Identifying cross-cutting concerns between command and query sides
+   - Optimizing event flow and state propagation
+
+2. **Advanced Kotlin Refactoring**
+   - Converting imperative code to idiomatic Kotlin (sequences, extensions, etc.)
+   - Applying context receivers and other Kotlin 1.6+ features
+   - Optimizing coroutine patterns and structured concurrency
+
+3. **Testing Intelligence**
+   - Identifying missing property-based test scenarios
+   - Suggesting event sequence combinations that could cause race conditions
+   - Creating comprehensive test fixtures for complex domain objects
+
+#### Example Prompts for GPT-4o
+
+Leverage GPT-4o's advanced capabilities with prompts like these:
+
+```text
+# Architecture Analysis
+"Analyze this CommandHandler implementation and suggest improvements to better align with CQRS principles, especially considering event sourcing implications."
+
+# Kotlin Refactoring
+"Refactor this Java-style code to use more idiomatic Kotlin patterns. Pay special attention to immutability, extension functions, and DSL opportunities."
+
+# Test Enhancement 
+"Review this test suite for our event processing pipeline and suggest additional test scenarios focusing on concurrent event handling edge cases."
+```
+
 ---
 
 ## 📋 Common Tasks
@@ -401,31 +453,6 @@ When faced with complex tasks, follow this framework:
  - You are here to help.
  - Stay consistent, stay clear, and help this Kotlin/Java codebase become more robust,
    elegant, and maintainable.
-
- ## 🌟 Real-World Examples
-
- <details>
- <summary>Click to see examples of excellent agent contributions</summary>
-
- ### Documentation Example (ChatGPT)
-
- Problem: Explain our event sourcing implementation.
-
- Solution: Added clear documentation with visual diagrams explaining event flow, persistence, and projection rebuilding.
-
- ### Code Completion Example (Codex)
-
- Problem: Complete missing command handlers for user management.
-
- Solution: Generated idiomatic Kotlin implementations with proper error handling and validation.
-
- ### Architecture Analysis Example (GPT-4o)
-
- Problem: Optimize query side performance.
-
- Solution: Analyzed bottlenecks and implemented view model caching with invalidation based on event types.
-
- </details>
 
 <!-- External links -->
 [spine-docs]: https://github.com/SpineEventEngine/documentation/wiki

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,43 @@ Tagging PRs helps the team:
 ### Naming convention for variables
 - Prefer simple nouns over composite nouns. E.g., `user` is better than `userAccount`.
 
+### Naming Guidelines
+
+#### Avoid using type names in variable names 
+| DO                                 | DON'T                                        |
+|------------------------------------|----------------------------------------------|
+| `val user = getUser()`             | `val userObject = getUser()`                 |
+| `val items = getItems()`           | `val itemList = getItems()`                  | 
+| `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
+
+#### Avoid duplication of strings in the code
+- Use constants in companion objects instead.
+- If a string contains Kotlin interpolation, it should be a property instead.
+
+#### Prefer generic parameters over explicit variable types
+| DO                                      | DON'T                                               |
+|-----------------------------------------|-----------------------------------------------------|
+| `val list = mutableList<Deppendency>()` | `val list: MutableList<Dependency> = mutableList()` |
+
+### Code Formatting Guidelines
+- Start parameter descriptions with a capital letter.
+- In-line code fragments are always surrounded with back ticks. E.g., `code`.
+- File and directory names are code and should be formatted as such.
+- Block code fragments in documentation and diagnostic messages must be surrounded
+  with code fences (```).
+- Code fences that are part of the code come with extra backtick:
+  ```text
+     Here's how you put the nested code fences:
+     ````kotlin
+     // Nested code example.
+     ````
+  ```
+- Descriptions of parameters, properties, and exceptions in KDoc must be terminated with a comma.
+- When creating `.md` files wrap the text so that it is not wider than 80 characters.
+- Put periods at the end of sentences.
+- Do not put periods if a line of text is a fragment.
+- Avoid in-place comments in the code unless specifically asked.
+
 ### Safety Rules Checklist
 - ✅ Ensure all generated code compiles and passes static analysis.
 - ❌ Avoid unnecessary reflection or unsafe code (e.g., `!!` in Kotlin).
@@ -249,7 +286,7 @@ version.gradle.kts # Declares the project version.
 - Avoid generating blocking calls inside coroutines.
 
 ---
-   
+
 ## ⚙️ Refactoring Guidelines
 - Do not replace Kotest assertions with standard Kotlin's Built-In Test Assertions.
 
@@ -283,6 +320,16 @@ These goals guide how agents (ChatGPT, Codex) are used in this project to:
 - Provide language-aware guidance on Kotlin/Java idioms.
 - Lower the barrier to onboarding new contributors.
 - Enable collaborative, explainable, and auditable development with AI.
+
+---
+
+## 📋 Common Tasks
+
+- **Adding a new dependency**: Update relevant files in `buildSrc` directory.
+- **Creating a new module**: Follow existing module structure patterns.
+- **Documentation**: Use KDoc style for public and internal APIs.
+- **Testing**: Create comprehensive tests using Kotest assertions.
+
 --- 
 
 ## 👋 Welcome, Agents!

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,150 +74,70 @@ Tagging PRs helps the team:
 
 ## 🧾 Coding guidelines for Agents
 
-### General Guidelines
+### Core Principles
+
 - Adhere to [Spine Event Engine Documentation][spine-docs] for coding style.
+- Generate code that compiles cleanly and passes static analysis.
+- Respect existing architecture, naming conventions, and project structure.
 - Write clear, incremental commits with descriptive messages.
 - Include automated tests for any code change that alters functionality.
-- Avoid in-place comments in code unless specifically requested.
 
-### Naming Conventions
+### Kotlin Best Practices
 
 #### ✅ Prefer
-- **Simple nouns** over composite nouns (`user` > `userAccount`).
-- **Generic parameters** over explicit variable types:
-
-| DO                                      | DON'T                                               |
-|-----------------------------------------|-----------------------------------------------------|
-| `val list = mutableList<Dependency>()`  | `val list: MutableList<Dependency> = mutableList()` |
+- **Kotlin idioms** over Java-style approaches:
+  - Extension functions
+  - `when` expressions 
+  - Smart casts
+  - Data classes and sealed classes
+  - Immutable data structures
+- **Simple nouns** over composite nouns (`user` > `userAccount`)  
+- **Generic parameters** over explicit variable types (`val list = mutableList<Dependency>()`)  
+- **Java interop annotations** only when needed (`@file:JvmName`, `@JvmStatic`)
+- **Kotlin DSL** for Gradle files
 
 #### ❌ Avoid
-- **String duplication**: Use constants in companion objects,
-  or properties for interpolated strings where appropriate.
+- Mutable data structures
+- Java-style verbosity (builders with setters)
+- Redundant null checks (`?.let` misuse)
+- Using `!!` unless clearly justified
+- Type names in variable names (`userObject`, `itemList`)
+- String duplication (use constants in companion objects)
+- Mixing Groovy and Kotlin DSLs in build logic
+- Reflection unless specifically requested
 
- - Using **type names** in variable names:
+### Documentation & Comments
 
-  | DO                                 | DON'T                                        |
-  |------------------------------------|----------------------------------------------|
-  | `val user = getUser()`             | `val userObject = getUser()`                 |
-  | `val items = getItems()`           | `val itemList = getItems()`                  | 
-  | `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
-
-
-### KDoc and Commenting
-- Write concise and clear KDoc descriptions for all public and internal APIs.
-- Use the following style for parameter descriptions:
-  - Begin descriptions with uppercase letters.
-  - Terminate them with commas.
-- Format blocks of code in documentation with fences:
+#### KDoc Style
+- Write concise descriptions for all public and internal APIs
+- Start parameter descriptions with capital letters
+- End parameter descriptions with commas
+- Use inline code with backticks for code references (`example`)
+- Format code blocks with fences and language identifiers:
   ```kotlin
-  // Example:
-  override fun toString(): String {
-      return "Example"
+  // Example code
+  fun example() {
+      // Implementation
   }
   ```
 
-- Avoid inline comments in the production code unless necessary.
-- Inline comments are helpful in tests.
-
-#### Formatting
-- Wrap `.md` text to **80 characters** for readability.
-- Use proper punctuation:
-  - Periods at the end of full sentences.
-  - No periods for text fragments or bullet points.
-- Inline code fragments must always be encapsulated with backticks (`example`).
-
-### ✅ Preferred
-
-1. Kotlin idioms are **preferred** over Java-style approaches, including:
-   - Extension functions
-   - `when` expressions
-   - Smart casts
-   - Data classes
-   - Sealed classes
-
-2. Immutable data structures. 
-
-3. Apply **Java interop** only when needed (e.g., using annotations or legacy libraries).
-
-4. Use **Kotlin DSL** when modifying or generating Gradle files.
-
-5. Generate code that **compiles cleanly** and **passes static analysis**.
-
-6. Respect **existing architecture**, naming conventions, and project structure.
-
-7. Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
-
-### ❌ Avoid
-
-- Mutable data structures
-- Java-style verbosity (e.g., builders with setters)
-- Redundant null checks (`?.let` misuse)
-- Using `!!` unless clearly justified
-- Mixing Groovy and Kotlin DSLs in build logic
-- Using reflection unless requested
-
-### General guidance
-- Adhere to the [Spine Event Engine Documentation][spine-docs]
-  for coding style and contribution procedures. 
-
-- The conventions on the [Spine Event Engine Documentation][spine-docs]
-  page and other pages in this Wiki area **take precedence over** standard Kotlin or
-  Java conventions.
-
-- Write clear, incremental commits with descriptive messages.
-- Include automated tests for any code change that alters functionality.
-- Keep pull requests focused and small.
-
-### Naming convention for variables
-- Prefer simple nouns over composite nouns. E.g., `user` is better than `userAccount`.
-
-### Naming Guidelines
-
-#### Avoid using type names in variable names
-
-| DO                                 | DON'T                                        |
-|------------------------------------|----------------------------------------------|
-| `val user = getUser()`             | `val userObject = getUser()`                 |
-| `val items = getItems()`           | `val itemList = getItems()`                  | 
-| `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
-
-#### Avoid duplication of strings in the code
-- Use constants in companion objects instead.
-- If a string contains Kotlin interpolation, it should be a property instead.
-
-#### Prefer generic parameters over explicit variable types
-
-| DO                                      | DON'T                                               |
-|-----------------------------------------|-----------------------------------------------------|
-| `val list = mutableList<Deppendency>()` | `val list: MutableList<Dependency> = mutableList()` |
-
-### Code Formatting Guidelines
-- Start parameter descriptions with a capital letter.
-- In-line code fragments are always surrounded with back ticks. E.g., `code`.
-- File and directory names are code and should be formatted as such.
-- Block code fragments in documentation and diagnostic messages must be surrounded
-  with code fences (```).
-- Code fences that are part of the code come with extra backtick:
-  ```text
-     Here's how you put the nested code fences:
-     ````kotlin
-     // Nested code example.
-     ````
-  ```
-- Descriptions of parameters, properties, and exceptions in KDoc must be terminated with a comma.
-- When creating `.md` files wrap the text so that it is not wider than 80 characters.
-
-#### Using periods in the texts
-- Put periods at the end of sentences.
-- Do not put periods if a line of text is a fragment.
-
 #### Commenting Guidelines
-- Avoid in-place comments in the code unless specifically asked.
+- Avoid inline comments in production code unless necessary
+- Inline comments are helpful in tests
+- When using TODO comments, follow the format on [dedicated page][todo-comments]
+- File and directory names should be formatted as code
 
-### Safety Rules Checklist
-- ✅ Ensure all generated code compiles and passes static analysis.
-- ❌ Avoid unnecessary reflection or unsafe code (e.g., `!!` in Kotlin).
-- ✅ Do not auto-update external dependencies unless explicitly allowed.
+#### Text Formatting
+- Wrap `.md` text to 80 characters for readability
+- Use periods at the end of complete sentences only
+- No periods for bullet points or fragments
+
+### Safety Rules
+- ✅ All code must compile and pass static analysis
+- ❌ Never use reflection or unsafe code without explicit approval
+- ✅ Do not auto-update external dependencies
+- ❌ No analytics or telemetry code
+- ❌ No blocking calls inside coroutines
 
 ---
 ## Version policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,31 +74,36 @@ Tagging PRs helps the team:
 
 ## 🧾 Coding guidelines for Agents
 
-### General coding and formatting guidelines
-
-#### General Guidelines
+### General Guidelines
 - Adhere to [Spine Event Engine Documentation][spine-docs] for coding style.
 - Write clear, incremental commits with descriptive messages.
 - Include automated tests for any code change that alters functionality.
 - Avoid in-place comments in code unless specifically requested.
 
-#### Naming Conventions
-- Prefer **simple nouns** over composite nouns (`user` > `userAccount`).
-- Avoid using **type names** in variable names:
+### Naming Conventions
+
+#### ✅ Prefer
+- **Simple nouns** over composite nouns (`user` > `userAccount`).
+- **Generic parameters** over explicit variable types:
+
+| DO                                      | DON'T                                               |
+|-----------------------------------------|-----------------------------------------------------|
+| `val list = mutableList<Dependency>()`  | `val list: MutableList<Dependency> = mutableList()` |
+
+#### ❌ Avoid
+- **String duplication**: Use constants in companion objects,
+  or properties for interpolated strings where appropriate.
+
+ - Using **type names** in variable names:
+
   | DO                                 | DON'T                                        |
   |------------------------------------|----------------------------------------------|
   | `val user = getUser()`             | `val userObject = getUser()`                 |
   | `val items = getItems()`           | `val itemList = getItems()`                  | 
   | `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
 
-- Avoid **string duplication**: Use constants in companion objects,
-  or properties for interpolated strings where appropriate.
-- Prefer **generic parameters** over explicit variable types:
-  | DO                                      | DON'T                                               |
-  |-----------------------------------------|-----------------------------------------------------|
-  | `val list = mutableList<Dependency>()`  | `val list: MutableList<Dependency> = mutableList()` |
 
-#### KDoc and Commenting
+### KDoc and Commenting
 - Write concise and clear KDoc descriptions for all public and internal APIs.
 - Use the following style for parameter descriptions:
   - Begin descriptions with uppercase letters.
@@ -111,7 +116,8 @@ Tagging PRs helps the team:
   }
   ```
 
-- Avoid inline comments unless necessary.
+- Avoid inline comments in the production code unless necessary.
+- Inline comments are helpful in tests.
 
 #### Formatting
 - Wrap `.md` text to **80 characters** for readability.
@@ -167,7 +173,8 @@ Tagging PRs helps the team:
 
 ### Naming Guidelines
 
-#### Avoid using type names in variable names 
+#### Avoid using type names in variable names
+
 | DO                                 | DON'T                                        |
 |------------------------------------|----------------------------------------------|
 | `val user = getUser()`             | `val userObject = getUser()`                 |
@@ -179,6 +186,7 @@ Tagging PRs helps the team:
 - If a string contains Kotlin interpolation, it should be a property instead.
 
 #### Prefer generic parameters over explicit variable types
+
 | DO                                      | DON'T                                               |
 |-----------------------------------------|-----------------------------------------------------|
 | `val list = mutableList<Deppendency>()` | `val list: MutableList<Dependency> = mutableList()` |
@@ -203,7 +211,7 @@ Tagging PRs helps the team:
 - Put periods at the end of sentences.
 - Do not put periods if a line of text is a fragment.
 
-#### Commenting Guildeines
+#### Commenting Guidelines
 - Avoid in-place comments in the code unless specifically asked.
 
 ### Safety Rules Checklist
@@ -264,6 +272,9 @@ A branch conflict over the version number should be resolved as described below.
 
 ## 📁 Project structure expectations
 
+<details>
+<summary>Click to expand project structure details</summary>
+
 ```yaml
 .github
 buildSrc/
@@ -283,13 +294,13 @@ README.md # Project overview
 AGENTS.md # LLM agent instructions (this file)
 version.gradle.kts # Declares the project version. 
 ```
+
+</details>
 ---
 
 ## 📄 Documentation tasks
 
 - Suggest better **names** and **abstractions**.
-
-- Help format inline comments and design rationale.
 
 #### Documentation Checklist
 1. Ensure all public and internal APIs have KDoc examples.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@
 
 ## 🧠 Purpose
 
+> **EXECUTIVE SUMMARY**: This guide outlines how AI agents (ChatGPT, Codex, GPT-4o)
+> collaborate on our Kotlin/Java CQRS project. It defines responsibilities, coding standards,
+> and workflows to maintain high code quality and architectural integrity.
+
 This document explains how to use **ChatGPT** and **Codex** effectively in this Kotlin/Java project.
 
 It outlines:
@@ -48,14 +52,32 @@ with AI to maintain a high-quality codebase.
 
 ## 🤖 Agent responsibilities
 
-| Task/Feature                      | Primary Agent | Supporting Agent | Notes                                      |
-|-----------------------------------|---------------|------------------|--------------------------------------------|
-| Writing documentation (like KDoc) | ChatGPT       | Codex            | Use for readable, structured docs.         |
-| Explaining APIs and architecture  | ChatGPT       | -                | Great for clarity in team workflows.       |
-| Code generation (e.g., tests)     | Codex         | ChatGPT          | Codex produces quick scaffolding.          |
-| Code refactoring suggestions      | ChatGPT       | Codex            | Use ChatGPT for design-level improvements. |
-| Completing functions or classes   | Codex         | -                | Codex is better for direct completions.    |
-| Debugging and test suggestions    | ChatGPT       | Codex            | ChatGPT suggests missing scenarios.        |
+| Task/Feature                      | Primary Agent | Supporting Agent | Notes                                       |
+|-----------------------------------|---------------|------------------|---------------------------------------------|
+| Writing documentation (like KDoc) | ChatGPT       | Codex            | Use for readable, structured docs.          |
+| Explaining APIs and architecture  | ChatGPT       | -                | Great for clarity in team workflows.        |
+| Code generation (e.g., tests)     | Codex         | ChatGPT          | Codex produces quick scaffolding.           |
+| Code refactoring suggestions      | ChatGPT       | Codex            | Use ChatGPT for design-level improvements.  |
+| Completing functions or classes   | Codex         | -                | Codex is better for direct completions.     |
+| Debugging and test suggestions    | ChatGPT       | Codex            | ChatGPT suggests missing scenarios.         |
+| Advanced architecture analysis    | GPT-4o        | -                | Best for complex CQRS pattern optimization. |
+| Kotlin idiom optimization         | GPT-4o        | Codex            | Leverages latest language features.         |
+
+### Agent Collaboration Workflow
+
+```mermaid
+graph TD
+    A[Human Developer] -->|Request task| B{Task Type?}
+    B -->|Documentation| C[ChatGPT]
+    B -->|Code Generation| D[Codex]
+    B -->|Architecture Analysis| E[GPT-4o]
+    C -->|Produce Documentation| F[Review & Merge]
+    D -->|Generate Code| F
+    E -->|Optimize & Refactor| F
+    F -->|Iterate if needed| A
+```
+
+*Note: The diagram shows the typical workflow and which agent to use for different task types.*
 
 
 ### Tagging pull request messages
@@ -64,12 +86,40 @@ Use PR tags for clarity:
 ```text
 feat(chatgpt): Updated README with clearer KDoc examples
 fix(codex): Completed missing `when` branches in tests
+perf(gpt-4o): Optimized event processing pipeline
 ```
 #### Why tag pull requests?
 Tagging PRs helps the team:
   - Track which agent contributed to specific changes.
   - Understand whether a PR needs extra human review based on the agent's role.
   - Make decisions about multi-agent collaboration in reviews.
+
+### Selecting the Right Agent
+
+<details>
+<summary>Click to expand decision tree for agent selection</summary>
+
+```
+Is the task primarily documentation or explanation?
+├── Yes → Use ChatGPT
+└── No → Continue
+
+Is the task primarily generating boilerplate code or tests?
+├── Yes → Use Codex
+└── No → Continue
+
+Does the task involve complex architectural decisions or advanced Kotlin features?
+├── Yes → Use GPT-4o
+└── No → Use ChatGPT for analysis, then Codex for implementation
+```
+
+**Task Examples by Agent:**
+
+- **ChatGPT**: Documentation, conceptual explanations, architectural insights
+- **Codex**: Code generation, test scaffolding, completing partially written code
+- **GPT-4o**: Advanced architectural patterns, Kotlin idiom optimization, complex refactoring
+
+</details>
 ---
 
 ## 🧾 Coding guidelines for Agents
@@ -318,6 +368,19 @@ These goals guide how agents (ChatGPT, Codex) are used in this project to:
 - Lower the barrier to onboarding new contributors.
 - Enable collaborative, explainable, and auditable development with AI.
 
+### Problem-Solving Framework for Complex Tasks
+
+When faced with complex tasks, follow this framework:
+
+1. **Decompose**: Break down the problem into smaller, manageable parts
+2. **Analyze**: Understand the architectural implications of each part
+3. **Pattern-Match**: Identify established patterns that apply
+4. **Implement**: Write code that follows project conventions
+5. **Test**: Ensure comprehensive test coverage
+6. **Document**: Provide clear explanations of your solution
+
+*This framework helps maintain consistency across contributions from different agents.*
+
 ---
 
 ## 📋 Common Tasks
@@ -338,6 +401,31 @@ These goals guide how agents (ChatGPT, Codex) are used in this project to:
  - You are here to help.
  - Stay consistent, stay clear, and help this Kotlin/Java codebase become more robust,
    elegant, and maintainable.
+
+ ## 🌟 Real-World Examples
+
+ <details>
+ <summary>Click to see examples of excellent agent contributions</summary>
+
+ ### Documentation Example (ChatGPT)
+
+ Problem: Explain our event sourcing implementation.
+
+ Solution: Added clear documentation with visual diagrams explaining event flow, persistence, and projection rebuilding.
+
+ ### Code Completion Example (Codex)
+
+ Problem: Complete missing command handlers for user management.
+
+ Solution: Generated idiomatic Kotlin implementations with proper error handling and validation.
+
+ ### Architecture Analysis Example (GPT-4o)
+
+ Problem: Optimize query side performance.
+
+ Solution: Analyzed bottlenecks and implemented view model caching with invalidation based on event types.
+
+ </details>
 
 <!-- External links -->
 [spine-docs]: https://github.com/SpineEventEngine/documentation/wiki

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,3 @@
-
 ## 📝 Quick Reference Card
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,18 @@
 ## Table of Contents
-1. [🧠 Purpose](#-purpose)
-2. [🛠️ Project overview](#-project-overview)
-3. [🤖 Agent responsibilities](#-agent-responsibilities)
-4. [🧾 Coding guidelines for Agents](#-coding-guidelines-for-agents)
+## Table of Contents
+1. [Purpose](#-purpose)
+2. [Project overview](#-project-overview)
+3. [Agent responsibilities](#-agent-responsibilities)
+4. [Coding guidelines for Agents](#-coding-guidelines-for-agents)
 5. [Running builds](#running-builds)
 6. [Version policy](#version-policy)
-7. [📁 Project structure expectations](#-project-structure-expectations)
-8. [📄 Documentation tasks](#-documentation-tasks)
-9. [🧪 Testing](#-testing)
-10. [🚨 Safety rules for Agents](#-safety-rules-for-agents)
-11. [💬 Interaction tips – key to effective collaboration!](#-interaction-tips--key-to-effective-collaboration)
-12. [🧭 LLM Goals](#-llm-goals)
-13. [👋 Welcome, Agents!](#-welcome-agents)
+7. [Project structure expectations](#-project-structure-expectations)
+8. [Documentation tasks](#-documentation-tasks)
+9. [Testing](#-testing)
+10. [Safety rules for Agents](#-safety-rules-for-agents)
+11. [Interaction tips – key to effective collaboration!](#-interaction-tips--key-to-effective-collaboration)
+12. [LLM Goals](#-llm-goals)
+13. [Welcome, Agents!](#-welcome-agents)
 
 ## 🧠 Purpose
 
@@ -59,7 +60,7 @@ with AI to maintain a high-quality codebase.
 
 ### Tagging pull request messages
 
-While crafting GitHub PR messages, tag agent roles as needed:
+Use PR tags for clarity:
 ```text
 feat(chatgpt): Updated README with clearer KDoc examples
 fix(codex): Completed missing `when` branches in tests
@@ -151,8 +152,12 @@ Tagging PRs helps the team:
   ```
 - Descriptions of parameters, properties, and exceptions in KDoc must be terminated with a comma.
 - When creating `.md` files wrap the text so that it is not wider than 80 characters.
+
+#### Using periods in the texts
 - Put periods at the end of sentences.
 - Do not put periods if a line of text is a fragment.
+
+#### Commenting Guildeines
 - Avoid in-place comments in the code unless specifically asked.
 
 ### Safety Rules Checklist
@@ -164,39 +169,25 @@ Tagging PRs helps the team:
 ## Version policy
 
 ### We use semver
-The version number of the project is kept in the file named `version.gradle.kts` which resides
-in the root of the project.
+The version of the project is kept in the `version.gradle.kts` file in the root of the project.
 
 The version numbers in these files follow the conventions of
-[Semantic Versioning 2.0.0][semver].
+[Semantic Versioning 2.0.0](https://semver.org/).
 
-### Increment a patch version for each pull request
+IMPORTANT: ALWAYS increment the version when a new branch is created.
 
-1. Open the `version.gradle.kts` file in the root directory.
-
-2. Increment the **last number** of the version. Retain zero-padding if applicable:
+### Quick Checklist for Versioning
+1. Increment the patch version in `version.gradle.kts`.
+   Retain zero-padding if applicable:
     - Example: `"2.0.0-SNAPSHOT.009"` → `"2.0.0-SNAPSHOT.010"`
-
-3. Commit the `version.gradle.kts` file in a separate commit with the comment of the following
-   format:
-    ```text
-    Bump version -> `$newVersion`
-    ```
-    where `$newVersion` is the version number without quotes. For example:
-    ```text
-    Bump version -> `2.0.0-SNAPSHOT.010`
-    ```
-4. Run `./gradlew clean build`
-
-5. Commit updated files `pom.xml` and `dependencies.md` with the following comment: 
+2. Commit the version bump separately with this comment:
    ```text
-   Update dependency reports.
-   ```
+   Bump version → `$newVersion`
+   ``` 
+3. Rebuild using `./gradlew clean build`.
+4. Update `pom.xml`, `dependencies.md` and commit changes with: `Update dependency reports`
 
-### What happens if you forget to increment the version?
-
-Build failure! A GitHub workflow checks for correct version increments.
-
+Remember: PRs without version bumps will fail CI (conflict resolution detailed above).
 
 ### Resolving conflicts in `version.gradle.kts`
 A branch conflict over the version number should be resolved as described below.
@@ -250,12 +241,15 @@ version.gradle.kts # Declares the project version.
 
 ## 📄 Documentation tasks
 
-- Generate and update **KDoc** for `public` and `internal` APIs.
-  Remember to focus on structure for readability.
-
 - Suggest better **names** and **abstractions**.
 
 - Help format inline comments and design rationale.
+
+#### Documentation Checklist
+1. Ensure all public and internal APIs have KDoc examples.
+2. Add in-line code blocks for clarity.
+3. Use `TODO` comments with agent names for unresolved logic sections:
+    - Example: `// TODO(chatgpt): Refactor `EventStore` for better CQRS compliance.`
 
 ---
 
@@ -339,6 +333,5 @@ These goals guide how agents (ChatGPT, Codex) are used in this project to:
 
 <!-- External links -->
 [spine-docs]: https://github.com/SpineEventEngine/documentation/wiki
-[semver]: https://semver.org/
 [kotest-assertions]: https://kotest.io/docs/assertions/assertions.html
 [todo-comments]: https://github.com/SpineEventEngine/documentation/wiki/TODO-comments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,297 @@
+## Table of Contents
+1. [🧠 Purpose](#-purpose)
+2. [🛠️ Project overview](#-project-overview)
+3. [🤖 Agent responsibilities](#-agent-responsibilities)
+4. [🧾 Coding guidelines for Agents](#-coding-guidelines-for-agents)
+5. [Running builds](#running-builds)
+6. [Version policy](#version-policy)
+7. [📁 Project structure expectations](#-project-structure-expectations)
+8. [📄 Documentation tasks](#-documentation-tasks)
+9. [🧪 Testing](#-testing)
+10. [🚨 Safety rules for Agents](#-safety-rules-for-agents)
+11. [💬 Interaction tips – key to effective collaboration!](#-interaction-tips--key-to-effective-collaboration)
+12. [🧭 LLM Goals](#-llm-goals)
+13. [👋 Welcome, Agents!](#-welcome-agents)
+
+## 🧠 Purpose
+
+This document explains how to use **ChatGPT** and **Codex** effectively in this Kotlin/Java project.
+
+It outlines:
+
+- Agent responsibilities (who does what).
+- Coding and architectural guidelines agents must follow.
+- Instructions for creating and testing agent-generated outputs.
+
+Whether you are a developer, tester, or contributor, this guide will help you collaborate
+with AI to maintain a high-quality codebase.
+
+### Terminology
+- **LLM**: Refers to the general category of language models (e.g., ChatGPT, Codex, Claude).
+- **Agents**: A broader term for LLMs collaborating on this project. 
+- Use specific names (**ChatGPT**, **Codex**) when they excel at different tasks 
+  (e.g., scaffolding versus explanation).
+
+---
+
+## 🛠️ Project overview
+
+- **Languages**: Kotlin (primary), Java (secondary).
+- **Build tool**: Gradle with Kotlin DSL.
+- **Architecture**: Event-driven Command Query Responsibility Segregation (CQRS).
+- **Static analysis**: detekt, ErrorProne, Checkstyle, PMD. 
+- **Testing**: JUnit 5, Kotest Assertions, Codecov.
+- **Tools used**: Gradle plugins, IntelliJ IDEA Platform, KSP, KotlinPoet, Dokka. 
+
+---
+
+## 🤖 Agent responsibilities
+
+| Task/Feature                      | Primary Agent | Supporting Agent | Notes                                      |
+|-----------------------------------|---------------|------------------|--------------------------------------------|
+| Writing documentation (like KDoc) | ChatGPT       | Codex            | Use for readable, structured docs.         |
+| Explaining APIs and architecture  | ChatGPT       | -                | Great for clarity in team workflows.       |
+| Code generation (e.g., tests)     | Codex         | ChatGPT          | Codex produces quick scaffolding.          |
+| Code refactoring suggestions      | ChatGPT       | Codex            | Use ChatGPT for design-level improvements. |
+| Completing functions or classes   | Codex         | -                | Codex is better for direct completions.    |
+| Debugging and test suggestions    | ChatGPT       | Codex            | ChatGPT suggests missing scenarios.        |
+
+
+### Tagging pull request messages
+
+While crafting GitHub PR messages, tag agent roles as needed:
+```text
+feat(chatgpt): Updated README with clearer KDoc examples
+fix(codex): Completed missing `when` branches in tests
+```
+#### Why tag pull requests?
+Tagging PRs helps the team:
+  - Track which agent contributed to specific changes.
+  - Understand whether a PR needs extra human review based on the agent's role.
+  - Make decisions about multi-agent collaboration in reviews.
+---
+
+## 🧾 Coding guidelines for Agents
+
+### ✅ Preferred
+
+1. Kotlin idioms are **preferred** over Java-style approaches, including:
+   - Extension functions
+   - `when` expressions
+   - Smart casts
+   - Data classes
+   - Sealed classes
+
+2. Immutable data structures. 
+
+3. Apply **Java interop** only when needed (e.g., using annotations or legacy libraries).
+
+4. Use **Kotlin DSL** when modifying or generating Gradle files.
+
+5. Generate code that **compiles cleanly** and **passes static analysis**.
+
+6. Respect **existing architecture**, naming conventions, and project structure.
+
+7. Use `@file:JvmName`, `@JvmStatic`, etc., where appropriate.
+
+### ❌ Avoid
+
+- Mutable data structures
+- Java-style verbosity (e.g., builders with setters)
+- Redundant null checks (`?.let` misuse)
+- Using `!!` unless clearly justified
+- Mixing Groovy and Kotlin DSLs in build logic
+- Using reflection unless requested
+
+### General guidance
+- Adhere to the [Spine Event Engine Documentation][spine-docs]
+  for coding style and contribution procedures. 
+
+- The conventions on the [Spine Event Engine Documentation][spine-docs]
+  page and other pages in this Wiki area **take precedence over** standard Kotlin or
+  Java conventions.
+
+- Write clear, incremental commits with descriptive messages.
+- Include automated tests for any code change that alters functionality.
+- Keep pull requests focused and small.
+
+### Naming convention for variables
+- Prefer simple nouns over composite nouns. E.g., `user` is better than `userAccount`.
+
+### Safety Rules Checklist
+- ✅ Ensure all generated code compiles and passes static analysis.
+- ❌ Avoid unnecessary reflection or unsafe code (e.g., `!!` in Kotlin).
+- ✅ Do not auto-update external dependencies unless explicitly allowed.
+
+---
+## Version policy
+
+### We use semver
+The version number of the project is kept in the file named `version.gradle.kts` which resides
+in the root of the project.
+
+The version numbers in these files follow the conventions of
+[Semantic Versioning 2.0.0][semver].
+
+### Increment a patch version for each pull request
+
+1. Open the `version.gradle.kts` file in the root directory.
+
+2. Increment the **last number** of the version. Retain zero-padding if applicable:
+    - Example: `"2.0.0-SNAPSHOT.009"` → `"2.0.0-SNAPSHOT.010"`
+
+3. Commit the `version.gradle.kts` file in a separate commit with the comment of the following
+   format:
+    ```text
+    Bump version -> `$newVersion`
+    ```
+    where `$newVersion` is the version number without quotes. For example:
+    ```text
+    Bump version -> `2.0.0-SNAPSHOT.010`
+    ```
+4. Run `./gradlew clean build`
+
+5. Commit updated files `pom.xml` and `dependencies.md` with the following comment: 
+   ```text
+   Update dependency reports.
+   ```
+
+### What happens if you forget to increment the version?
+
+Build failure! A GitHub workflow checks for correct version increments.
+
+
+### Resolving conflicts in `version.gradle.kts`
+A branch conflict over the version number should be resolved as described below.
+ * If a merged branch has a number which is less than that of the current branch, the version of
+   the current branch stays.
+ * If the merged branch has the number which is greater or equal to that of the current branch,
+   the number should be increased by one.
+---
+
+## Running builds
+
+1. When modifying code, run:
+   ```bash
+   ./gradlew build
+   ```
+
+2. If Protobuf (`.proto`) files are modified run:
+   ```bash
+   ./gradlew clean build
+   ````
+
+3. Documentation-only changes run:
+   ```bash
+   ./gradlew dokka
+   ```
+   Documentation-only changes do not require running tests!
+---
+
+## 📁 Project structure expectations
+
+```yaml
+.github
+buildSrc/
+<module-1>
+  src/
+  ├── main/
+  │ ├── kotlin/ # Kotlin source files
+  │ └── java/ # Legacy Java code
+  ├── test/
+  │ └── kotlin/ # Unit and integration tests
+  build.gradle.kts # Kotlin-based build configuration
+<module-2>
+<module-3>
+build.gradle.kts # Kotlin-based build configuration
+settings.gradle.kts # Project structure and settings
+README.md # Project overview
+AGENTS.md # LLM agent instructions (this file)
+version.gradle.kts # Declares the project version. 
+```
+---
+
+## 📄 Documentation tasks
+
+- Generate and update **KDoc** for `public` and `internal` APIs.
+  Remember to focus on structure for readability.
+
+- Suggest better **names** and **abstractions**.
+
+- Help format inline comments and design rationale.
+
+---
+
+## 🧪 Testing
+
+### Guidelines
+- Do not use mocks, use stubs.
+- Prefer [Kotest assertions][kotest-assertions] over
+  assertions from JUnit or Google Truth.
+
+### Responsibilities
+
+#### Codex
+- Generate unit tests for APIs (handles edge cases/scenarios).
+- Supply scaffolds for typical Kotlin patterns (`when`, sealed classes).
+
+#### ChatGPT
+- Suggest test coverage improvements.
+- Propose property-based testing or rare edge case scenarios.
+
+---
+
+## 🚨 Safety rules for Agents
+
+- Do **not** auto-update external dependencies without explicit request.
+- Do **not** inject analytics or telemetry code.
+- Flag any usage of unsafe constructs (e.g., reflection, I/O on the main thread).
+- Avoid generating blocking calls inside coroutines.
+
+---
+   
+## ⚙️ Refactoring Guidelines
+- Do not replace Kotest assertions with standard Kotlin's Built-In Test Assertions.
+
+---
+
+## 💬 Interaction tips – key to effective collaboration!
+
+- Human programmers may use inline comments to guide agents:
+  ```kotlin
+    // ChatGPT: Suggest a refactor for better readability.
+    // Codex: Complete the missing branches in this `when` block.
+    // ChatGPT: explain this logic.
+    // Codex: complete this function.
+   ```
+- Agents should ensure pull request messages are concise and descriptive:
+  ```text
+  feat(chatgpt): suggested DSL refactoring for query handlers  
+  fix(codex): completed missing case in sealed class hierarchy
+  ```
+- Encourage `// TODO:` or `// FIXME:` comments to be clarified by ChatGPT.
+
+- When agents or humans add TODO comments, they **must** follow the format described on
+  the [dedicated page][todo-comments].
+
+---
+
+## 🧭 LLM Goals
+
+These goals guide how agents (ChatGPT, Codex) are used in this project to:
+- Help developers move faster without sacrificing code quality.
+- Provide language-aware guidance on Kotlin/Java idioms.
+- Lower the barrier to onboarding new contributors.
+- Enable collaborative, explainable, and auditable development with AI.
+--- 
+
+## 👋 Welcome, Agents!
+ - You are here to help.
+ - Stay consistent, stay clear, and help this Kotlin/Java codebase become more robust,
+   elegant, and maintainable.
+
+<!-- External links -->
+[spine-docs]: https://github.com/SpineEventEngine/documentation/wiki
+[semver]: https://semver.org/
+[kotest-assertions]: https://kotest.io/docs/assertions/assertions.html
+[todo-comments]: https://github.com/SpineEventEngine/documentation/wiki/TODO-comments

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,52 @@ Tagging PRs helps the team:
 
 ## 🧾 Coding guidelines for Agents
 
+### General coding and formatting guidelines
+
+#### General Guidelines
+- Adhere to [Spine Event Engine Documentation][spine-docs] for coding style.
+- Write clear, incremental commits with descriptive messages.
+- Include automated tests for any code change that alters functionality.
+- Avoid in-place comments in code unless specifically requested.
+
+#### Naming Conventions
+- Prefer **simple nouns** over composite nouns (`user` > `userAccount`).
+- Avoid using **type names** in variable names:
+  | DO                                 | DON'T                                        |
+  |------------------------------------|----------------------------------------------|
+  | `val user = getUser()`             | `val userObject = getUser()`                 |
+  | `val items = getItems()`           | `val itemList = getItems()`                  | 
+  | `val gradleWrapper: IvyDependency` | `val gradleWrapperDependency: IvyDependency` |
+
+- Avoid **string duplication**: Use constants in companion objects,
+  or properties for interpolated strings where appropriate.
+- Prefer **generic parameters** over explicit variable types:
+  | DO                                      | DON'T                                               |
+  |-----------------------------------------|-----------------------------------------------------|
+  | `val list = mutableList<Dependency>()`  | `val list: MutableList<Dependency> = mutableList()` |
+
+#### KDoc and Commenting
+- Write concise and clear KDoc descriptions for all public and internal APIs.
+- Use the following style for parameter descriptions:
+  - Begin descriptions with uppercase letters.
+  - Terminate them with commas.
+- Format blocks of code in documentation with fences:
+  ```kotlin
+  // Example:
+  override fun toString(): String {
+      return "Example"
+  }
+  ```
+
+- Avoid inline comments unless necessary.
+
+#### Formatting
+- Wrap `.md` text to **80 characters** for readability.
+- Use proper punctuation:
+  - Periods at the end of full sentences.
+  - No periods for text fragments or bullet points.
+- Inline code fragments must always be encapsulated with backticks (`example`).
+
 ### ✅ Preferred
 
 1. Kotlin idioms are **preferred** over Java-style approaches, including:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -139,7 +139,7 @@ val koverVersion = "0.9.1"
  *
  * @see <a href="https://github.com/johnrengelman/shadow/releases">Shadow Plugin releases</a>
  */
-val shadowVersion = "7.1.2"
+val shadowVersion = "8.3.6"
 
 configurations.all {
     resolutionStrategy {
@@ -176,7 +176,7 @@ dependencies {
         "com.github.jk1:gradle-license-report:$licenseReportVersion",
         "com.google.guava:guava:$guavaVersion",
         "com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion",
-        "gradle.plugin.com.github.johnrengelman:shadow:$shadowVersion",
+        "com.gradleup.shadow:shadow-gradle-plugin:$shadowVersion",
         "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion",
         "io.kotest:kotest-gradle-plugin:$kotestJvmPluginVersion",
         // https://github.com/srikanth-lingala/zip4j

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -35,7 +35,7 @@ import io.spine.dependency.Dependency
  */
 @Suppress("unused")
 object Ksp : Dependency() {
-    override val version = "2.1.21-2.0.1"
+    override val version = "2.1.21-2.0.2"
     override val group = "com.google.devtools.ksp"
 
     const val id = "com.google.devtools.ksp"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,13 +34,22 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.332"
+    const val version = "2.0.0-SNAPSHOT.340"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"
     const val pluginTestlib = "$group:spine-plugin-testlib:$version"
 
+    const val intellijPlatform = "$group:spine-intellij-platform:$version"
     const val intellijPlatformJava = "$group:intellij-platform-java:$version"
 
+    const val psi = "$group:spine-psi:$version"
     const val psiJava = "$group:spine-psi-java:$version"
+
+    const val gradleRootPlugin = "$group:spine-gradle-root-plugin:$version"
+    const val gradlePluginApi = "$group:spine-gradle-plugin-api:$version"
+    const val gradlePluginApiTestFixtures = "$group:spine-gradle-plugin-api-test-fixtures:$version"
+
+    const val jvmTools = "$group:spine-jvm-tools:$version"
+    const val jvmToolPlugins = "$group:spine-jvm-tool-plugins:$version"
 }


### PR DESCRIPTION
This PR consolidates the guidelines for Junie and other agents, following the feedback from Junie and GPT-4o.

### Other notable changes
 * Newer Shadow plugin version was applied.
 * `buildSrc` got the `settings.gradle.kts` with the Foojay resolver plugin.
 * KSP was bumped -> `2.1.21-2.0.2`.
 * `ToolBase` dependency object got properties after the latest ToolBase module structure.
