### PR TITLE
Bump the Compiler, improve migration script

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,9 +1,9 @@
 # Guidelines for Junie and AI Agent from JetBrains
 
-Read the `../.agents/_TOC.md` file at the root of the project to understand:
+Read the `../.agents/_TOC.md` file to understand:
  - the agent responsibilities,
- - project overview, 
- - coding guidelines, 
+ - project overview,
+ - coding guidelines,
  - other relevant topics.
 
 Also follow the Junie-specific rules described below.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -70,7 +70,7 @@ object Compiler {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.017"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.021"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -79,7 +79,7 @@ object Compiler {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.017"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.021"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
@@ -161,10 +161,10 @@ object Compiler {
                 -----------------------------------------
                     Regular version     = v$version
                     Dogfooding version  = v$dogfoodingVersion
-                
+
                     The Compiler Gradle plugin can now be loaded from Maven Local.
-                    
-                    To reset the versions, erase the `$$VERSION_ENV` and `$$DF_VERSION_ENV` environment variables. 
+
+                    To reset the versions, erase the `$$VERSION_ENV` and `$$DF_VERSION_ENV` environment variables.
 
             """.trimIndent())
         } else {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -26,6 +26,10 @@
 
 package io.spine.dependency.local
 
+import io.spine.dependency.local.CoreJvmCompiler.dogfoodingVersion
+import io.spine.dependency.local.CoreJvmCompiler.version
+
+
 /**
  * Dependencies on the CoreJvm Compiler artifacts.
  *
@@ -46,12 +50,12 @@ object CoreJvmCompiler {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.008"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.009"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.008"
+    const val version = "2.0.0-SNAPSHOT.009"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.357"
+    const val version = "2.0.0-SNAPSHOT.358"
 
     const val lib = "$group:tool-base:$version"
     const val pluginBase = "$group:plugin-base:$version"

--- a/migrate
+++ b/migrate
@@ -12,9 +12,11 @@ cp CODE_OF_CONDUCT.md ..
 echo "Updating Codecov settings"
 cp .codecov.yml ..
 
-
 echo "Updating \\\`AGENTS.md\\\`"
 cp AGENTS.md ..
+
+echo "Updating \\\`CLAUDE.md\\\`"
+cp CLAUDE.md ..
 
 echo "Updating Junie guidelines"
 rm -rf ../.junie
@@ -47,13 +49,8 @@ cp -a .github-workflows/. ../.github/workflows
 cp -a .github/workflows/. ../.github/workflows
 rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
 
-# echo "Cleaning up GitHub workflows"
-#rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
-#rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
-
-# echo "Cleaning up Gradle 'buildSrc' scripts"
-#rm -f ../buildSrc/src/main/kotlin/force-jacoco.gradle.kts
-#rm -f ../buildSrc/src/main/kotlin/deps-between-tasks.kt
+# 2025-10-01 Remove renamed `CoreJava.kt`
+rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
 
 # 2025-05-02 Remove the refactored file.
 rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/javadoc/TaskContainerExtensions.kt


### PR DESCRIPTION
This PR bumps the version of Compiler and improves the migration script so that it removes recently renamed `CoreJava.kt` file.