### PR TITLE
Updates from Logging

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -46,7 +46,7 @@ object Logging {
     const val grpcContext = "$group:spine-logging-grpc-context:$version"
     const val smokeTest = "$group:spine-logging-smoke-test:$version"
 
-    const val testLib = "${Spine.toolsGroup}:spine-logging-testlib:$version"
+    const val testLib = "${Spine.toolsGroup}:logging-testlib:$version"
 
     // Transitive dependencies.
     // Make `public` and use them to force a version in a particular repository, if needed.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.411"
+    const val version = "2.0.0-SNAPSHOT.412"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Kotest.kt
@@ -41,23 +41,17 @@ object Kotest {
     const val assertions = "$group:kotest-assertions-core:$version"
     const val runnerJUnit5 = "$group:kotest-runner-junit5:$version"
     const val runnerJUnit5Jvm = "$group:kotest-runner-junit5-jvm:$version"
-    const val frameworkApi = "$group:kotest-framework-api:$version"
-    const val datatest = "$group:kotest-framework-datatest:$version"
     const val frameworkEngine = "$group:kotest-framework-engine:$version"
+    const val common = "$group:kotest-common:$version"
 
-    // https://plugins.gradle.org/plugin/io.kotest.multiplatform
-    @Deprecated("The plugin is deprecated. Use `io.kotest` plugin instead.")
-    object MultiplatformGradlePlugin {
-        const val version = "6.0.0.M4"
-        const val id = "io.kotest.multiplatform"
-        const val classpath = "$group:kotest-framework-multiplatform-plugin-gradle:$version"
-    }
-
-    // https://github.com/kotest/kotest-gradle-plugin
-    @Deprecated("The repository is archived. Use `io.kotest.multiplatform` plugin instead.")
-    object JvmGradlePlugin {
-        const val version = "0.4.11"
-        const val id = "io.kotest"
-        const val classpath = "$group:kotest-gradle-plugin:$version"
-    }
+    /**
+     * @deprecated Use `frameworkEngine` instead.
+     */
+    @Deprecated("Use `frameworkEngine` instead.", ReplaceWith("frameworkEngine"))
+    const val frameworkApi = "$group:kotest-framework-api:$version"
+    /**
+     * @deprecated The dependency was merged into the core framework.
+     */
+    @Deprecated("The dependency was merged into the core framework.")
+    const val datatest = "$group:kotest-framework-datatest:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,8 +133,14 @@ sealed class PublicationHandler(
      *  * [version][Project.getVersion];
      *  * [description][Project.getDescription].
      *
-     * The [artifactId] of the publication is copied from the project
-     * [extension property][io.spine.gradle.artifactId] of the same name.
+     * The [artifactId] is derived from the project
+     * [extension property][io.spine.gradle.artifactId] of the same name, combined with
+     * the platform-specific suffix already present in the publication's artifact ID.
+     * This preserves Kotlin Multiplatform suffixes such as `-jvm`.
+     *
+     * For example, if the project artifact ID is `spine-logging` and the publication's
+     * current artifact ID is `logging-jvm` (set by the KMP plugin), the resulting
+     * artifact ID will be `spine-logging-jvm`.
      *
      * The Apache Software License 2.0 is set as the only license
      * under which the published artifact is distributed via [LicenseSettings]
@@ -146,7 +152,8 @@ sealed class PublicationHandler(
      */
     protected fun MavenPublication.copyProjectAttributes() {
         groupId = project.group.toString()
-        artifactId = project.artifactId
+        val platformSuffix = artifactId.removePrefix(project.name)
+        artifactId = project.artifactId + platformSuffix
         version = project.version.toString()
         pom.description.set(project.description)
         pom.inceptionYear.set(InceptionYear.value)

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -30,6 +30,8 @@ import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.JSpecify
 import io.spine.dependency.lib.Guava
+import io.spine.dependency.lib.Jackson
+import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Reflect
 import io.spine.dependency.test.Jacoco
@@ -130,7 +132,13 @@ fun Module.forceConfigurations() {
         excludeProtobufLite()
         all {
             resolutionStrategy {
+                val cfg = this@all
+                val rs = this@resolutionStrategy
+                Jackson.forceArtifacts(project, cfg, rs)
+                Jackson.DataFormat.forceArtifacts(project, cfg, rs)
                 force(
+                    Jackson.annotations,
+                    Kotlin.bom,
                     Dokka.BasePlugin.lib,
                     Reflect.lib,
                 )

--- a/buildSrc/src/main/kotlin/kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp-module.gradle.kts
@@ -25,6 +25,8 @@
  */
 
 import io.spine.dependency.boms.BomsPlugin
+import io.spine.dependency.lib.Jackson
+import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.local.Reflect
 import io.spine.dependency.local.TestLib
 import io.spine.dependency.test.JUnit
@@ -82,7 +84,12 @@ fun Project.forceConfigurations() {
         forceVersions()
         all {
             resolutionStrategy {
+                val cfg = this@all
+                val rs = this@resolutionStrategy
+                Jackson.forceArtifacts(project, cfg, rs)
+                Jackson.DataFormat.forceArtifacts(project, cfg, rs)
                 force(
+                    Kotlin.bom,
                     Reflect.lib
                 )
             }
@@ -123,7 +130,6 @@ kotlin {
                 implementation(kotlin("test-annotations-common"))
                 implementation(Kotest.assertions)
                 implementation(Kotest.frameworkEngine)
-                implementation(Kotest.datatest)
             }
         }
         val jvmTest by getting {


### PR DESCRIPTION
This PR brings in improvements to publishing recently adopted in Logging. Also, this PR removes the deprecated inner dependency objects of `Kotest`.