### PR TITLE
Bump versions and `JetBrainsAnnotations` dependency object

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
@@ -26,6 +26,7 @@
 
 package io.spine.dependency.build
 
+import io.spine.dependency.build.Dokka.GradlePlugin.id
 import io.spine.dependency.local.Spine
 
 // https://github.com/Kotlin/dokka
@@ -37,7 +38,7 @@ object Dokka {
      * When changing the version, also change the version used in the
      * `buildSrc/build.gradle.kts`.
      */
-    const val version = "2.1.0"
+    const val version = "2.2.0"
 
     object GradlePlugin {
         const val id = "org.jetbrains.dokka"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JetBrainsAnnotations.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JetBrainsAnnotations.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.lib
+
+/**
+ * Annotations library from JetBrains.
+ *
+ * https://github.com/JetBrains/java-annotations
+ */
+object JetBrainsAnnotations {
+    /**
+     * The version of the library transitively used.
+     */
+    const val version = "23.0.0"
+    const val groupId = "org.jetbrains"
+    const val artifactId = "annotations"
+    const val lib = "$groupId:$artifactId:$version"
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.042"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.043"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.042"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.043"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.412"
+    const val version = "2.0.0-SNAPSHOT.413"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.414"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.376"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.376"
+    const val version = "2.0.0-SNAPSHOT.378"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.378"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"


### PR DESCRIPTION
This PR:
 * Restores the version of Dokka to `2.2.0`. It was accidentally rolled back to `2.1.0` by one of the previous updates.
 * Bumps Logging and Compiler.
 * Adds the dependency object for JetBrains Annotations so that we can force its version.