### PR TITLE
Fix Dokka version in `buildSrc/build.gradle.kts`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -115,7 +115,7 @@ val protobufPluginVersion = "0.9.6"
  * @see <a href="https://github.com/Kotlin/dokka/releases">
  *     Dokka Releases</a>
  */
-val dokkaVersion = "2.1.0"
+val dokkaVersion = "2.2.0"
 
 /**
  * The version of Detekt Gradle Plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.414"
+    const val version = "2.0.0-SNAPSHOT.415"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"


### PR DESCRIPTION
This PR fixes the version of Dokka set under `buildSrc/build.gradle.kts` to avoid the classpath issues when running publishing. 

The version of Logging was also bumped to match the hopefully published version.