### PR TITLE
Fix `license.distrubution` property, log replacing `artifactId`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.415"
+    const val version = "2.0.0-SNAPSHOT.417"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
@@ -158,11 +158,18 @@ sealed class PublicationHandler(
         // the `project.name` with the platform suffix of a KMM distribution.
         artifactId = if (artifactId.startsWith(project.name)) {
             val platformSuffix = artifactId.removePrefix(project.name)
-            project.artifactId + platformSuffix
+            val replacedId = project.artifactId + platformSuffix
+            project.logger.info(
+                "The project `${project.name}` got modified artifact: `$replacedId`."
+            )
+            replacedId
         } else {
-            // This is unlikely case of `artifactId` being set to something unrelated.
-            // We overwrite it with our calculated ID.
-            project.artifactId
+            project.logger.info(
+                "The `artifactId` for the project `${project.name}` stays: `$artifactId`."
+            )
+            // This is an unlikely case of `artifactId` being set to something unrelated
+            // to the project name. Let's keep it as is.
+            artifactId
         }
         version = project.version.toString()
         pom.description.set(project.description)

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
@@ -26,6 +26,7 @@
 
 package io.spine.gradle.publish
 
+import DocumentationSettings
 import LicenseSettings
 import io.spine.gradle.artifactId
 import io.spine.gradle.isSnapshot
@@ -152,8 +153,17 @@ sealed class PublicationHandler(
      */
     protected fun MavenPublication.copyProjectAttributes() {
         groupId = project.group.toString()
-        val platformSuffix = artifactId.removePrefix(project.name)
-        artifactId = project.artifactId + platformSuffix
+        // Add the proper prefix to the `artifactId`.
+        // The default `artifactId` is either `project.name` or
+        // the `project.name` with the platform suffix of a KMM distribution.
+        artifactId = if (artifactId.startsWith(project.name)) {
+            val platformSuffix = artifactId.removePrefix(project.name)
+            project.artifactId + platformSuffix
+        } else {
+            // This is unlikely case of `artifactId` being set to something unrelated.
+            // We overwrite it with our calculated ID.
+            project.artifactId
+        }
         version = project.version.toString()
         pom.description.set(project.description)
         pom.inceptionYear.set(InceptionYear.value)
@@ -161,7 +171,9 @@ sealed class PublicationHandler(
             license {
                 name.set(LicenseSettings.name)
                 url.set(LicenseSettings.url)
-                distribution.set(LicenseSettings.url)
+                // It's either `"repo"` or `"manual"`.
+                // https://maven.apache.org/ref/3.9.15/maven-model/apidocs/org/apache/maven/model/License.html?utm_source=chatgpt.com#setDistribution(java.lang.String)
+                distribution.set("repo")
             }
         }
         pom.scm {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
@@ -179,7 +179,7 @@ sealed class PublicationHandler(
                 name.set(LicenseSettings.name)
                 url.set(LicenseSettings.url)
                 // It's either `"repo"` or `"manual"`.
-                // https://maven.apache.org/ref/3.9.15/maven-model/apidocs/org/apache/maven/model/License.html?utm_source=chatgpt.com#setDistribution(java.lang.String)
+                // https://maven.apache.org/ref/3.9.15/maven-model/apidocs/org/apache/maven/model/License.html#setDistribution(java.lang.String)
                 distribution.set("repo")
             }
         }


### PR DESCRIPTION
This PR updates `PublicationHandler.kt`:
 * Fixed the value of `license.distribution` property to be `"repo"` instead of license URL.
 * Added logging for the replacing `artifactId` of a Maven publication.

Also, the version of Logging was bumped to the latest published version.
