### PR TITLE
Tune skills

### DIFF
--- a/.agents/_TOC.md
+++ b/.agents/_TOC.md
@@ -13,4 +13,4 @@
 11. [Advanced safety rules](advanced-safety-rules.md)
 12. [Refactoring guidelines](refactoring-guidelines.md)
 13. [Common tasks](common-tasks.md)
-14. [Java to Kotlin conversion](java-kotlin-conversion.md)
+14. [Java to Kotlin conversion](skills/java-to-kotlin/SKILL.md)

--- a/.agents/quick-reference-card.md
+++ b/.agents/quick-reference-card.md
@@ -3,7 +3,6 @@
 ```
 🔑 Key Information:
 - Kotlin/Java project with CQRS architecture
-- Use ChatGPT for documentation, Codex for code generation, GPT-4o for complex analysis
 - Follow coding guidelines in Spine Event Engine docs
 - Always include tests with code changes
 - Version bump required for all PRs

--- a/.agents/skills/java-to-kotlin/SKILL.md
+++ b/.agents/skills/java-to-kotlin/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: java-to-kotlin
+description: >
+  Convert Java code to Kotlin, including Java API comments from Javadoc to KDoc.
+  Use when asked to migrate Java files, classes, methods, nullability semantics,
+  or common Java patterns into idiomatic Kotlin while preserving behavior.
+---
+
 # 🪄 Converting Java code to Kotlin
 
 * Java code API comments are Javadoc format.

--- a/.agents/skills/java-to-kotlin/agents/openai.yaml
+++ b/.agents/skills/java-to-kotlin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Java to Kotlin"
+  short_description: "Convert Java code to idiomatic Kotlin"
+  default_prompt: "Use $java-to-kotlin to convert Java code to Kotlin while preserving behavior, nullability, and API documentation wording."

--- a/.junie/skills
+++ b/.junie/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
This PR adds a `java-to-kotlin` conversion skill and links `.junie/skills` to `.agents/skills`.

### Other notable changes
 * The `guick-reference-card.md` was updated to remove the assignments text for ChatGPT and Codex.