### PR TITLE
Updates from CoreJvm Compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 
 # Internal tool directories.
 .fleet/
+.junie/memory/
 
 # Kotlin temp directories.
 **/.kotlin/

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -10,7 +10,7 @@ Also follow the Junie-specific rules described below.
 
 ## Junie Assistance Tips
 
-When working with Junie AI on the Spine Tool-Base project:
+When working with Junie AI on the Spine family of projects:
 
 1. **Project Navigation**: Use `search_project` to find relevant files and code segments.
 2. **Code Understanding**: Request file structure with `get_file_structure` before editing.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -137,8 +137,6 @@ val koverVersion = "0.9.1"
 /**
  * The version of the Shadow Plugin.
  *
- * `7.1.2` is the last version compatible with Gradle 7.x. Newer versions require Gradle v8.x.
- *
  * @see <a href="https://github.com/GradleUp/shadow">Shadow Plugin releases</a>
  */
 val shadowVersion = "9.4.1"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Dokka.kt
@@ -26,7 +26,6 @@
 
 package io.spine.dependency.build
 
-import io.spine.dependency.build.Dokka.GradlePlugin.id
 import io.spine.dependency.local.Spine
 
 // https://github.com/Kotlin/dokka

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -26,9 +26,6 @@
 
 package io.spine.dependency.local
 
-import io.spine.dependency.local.CoreJvmCompiler.dogfoodingVersion
-
-
 /**
  * Dependencies on the CoreJvm Compiler artifacts.
  *

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -26,6 +26,9 @@
 
 package io.spine.dependency.local
 
+import io.spine.dependency.local.CoreJvmCompiler.dogfoodingVersion
+
+
 /**
  * Dependencies on the CoreJvm Compiler artifacts.
  *
@@ -46,7 +49,7 @@ object CoreJvmCompiler {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.062"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.063"
 
     /**
      * The version to be used for integration tests.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -40,7 +40,7 @@ import io.spine.dependency.Dependency
 )
 object Time : Dependency() {
     override val group = Spine.group
-    override val version = "2.0.0-SNAPSHOT.235"
+    override val version = "2.0.0-SNAPSHOT.236"
     private const val infix = "spine-time"
 
     fun lib(version: String): String = "$group:$infix:$version"
@@ -55,6 +55,12 @@ object Time : Dependency() {
 
     fun testLib(version: String): String = "${Spine.toolsGroup}:time-testlib:$version"
     val testLib get() = testLib(version)
+
+    fun validation(version: String): String = "${Spine.toolsGroup}:time-validation:$version"
+    val validation get() = validation(version)
+
+    fun gradlePlugin(version: String): String = "${Spine.toolsGroup}:time-gradle-plugin:$version"
+    val gradlePlugin get() = gradlePlugin(version)
 
     override val modules: List<String>
         get() = listOf(

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.414"
 
     /**
      * The last version of Validation compatible with ProtoData.


### PR DESCRIPTION
This PR brings updates recently [adopted in CoreJvm Compiler](https://github.com/SpineEventEngine/core-jvm-compiler/pull/83).