### PR TITLE
Improve naming in GitHub workflows

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -1,10 +1,9 @@
-name: Build under Ubuntu
+name: Build on Ubuntu
 
 on: push
 
 jobs:
   build:
-    name: Build under Ubuntu
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -1,10 +1,9 @@
-name: Build under Windows
+name: Build on Windows
 
 on: pull_request
 
 jobs:
   build:
-    name: Build under Windows
     runs-on: windows-latest
 
     steps:

--- a/.github-workflows/ensure-reports-updated.yml
+++ b/.github-workflows/ensure-reports-updated.yml
@@ -8,8 +8,7 @@ on:
       - '**'
 
 jobs:
-  build:
-    name: Ensure license reports updated
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -9,8 +9,7 @@ on:
       - '**'
 
 jobs:
-  build:
-    name: Check version increment
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/remove-obsolete-artifacts-from-packages.yaml
+++ b/.github-workflows/remove-obsolete-artifacts-from-packages.yaml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   retrieve-package-names:
-    name: Retrieve the package names published from this repository
+    name: Retrieve package names
     runs-on: ubuntu-latest
     outputs:
       package-names: ${{ steps.request-package-names.outputs.package-names }}
@@ -54,7 +54,7 @@ jobs:
           echo "package-names=$(<./package-names.json)" >> $GITHUB_OUTPUT
 
   delete-obsolete-artifacts:
-    name: Remove obsolete artifacts published from this repository to GitHub Packages
+    name: Delete obsolete artifacts
     needs: retrieve-package-names
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/detekt-code-analysis.yml
+++ b/.github/workflows/detekt-code-analysis.yml
@@ -3,8 +3,7 @@ name: Run Detekt code analysis
 on: push
 
 jobs:
-  build:
-    name: Run Detekt code analysis
+  detekt:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   validation:
-    name: Gradle Wrapper Validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code


### PR DESCRIPTION
This PR updates templates for GitHub workflows to avoid duplicating a workflow name in its job name. Some job IDs were renamed to better reflect job nature.

Also, some names were shortened for better readability.