### PR TITLE
Add job names

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -1,9 +1,10 @@
-name: Build on Ubuntu
+name: Ubuntu CI
 
 on: push
 
 jobs:
   build:
+    name: Build on Ubuntu
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -1,10 +1,11 @@
-name: Build on Windows
+name: Windows CI
 
 on: pull_request
 
 jobs:
   build:
     runs-on: windows-latest
+    name: Build and test on Windows
 
     steps:
       - uses: actions/checkout@v4

--- a/.github-workflows/ensure-reports-updated.yml
+++ b/.github-workflows/ensure-reports-updated.yml
@@ -1,6 +1,6 @@
 # Ensures that the license report files were modified in this PR.
 
-name: Ensure license reports updated
+name: License Reports
 
 on:
   pull_request:
@@ -9,12 +9,13 @@ on:
 
 jobs:
   check:
+    name: Ensure license reports are updated
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
-          # Configure the checkout of all branches, so that it is possible to run the comparison.
+          # Configure the checkout of all branches so that it is possible to run the comparison.
           fetch-depth: 0
           # Check out the `config` submodule to fetch the required script file.
           submodules: true

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -1,7 +1,7 @@
 # Ensures that the current lib version is not yet published but executing the Gradle
 # `checkVersionIncrement` task.
 
-name: Check version increment
+name: Version Guard
 
 on:
   push:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   check:
+    name: Check version increment
     runs-on: ubuntu-latest
 
     steps:

--- a/.github-workflows/publish.yml
+++ b/.github-workflows/publish.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   publish:
+    name: Publish to Maven repositories
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/detekt-code-analysis.yml
+++ b/.github/workflows/detekt-code-analysis.yml
@@ -1,9 +1,10 @@
-name: Run Detekt code analysis
+name: detekt code analysis
 
 on: push
 
 jobs:
   detekt:
+    name: Run detekt
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,4 +1,4 @@
-name: Validate Gradle Wrapper
+name: Gradle Wrapper validation
 on:
   push:
     branches:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   validation:
+    name: Validate Gradle Wrapper
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -40,7 +40,7 @@ import io.spine.dependency.Dependency
 )
 object Time : Dependency() {
     override val group = Spine.group
-    override val version = "2.0.0-SNAPSHOT.237"
+    override val version = "2.0.0-SNAPSHOT.238"
     private const val infix = "spine-time"
 
     fun lib(version: String): String = "$group:$infix:$version"


### PR DESCRIPTION
This PR adds names for the GitHub Workflow jobs so that they can be used as status checks in the branch protection rule sets.