### PR TITLE
Introduce `bump-version` skill

### DIFF
--- a/.agents/skills/bump-version/SKILL.md
+++ b/.agents/skills/bump-version/SKILL.md
@@ -77,34 +77,6 @@ PRs without a version bump fail CI.
    Bump version -> `2.0.0-SNAPSHOT.183`
    ```
 
-   When the commit bumps a named dependency rather than the current project's
-   own version, replace `version` with the dependency's display name — the
-   Kotlin `object` name from `buildSrc/src/main/kotlin/io/spine/dependency/local/*.kt`
-   (`Time`, `Validation`, `Logging`, ...). Compound names use the spaced form
-   seen in recent commits (e.g. `CoreJvm Compiler`, `Shadow plugin`). When in
-   doubt, check the prevailing form: `git log --format=%s --grep='^Bump '`.
-
-   ```text
-   Bump Time -> `2.0.0-SNAPSHOT.238`
-   ```
-
-   The arrow style and backticks are the same.
-
-   When a single commit bumps **multiple dependencies**, the `-> \`<version>\``
-   tail is omitted because no single version applies. Use one of:
-
-   ```text
-   Bump Time and Validation
-   Bump local dependencies
-   ```
-
-   Name the dependencies when there are two or three; use the canonical
-   generic form `Bump local dependencies` (the prevailing form in repo
-   history) when more are touched. Confirm against current usage with
-   `git log --format=%s --grep='^Bump '` before inventing a new variant.
-   Prefer one bump-per-dependency when feasible so the arrow form (and its
-   CI-relevant version) is preserved.
-
 3. Rebuild to verify the bump and regenerate dependency reports:
 
    ```bash
@@ -144,16 +116,16 @@ Resolve as follows:
 ## Validate
 
 - `./gradlew clean build` succeeds after the bump.
-- The bump commit's subject matches the convention. Locate it without assuming
-  it is `HEAD` (a "Update dependency reports" commit may sit on top), and
-  scope to commits introduced on the current branch. Set `BASE` to the
-  branch this PR will merge into — typically `master`, but a release line
-  such as `1.5.x` for a patch release:
+- The bump commit's subject matches the convention. It may not be `HEAD`
+  (a "Update dependency reports" commit can sit on top), so scope to commits
+  introduced on the current branch. Set `BASE` to the branch this PR will
+  merge into — typically `master`, or a release line such as `1.5.x` for a
+  patch release:
 
   ```bash
   BASE=master
   git fetch --quiet origin "$BASE"
-  git log --format=%s "$(git merge-base HEAD origin/$BASE)..HEAD" | grep '^Bump '
+  git log --format=%s "$(git merge-base HEAD origin/$BASE)..HEAD" | grep '^Bump version '
   ```
 
   The `git fetch` step guards against false negatives in fresh clones,

--- a/.agents/skills/bump-version/SKILL.md
+++ b/.agents/skills/bump-version/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: bump-version
+description: >
+  Bump the project version in `version.gradle.kts` following the Spine SDK
+  versioning policy. Use when starting a new branch, before opening a PR, or
+  when CI rejects a branch for a missing/insufficient version increment. Covers
+  version-number selection, the commit-message convention, the post-bump
+  rebuild, dependency-report updates, and conflict resolution against the base
+  branch.
+---
+
+# Bump the project version
+
+The authoritative versioning policy is
+[Spine SDK Versioning][wiki-versioning]. This skill encodes the parts of that
+policy that affect day-to-day work in this repo. CI enforces the bump via
+`io.spine.internal.gradle.publish.CheckVersionIncrement`, which inspects the
+version number — not the commit subject.
+
+## Version format
+
+Versions live in `version.gradle.kts` at the project root, for example:
+
+```kotlin
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")
+```
+
+Spine uses Semantic Versioning with extensions:
+
+- **Snapshot:** `MAJOR.MINOR.PATCH-SNAPSHOT.NUMBER` during active development.
+  The trailing `NUMBER` is the per-PR counter.
+- **Release:** standard semver, such as `1.5.0`.
+- **Patch release:** issued only when an urgent fix is needed against a
+  released minor; bumps the `PATCH` digit (e.g. `1.5.0` → `1.5.1`).
+- **Flavor:** suffixes like `-jdk8` denote a specific build flavor.
+
+Preserve zero-padding on the snapshot `NUMBER` when it is present:
+`2.0.0-SNAPSHOT.009` → `2.0.0-SNAPSHOT.010`.
+
+## When to bump
+
+Every code advancement must move the version forward. Which component moves
+depends on the release line:
+
+- **Snapshot line (active development):** bump the snapshot `NUMBER` on every
+  PR. This is the normal day-to-day case.
+- **Released minor needing an urgent fix:** bump the `PATCH` digit and cut a
+  patch release.
+- **Feature or significant bug fix on a released line:** bump the `MINOR`
+  digit.
+
+Also bump when starting a new branch so the branch starts ahead of `master`.
+PRs without a version bump fail CI.
+
+## How to bump
+
+1. Increment the version in `version.gradle.kts`. Pick the component that
+   matches the release line (see "When to bump"):
+   - **Snapshot PR (default):** `+1` on the snapshot `NUMBER`
+     (e.g. `2.0.0-SNAPSHOT.182` → `2.0.0-SNAPSHOT.183`). Preserve zero-padding
+     (see "Version format").
+   - **Snapshot PR with a breaking change:** advance `NUMBER` to the next
+     multiple of 10 **strictly greater than** the current value (`.187` →
+     `.190`, and also `.180` → `.190` — never stay at the same value).
+     Rounding signals "this PR is significant" to downstream readers.
+   - **Feature/significant fix on a released line:** `+1` on `MINOR`, reset
+     `PATCH` to `0` (e.g. `1.5.3` → `1.6.0`).
+   - **Urgent fix on a released minor:** `+1` on `PATCH`
+     (e.g. `1.5.0` → `1.5.1`).
+2. Commit the version bump as a **separate commit**, with this subject (ASCII
+   arrow `->`, backticked version):
+
+   ```text
+   Bump version -> `2.0.0-SNAPSHOT.183`
+   ```
+
+   When the commit bumps a named dependency rather than the current project's
+   own version, replace `version` with the dependency's display name — the
+   Kotlin `object` name from `buildSrc/src/main/kotlin/io/spine/dependency/local/*.kt`
+   (`Time`, `Validation`, `Logging`, ...). Compound names use the spaced form
+   seen in recent commits (e.g. `CoreJvm Compiler`, `Shadow plugin`). When in
+   doubt, check the prevailing form: `git log --format=%s --grep='^Bump '`.
+
+   ```text
+   Bump Time -> `2.0.0-SNAPSHOT.238`
+   ```
+
+   The arrow style and backticks are the same.
+
+   When a single commit bumps **multiple dependencies**, the `-> \`<version>\``
+   tail is omitted because no single version applies. Use one of:
+
+   ```text
+   Bump Time and Validation
+   Bump local dependencies
+   ```
+
+   Name the dependencies when there are two or three; use the canonical
+   generic form `Bump local dependencies` (the prevailing form in repo
+   history) when more are touched. Confirm against current usage with
+   `git log --format=%s --grep='^Bump '` before inventing a new variant.
+   Prefer one bump-per-dependency when feasible so the arrow form (and its
+   CI-relevant version) is preserved.
+
+3. Rebuild to verify the bump and regenerate dependency reports:
+
+   ```bash
+   ./gradlew clean build
+   ```
+
+   `build` finalizes `generatePom` and `mergeAllLicenseReports`, so `pom.xml`
+   and `dependencies.md` are regenerated automatically when they are produced
+   by this repo's build.
+
+4. If `./gradlew clean build` produced changes to `pom.xml` and/or
+   `dependencies.md`, stage **whichever of the two changed** and commit them
+   as a second commit:
+
+   ```text
+   Update dependency reports
+   ```
+
+   If neither file changed, skip this step — do not create an empty commit.
+
+## Resolving conflicts in `version.gradle.kts`
+
+Use these roles to disambiguate during a merge:
+
+- **base branch:** the branch being merged in (typically `master`).
+- **feature branch:** the branch currently checked out (the one with the open
+  PR).
+
+Resolve as follows:
+
+- If the base branch's number is **less than** the feature branch's, keep the
+  feature branch's version unchanged.
+- If the base branch's number is **greater than or equal to** the feature
+  branch's, set the feature branch's number to `base + 1` (or apply the
+  rounding rule from "How to bump" for a breaking change).
+
+## Validate
+
+- `./gradlew clean build` succeeds after the bump.
+- The bump commit's subject matches the convention. Locate it without assuming
+  it is `HEAD` (a "Update dependency reports" commit may sit on top), and
+  scope to commits introduced on the current branch. Set `BASE` to the
+  branch this PR will merge into — typically `master`, but a release line
+  such as `1.5.x` for a patch release:
+
+  ```bash
+  BASE=master
+  git fetch --quiet origin "$BASE"
+  git log --format=%s "$(git merge-base HEAD origin/$BASE)..HEAD" | grep '^Bump '
+  ```
+
+  The `git fetch` step guards against false negatives in fresh clones,
+  worktrees, or CI checkouts where `origin/$BASE` may not exist locally yet.
+
+- If dependency reports were regenerated, the commit immediately following the
+  bump has subject `Update dependency reports`, and `git status` is clean.
+
+[wiki-versioning]: https://github.com/SpineEventEngine/documentation/wiki/Versioning

--- a/.agents/skills/bump-version/SKILL.md
+++ b/.agents/skills/bump-version/SKILL.md
@@ -14,8 +14,11 @@ description: >
 The authoritative versioning policy is
 [Spine SDK Versioning][wiki-versioning]. This skill encodes the parts of that
 policy that affect day-to-day work in this repo. CI enforces the bump via
-`io.spine.internal.gradle.publish.CheckVersionIncrement`, which inspects the
-version number — not the commit subject.
+`io.spine.gradle.publish.CheckVersionIncrement` (applied through
+`IncrementGuard`): it fetches the project's Maven metadata and fails if the
+current version already exists in the repository. It does **not** diff
+against `master` or any git branch — the gate is "this version must not
+already be published" — and it does not inspect the commit subject.
 
 ## Version format
 

--- a/.agents/skills/bump-version/SKILL.md
+++ b/.agents/skills/bump-version/SKILL.md
@@ -4,134 +4,100 @@ description: >
   Bump the project version in `version.gradle.kts` following the Spine SDK
   versioning policy. Use when starting a new branch, before opening a PR, or
   when CI rejects a branch for a missing/insufficient version increment. Covers
-  version-number selection, the commit-message convention, the post-bump
-  rebuild, dependency-report updates, and conflict resolution against the base
-  branch.
+  locating the published version value, choosing the increment, committing the
+  bump, rebuilding reports, and resolving version conflicts.
 ---
 
 # Bump the project version
 
-The authoritative versioning policy is
-[Spine SDK Versioning][wiki-versioning]. This skill encodes the parts of that
-policy that affect day-to-day work in this repo. CI enforces the bump via
-`io.spine.gradle.publish.CheckVersionIncrement` (applied through
-`IncrementGuard`): it fetches the project's Maven metadata and fails if the
-current version already exists in the repository. It does **not** diff
-against `master` or any git branch — the gate is "this version must not
-already be published" — and it does not inspect the commit subject.
+The authoritative policy is [Spine SDK Versioning][wiki-versioning]. In this
+repo, CI runs `io.spine.gradle.publish.CheckVersionIncrement` through
+`IncrementGuard`; it fails if the current project version already exists in the
+Maven repository. It does not compare git branches or inspect commit subjects.
 
-## Version format
+## Checklist
 
-Versions live in `version.gradle.kts` at the project root, for example:
+1. Locate `version.gradle.kts` and update the value that feeds
+   `versionToPublish`.
 
-```kotlin
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")
-```
+   The published version may be a literal:
 
-Spine uses Semantic Versioning with extensions:
+   ```kotlin
+   val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")
+   ```
 
-- **Snapshot:** `MAJOR.MINOR.PATCH-SNAPSHOT.NUMBER` during active development.
-  The trailing `NUMBER` is the per-PR counter.
-- **Release:** standard semver, such as `1.5.0`.
-- **Patch release:** issued only when an urgent fix is needed against a
-  released minor; bumps the `PATCH` digit (e.g. `1.5.0` → `1.5.1`).
-- **Flavor:** suffixes like `-jdk8` denote a specific build flavor.
+   Or it may come from another variable:
 
-Preserve zero-padding on the snapshot `NUMBER` when it is present:
-`2.0.0-SNAPSHOT.009` → `2.0.0-SNAPSHOT.010`.
+   ```kotlin
+   val compilerVersion: String by extra("2.0.0-SNAPSHOT.043")
+   val versionToPublish by extra(compilerVersion)
+   ```
 
-## When to bump
+   In the second case, update the source value (`compilerVersion` here), not
+   only the `versionToPublish` alias.
 
-Every code advancement must move the version forward. Which component moves
-depends on the release line:
+2. Choose the increment.
 
-- **Snapshot line (active development):** bump the snapshot `NUMBER` on every
-  PR. This is the normal day-to-day case.
-- **Released minor needing an urgent fix:** bump the `PATCH` digit and cut a
-  patch release.
-- **Feature or significant bug fix on a released line:** bump the `MINOR`
-  digit.
+   For the normal snapshot-line PR, increment the trailing snapshot number by
+   one: `2.0.0-SNAPSHOT.182` -> `2.0.0-SNAPSHOT.183`. Preserve existing
+   zero-padding: `2.0.0-SNAPSHOT.009` -> `2.0.0-SNAPSHOT.010`.
 
-Also bump when starting a new branch so the branch starts ahead of `master`.
-PRs without a version bump fail CI.
+   For a breaking snapshot-line PR, advance to the next multiple of 10 that is
+   strictly greater than the current value: `.187` -> `.190`, and `.180` ->
+   `.190`.
 
-## How to bump
+   For release-line work, follow the wiki policy: urgent fixes bump `PATCH`;
+   feature work or significant fixes bump `MINOR` and reset `PATCH` to `0`.
 
-1. Increment the version in `version.gradle.kts`. Pick the component that
-   matches the release line (see "When to bump"):
-   - **Snapshot PR (default):** `+1` on the snapshot `NUMBER`
-     (e.g. `2.0.0-SNAPSHOT.182` → `2.0.0-SNAPSHOT.183`). Preserve zero-padding
-     (see "Version format").
-   - **Snapshot PR with a breaking change:** advance `NUMBER` to the next
-     multiple of 10 **strictly greater than** the current value (`.187` →
-     `.190`, and also `.180` → `.190` — never stay at the same value).
-     Rounding signals "this PR is significant" to downstream readers.
-   - **Feature/significant fix on a released line:** `+1` on `MINOR`, reset
-     `PATCH` to `0` (e.g. `1.5.3` → `1.6.0`).
-   - **Urgent fix on a released minor:** `+1` on `PATCH`
-     (e.g. `1.5.0` → `1.5.1`).
-2. Commit the version bump as a **separate commit**, with this subject (ASCII
-   arrow `->`, backticked version):
+3. Commit only the `version.gradle.kts` change with this subject:
 
    ```text
    Bump version -> `2.0.0-SNAPSHOT.183`
    ```
 
-3. Rebuild to verify the bump and regenerate dependency reports:
+4. Run the build to verify the bump and regenerate reports:
 
    ```bash
    ./gradlew clean build
    ```
 
-   `build` finalizes `generatePom` and `mergeAllLicenseReports`, so `pom.xml`
-   and `dependencies.md` are regenerated automatically when they are produced
-   by this repo's build.
+   Repos using this config commonly finalize `generatePom` and
+   `mergeAllLicenseReports` after `build`, which updates `pom.xml` and
+   `dependencies.md` when those reports are configured.
 
-4. If `./gradlew clean build` produced changes to `pom.xml` and/or
-   `dependencies.md`, stage **whichever of the two changed** and commit them
-   as a second commit:
+5. If `pom.xml`, `dependencies.md`, or `license-report.md` changed, commit
+   those generated files separately:
 
    ```text
    Update dependency reports
    ```
 
-   If neither file changed, skip this step — do not create an empty commit.
+   If the PR has the "License Reports" workflow, make sure the branch modifies
+   `pom.xml` and either `dependencies.md` or `license-report.md`.
 
-## Resolving conflicts in `version.gradle.kts`
+6. Validate the branch state.
 
-Use these roles to disambiguate during a merge:
+   ```bash
+   BASE=master
+   git fetch --quiet origin "$BASE"
+   RANGE="$(git merge-base HEAD origin/$BASE)..HEAD"
+   git log --format=%s "$RANGE" | grep '^Bump version ->'
+   git diff --name-only "$RANGE" -- version.gradle.kts | grep '^version.gradle.kts$'
+   ```
 
-- **base branch:** the branch being merged in (typically `master`).
-- **feature branch:** the branch currently checked out (the one with the open
-  PR).
+   Use the actual merge target for `BASE` when it is not `master`.
 
-Resolve as follows:
+## Conflict Rule
 
-- If the base branch's number is **less than** the feature branch's, keep the
-  feature branch's version unchanged.
-- If the base branch's number is **greater than or equal to** the feature
-  branch's, set the feature branch's number to `base + 1` (or apply the
-  rounding rule from "How to bump" for a breaking change).
+When merging a base branch into a feature branch:
 
-## Validate
+- If the base branch version is lower, keep the feature branch version.
+- If the base branch version is greater than or equal to the feature branch
+  version, set the feature branch version to `base + 1`, or apply the breaking
+  change rounding rule.
 
-- `./gradlew clean build` succeeds after the bump.
-- The bump commit's subject matches the convention. It may not be `HEAD`
-  (a "Update dependency reports" commit can sit on top), so scope to commits
-  introduced on the current branch. Set `BASE` to the branch this PR will
-  merge into — typically `master`, or a release line such as `1.5.x` for a
-  patch release:
-
-  ```bash
-  BASE=master
-  git fetch --quiet origin "$BASE"
-  git log --format=%s "$(git merge-base HEAD origin/$BASE)..HEAD" | grep '^Bump version '
-  ```
-
-  The `git fetch` step guards against false negatives in fresh clones,
-  worktrees, or CI checkouts where `origin/$BASE` may not exist locally yet.
-
-- If dependency reports were regenerated, the commit immediately following the
-  bump has subject `Update dependency reports`, and `git status` is clean.
+Do not require a completely clean worktree if unrelated user changes are
+present. Instead, make sure no uncommitted changes were created by the version
+bump or report regeneration.
 
 [wiki-versioning]: https://github.com/SpineEventEngine/documentation/wiki/Versioning

--- a/.agents/skills/writer/SKILL.md
+++ b/.agents/skills/writer/SKILL.md
@@ -49,6 +49,15 @@ description: >
 
 - Follow `.agents/documentation-guidelines.md` and `.agents/documentation-tasks.md`.
 - Use fenced code blocks for commands and examples; format file/dir names as code.
+- When referencing a documentation page or section in body prose, use typographic
+  double quotation marks only if the visible reference text is the actual page or
+  section title, such as the “Getting started” page or the “Troubleshooting”
+  section. The title normally starts with a capital letter. Do not add these
+  quotes around generic or descriptive links such as “this page”, “the next
+  section”, “declaring constraints”, or `4.3`, even if they point to a page or
+  section. Do not add these quotes in “What’s next” sections or navigation
+  elements. Keep file paths, identifiers, frontmatter values, navigation labels,
+  and Markdown link labels in their expected syntax.
 - In Markdown files, prefer footnote-style reference links for external `https://`
   targets instead of inline links. Write readable body text like
   `[label][short-id]`, then place the URL definition near the end of the file,

--- a/.agents/version-policy.md
+++ b/.agents/version-policy.md
@@ -1,30 +1,15 @@
 # Version policy
 
-## We use semver
-The version of the project is kept in the `version.gradle.kts` file in the root of the project.
+The project follows the [Spine SDK Versioning policy][wiki-versioning].
+The version is kept in `version.gradle.kts` at the project root and follows
+[Semantic Versioning 2.0.0][semver] with Spine-specific extensions
+(snapshot `NUMBER`, patch, and flavor suffixes).
 
-The version numbers in these files follow the conventions of
-[Semantic Versioning 2.0.0](https://semver.org/).
+PRs without a version bump fail CI.
 
-## Quick checklist for versioning
-1. Increment the patch version in `version.gradle.kts`.
-   Retain zero-padding if applicable:
-    - Example: `"2.0.0-SNAPSHOT.009"` → `"2.0.0-SNAPSHOT.010"`
-2. Commit the version bump separately with this comment:
-   ```text
-   Bump version → `$newVersion`
-   ``` 
-3. Rebuild using `./gradlew clean build`.
-4. Update `pom.xml`, `dependencies.md` and commit changes with: `Update dependency reports`
+For the bump procedure — version-number selection, the commit-message
+convention, the rebuild, dependency-report updates, and conflict resolution —
+use the [`bump-version`](skills/bump-version/SKILL.md) skill.
 
-Remember: PRs without version bumps will fail CI (conflict resolution detailed above).
-
-## Resolving conflicts in `version.gradle.kts`
-A branch conflict over the version number should be resolved as described below.
- * If a merged branch has a number which is less than that of the current branch, the version of
-   the current branch stays.
- * If the merged branch has the number which is greater or equal to that of the current branch,
-   the number should be increased by one.
-
-## When to bump the version?
- - When a new branch is created.
+[semver]: https://semver.org/
+[wiki-versioning]: https://github.com/SpineEventEngine/documentation/wiki/Versioning


### PR DESCRIPTION
This PR introduces the `bump-version` skill and updates the `writer` skill with the improvements recently adopted in Validation.