### PR TITLE
Misc improvements

### DIFF
--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   build:
     runs-on: windows-latest
-    name: Build and test on Windows
+    name: Build on Windows
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ pubspec.lock
 # Python cache
 __pycache__/
 *.pyc
+
+# Claude working files
+/.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Agent Guidelines
 Please read and follow all guidelines in the project's agent documentation:
 
-- Start with the table of contents: `./agents/_TOC.md`.
+- Start with the table of contents: `.agents/_TOC.md`.
 - Follow all linked documents from the TOC.
 - Apply all coding standards, formatting rules, and project conventions found in these documents.
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -51,7 +51,7 @@ object CoreJvmCompiler {
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.062"
+    const val version = "2.0.0-SNAPSHOT.063"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/test/kotlin/io/spine/gradle/report/license/DependencyReportOutputTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/report/license/DependencyReportOutputTest.kt
@@ -57,8 +57,6 @@ class DependencyReportOutputTest {
 
     @Test
     fun `write the generated POM under docs-dependencies`() {
-        projectDir.resolve("pom.xml").writeText("legacy POM")
-
         PomGenerator.applyTo(project)
 
         project.tasks.named("generatePom").get()
@@ -70,8 +68,6 @@ class DependencyReportOutputTest {
 
     @Test
     fun `merge license reports under docs-dependencies`() {
-        projectDir.resolve("dependencies.md").writeText("legacy report")
-
         project.pluginManager.apply(BasePlugin::class.java)
         val subproject = subproject("sub")
         LicenseReporter.generateReportIn(subproject)


### PR DESCRIPTION
This PR:
 * Shortens the name of the Windows build workflow.
 * Removes unnecessary creation of legacy dependency reports in tests.
 * Fixes the link to the `_TOC.md` in `CLAUDE.md` file.
 * Fixes the version in `CoreJvmCompiler` dependency object.
