### PR TITLE
Improve `dependency-audit` skill performance

### DIFF
--- a/.agents/skills/dependency-audit/SKILL.md
+++ b/.agents/skills/dependency-audit/SKILL.md
@@ -39,17 +39,35 @@ Each file declares a Kotlin `object` extending `Dependency` or `DependencyWithBo
 
 ## How to run an audit
 
-1. **Scope the diff.**
-   - Run `git diff --stat <base>...HEAD -- 'buildSrc/src/main/kotlin/io/spine/dependency/**'`
-     (or `--staged` if the user is mid-commit) and read the file list.
-   - If the diff is empty, ask the user which files to audit.
+1. **Fetch the full diff once.** Run
+   `git diff <base>...HEAD -- 'buildSrc/src/main/kotlin/io/spine/dependency/**'`
+   (or `--staged` if the user is mid-commit). The unified diff already
+   contains the old and new lines you need for version-sanity and BOM
+   checks — do not call `--stat` first and then re-read each file. If the
+   diff is empty, ask the user which files to audit.
 
-2. **Read each changed file fully.** Don't trust the hunk in isolation —
-   `version` constants are often referenced elsewhere in the same file (e.g.
-   `runtimeVersion` reused as `embeddedVersion`).
+2. **Lean on the diff; `Read` on demand.** Version, BOM, copyright, and
+   deprecation deltas are all visible in the unified diff. Only `Read` a
+   file when (a) it is newly added, or (b) a hunk references a
+   `version`/`group` constant defined outside the hunk and you need
+   surrounding context. **Budget:** if more than 5 files changed, do not
+   `Read` individual files — work from the diff and use targeted `Grep`
+   for cross-cutting questions.
 
-3. **Run the checks below in order. Stop the audit and surface a finding the
-   moment any check fails.**
+3. **Batch independent work into one turn.** Issue the version-sanity (A),
+   convention-drift (D), and cross-cutting (E) tool calls *in parallel*
+   within a single response. Collect every finding and emit the report
+   once — **do not stop at the first failure**.
+
+4. **Batch greps.** For deprecation/caller checks (C) and snapshot-pin
+   checks (A), build one ripgrep over the union of symbols instead of one
+   command per symbol. Examples:
+   - `rg -n '\b(name1|name2|name3)\b' --type kt` to find callers of any
+     removed `const val`.
+   - `rg -L 'Copyright \(c\) 2026' <changed-files>` to flag every stale
+     header in one call.
+   - `rg -n '<lib>:<oldVersion>' --type kt --type gradle` once per
+     library to check for hardcoded pins.
 
 ## Checks
 

--- a/.claude/agents/dependency-audit.md
+++ b/.claude/agents/dependency-audit.md
@@ -2,7 +2,7 @@
 name: dependency-audit
 description: Audits changes to dependency declarations under `buildSrc/src/main/kotlin/io/spine/dependency/` — catches accidental version downgrades, BOM mismatches, missing deprecation markers, copyright drift, and convention drift. Use proactively whenever a diff touches that directory, or when the user asks "audit this dependency bump". Read-only; does not run builds.
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: claude-haiku-4-5-20251001
 ---
 
 Follow the `dependency-audit` skill exactly:
@@ -13,3 +13,7 @@ Follow the `dependency-audit` skill exactly:
   format (Must fix / Should fix / Nits + one-line verdict).
 - Read-only: use `Read`, `Grep`, `Glob`, and `Bash` solely for `git diff`,
   `git grep`, and related read-only inspection. Do not run builds.
+- **Be fast.** Fetch the full unified diff once, work from it, and `Read`
+  individual files only when the skill's step 2 budget allows. Issue
+  independent `Grep`/`Bash` calls in parallel within a single response;
+  do not halt at the first failure — collect all findings and report once.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.387"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.387"
+    const val version = "2.0.0-SNAPSHOT.389"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.389"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.043"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.044"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.043"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.044"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.063"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.065"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.063"
+    const val version = "2.0.0-SNAPSHOT.065"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -40,7 +40,7 @@ import io.spine.dependency.Dependency
 )
 object Time : Dependency() {
     override val group = Spine.group
-    override val version = "2.0.0-SNAPSHOT.238"
+    override val version = "2.0.0-SNAPSHOT.242"
     private const val infix = "spine-time"
 
     fun lib(version: String): String = "$group:$infix:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.415"
+    const val version = "2.0.0-SNAPSHOT.431"
 
     /**
      * The last version of Validation compatible with ProtoData.


### PR DESCRIPTION
This PR improves the speed of the `dependency-audit` skill:
 * The fast model (Haiku) was selected for the job.
 * The skill description was updated to group operations.