### PR TITLE
Bump dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,10 +33,10 @@ import io.spine.dependency.DependencyWithBom
 @Suppress("unused")
 object Jackson : DependencyWithBom() {
     override val group = "com.fasterxml.jackson"
-    override val version = "2.20.0"
+    override val version = "2.21.3"
 
     // https://github.com/FasterXML/jackson-annotations?tab=readme-ov-file#release-notes
-    const val annotationsVersion = "2.20"
+    const val annotationsVersion = "2.21"
 
     // https://github.com/FasterXML/jackson-bom
     override val bom = "$group:jackson-bom:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.389"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.389"
+    const val version = "2.0.0-SNAPSHOT.390"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.390"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.431"
+    const val version = "2.0.0-SNAPSHOT.433"
 
     /**
      * The last version of Validation compatible with ProtoData.


### PR DESCRIPTION
This PR updates recently released local dependencies, and Jackson per #655.