### PR TITLE
Add `api-discovery` skill

### DIFF
--- a/.agents/scripts/api-discovery/.gitignore
+++ b/.agents/scripts/api-discovery/.gitignore
@@ -1,0 +1,3 @@
+# Per-developer override of <workspace-root> for the api-discovery
+# extraction cache. Contains an absolute path; do not commit.
+.workspace-root

--- a/.agents/scripts/api-discovery/README.md
+++ b/.agents/scripts/api-discovery/README.md
@@ -1,0 +1,118 @@
+# `api-discovery` scripts
+
+Resolve the on-disk location of a Maven artifact's source code for
+agents and developers, without repeatedly `unzip`-ing JARs out of the
+Gradle cache.
+
+The agent-facing documentation lives in
+[`../../skills/api-discovery/SKILL.md`](../../skills/api-discovery/SKILL.md);
+this file is the implementation reference.
+
+## Why
+
+Agents investigating library APIs used to run dozens of `find
+~/.gradle/caches` + `unzip -l` + `unzip -p` calls per question. Each
+`unzip` decompresses the archive from scratch — slow and token-heavy.
+
+This package replaces that pattern with two cheap reads:
+
+1. **Sibling-first** — every Spine artifact maps to a sibling clone
+   under `<workspace-root>/<repo>/`. The source tree is already on
+   disk; we just resolve the right submodule path.
+2. **Extraction cache** — non-Spine artifacts (Jackson, Guava, etc.)
+   have their `-sources.jar` extracted **once** to a per-workstation
+   cache. Subsequent queries return instantly.
+
+## Layout
+
+```
+.agents/scripts/api-discovery/
+├── README.md           # this file
+├── lib/common.sh       # shared bash helpers
+├── discover            # main entry — resolve a coordinate to a path
+├── extract-sources     # one-shot JAR extraction (race-safe)
+└── clean-cache         # prune the extraction cache
+```
+
+The cache itself is **not** under the repo. It lives at:
+
+```
+<workspace-root>/.agents/caches/api-discovery/sources/<group>/<artifact>/<version>/
+```
+
+`<workspace-root>` defaults to the parent of the consumer repo (e.g.
+`/Users/<you>/Projects/Spine/` when the consumer repo is
+`.../Spine/config/`). To override, write the absolute path to an
+alternative root into `.workspace-root` next to this README (the
+script is gitignored).
+
+## Bootstrap
+
+First-time use needs the cache directory created. The scripts detect
+its absence and exit `10`; the skill instructs the agent to ask the
+user whether to:
+
+1. **Approve** the default path,
+2. **Provide an alternative** workspace root,
+3. **Disable** the cache for this repo (recorded in per-developer
+   auto-memory; sibling-first resolution still works).
+
+## Scripts
+
+### `discover`
+
+```
+discover <group>:<artifact>:<version>
+discover <group>:<artifact>           # version pulled from buildSrc
+discover <artifact>                   # Spine-only; group + version inferred
+```
+
+- **stdout** — absolute path to a directory you can `Grep`/`Read`.
+- **stderr** — `STALE` warnings when the sibling's `versionToPublish`
+  differs from the declared dependency version, plus other
+  diagnostics. Always inspect.
+- **exit 0** — path resolved (even if stale; the warning is on stderr).
+- **exit 1** — unresolvable (missing sibling AND no sources JAR).
+- **exit 10** — cache uninitialized; run the bootstrap flow.
+
+### `extract-sources`
+
+```
+extract-sources <group>:<artifact>:<version>
+```
+
+Idempotent and race-safe. If the target directory is already populated
+the script returns its path immediately. Concurrent first-time
+extractions race on an atomic `mv` of a per-PID temp directory; the
+loser discards its temp.
+
+### `clean-cache`
+
+```
+clean-cache --dry-run
+clean-cache --older-than 30d [--dry-run]
+clean-cache --all [--dry-run]
+```
+
+Manual pruning only. Nothing runs on a timer.
+
+## Conventions
+
+- **Bash 3.2 compatible** — macOS ships 3.2 by default.
+- **No external dependencies** beyond `bash`, coreutils, `grep`,
+  `sed`, `awk`, `unzip`, `find`.
+- **stdout** is always the answer; **stderr** is diagnostics. Mix
+  them only by piping.
+- Scripts source `lib/common.sh` after setting
+  `SPINE_API_DISCOVERY_DIR`, so the workspace-root pointer file is
+  reachable.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `cache not initialized` (exit 10) | Bootstrap not run | Follow the skill's bootstrap prompt |
+| `sibling not on disk` | Spine repo not cloned | `git clone` it next to your consumer repo |
+| `STALE: ...` | Sibling drifted from declared version | Pull the sibling, or accept the warning |
+| `is in the Gradle cache but publishes no -sources.jar` | Upstream artifact has no sources | Read the binary `.class` files via a different tool, or look at GitHub directly |
+| `is not in the local Gradle cache` | Gradle has not fetched the dep | `./gradlew dependencies` to populate, then retry |

--- a/.agents/scripts/api-discovery/README.md
+++ b/.agents/scripts/api-discovery/README.md
@@ -139,7 +139,8 @@ Manual pruning only. Nothing runs on a timer.
 
 - **Bash 3.2 compatible** — macOS ships 3.2 by default.
 - **No external dependencies** beyond `bash`, coreutils, `grep`,
-  `sed`, `awk`, `unzip`, `find`.
+  `sed`, `awk`, `unzip`, `find`, and `git` (used only by
+  `update-sibling`).
 - **stdout** is always the answer; **stderr** is diagnostics. Mix
   them only by piping.
 - Scripts source `lib/common.sh` after setting

--- a/.agents/scripts/api-discovery/README.md
+++ b/.agents/scripts/api-discovery/README.md
@@ -31,6 +31,7 @@ This package replaces that pattern with two cheap reads:
 ├── lib/common.sh       # shared bash helpers
 ├── discover            # main entry — resolve a coordinate to a path
 ├── extract-sources     # one-shot JAR extraction (race-safe)
+├── update-sibling      # `git pull --ff-only` a stale sibling (safe-guarded)
 └── clean-cache         # prune the extraction cache
 ```
 
@@ -86,6 +87,44 @@ the script returns its path immediately. Concurrent first-time
 extractions race on an atomic `mv` of a per-PID temp directory; the
 loser discards its temp.
 
+### `update-sibling`
+
+```
+update-sibling <sibling-name>            # resolved under <workspace-root>
+update-sibling <absolute-path>           # acts on that path directly
+```
+
+Invoked by the agent (after user consent) when `discover` emits a
+`STALE` warning. Safe by design:
+
+- Pulls **only** when the sibling is on `master` or `main` with a
+  clean working tree and a tracked upstream.
+- On any other branch, exits `0` without touching anything — the
+  user's "advancing multiple subprojects at once" workflow keeps
+  feature branches checked out as intentional staging state.
+- Refuses on detached HEAD (`3`), uncommitted changes (`4`), or
+  missing upstream (`5`).
+- Never switches branches, never `--rebase`, never `--force`.
+
+On success (exit `0`), the script writes a single stable token to
+**stdout** that names the outcome — callers should branch on the
+token, not on stderr text. Failure paths produce empty stdout.
+
+Exit codes:
+
+| Code | stdout | Meaning |
+|---|---|---|
+| `0` | `pulled` | HEAD advanced to upstream tip |
+| `0` | `up-to-date` | Already at upstream tip; nothing to do |
+| `0` | `skipped-branch` | On a non-default branch; left untouched |
+| `1` | _(empty)_ | Sibling not on disk |
+| `2` | _(empty)_ | Not a git repository |
+| `3` | _(empty)_ | Detached HEAD — refused |
+| `4` | _(empty)_ | Working tree dirty — refused |
+| `5` | _(empty)_ | No upstream tracking on default branch — refused |
+| `6` | _(empty)_ | `git pull --ff-only` failed (divergence, network, etc.) |
+| `64` | _(empty)_ | Usage error (no/too many arguments) — BSD `sysexits(3)` convention |
+
 ### `clean-cache`
 
 ```
@@ -113,6 +152,6 @@ Manual pruning only. Nothing runs on a timer.
 |---|---|---|
 | `cache not initialized` (exit 10) | Bootstrap not run | Follow the skill's bootstrap prompt |
 | `sibling not on disk` | Spine repo not cloned | `git clone` it next to your consumer repo |
-| `STALE: ...` | Sibling drifted from declared version | Pull the sibling, or accept the warning |
+| `STALE: ...` | Sibling drifted from declared version | Run `update-sibling <path>` (auto-skips feature branches), or accept the warning |
 | `is in the Gradle cache but publishes no -sources.jar` | Upstream artifact has no sources | Read the binary `.class` files via a different tool, or look at GitHub directly |
 | `is not in the local Gradle cache` | Gradle has not fetched the dep | `./gradlew dependencies` to populate, then retry |

--- a/.agents/scripts/api-discovery/clean-cache
+++ b/.agents/scripts/api-discovery/clean-cache
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Prune the workstation api-discovery extraction cache.
+#
+# Usage:
+#   clean-cache --dry-run              # list what would be removed (no deletes)
+#   clean-cache --older-than 30d       # remove entries older than 30 days
+#   clean-cache --older-than 7d --dry-run
+#   clean-cache --all                  # wipe the whole sources cache
+#   clean-cache --all --dry-run
+#
+# The cache is at
+# `<workspace-root>/.agents/caches/api-discovery/sources/<group>/<artifact>/<version>/`.
+# "Age" is the directory's mtime (recorded at extraction time).
+#
+# Exit codes (see lib/common.sh):
+#   0  — succeeded (with or without removals).
+#   1  — bad arguments or filesystem error.
+#   10 — cache not initialized (nothing to clean).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SPINE_API_DISCOVERY_DIR="$SCRIPT_DIR"
+export SPINE_API_DISCOVERY_DIR
+# shellcheck source=lib/common.sh
+. "$SCRIPT_DIR/lib/common.sh"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  clean-cache --dry-run
+  clean-cache --older-than <DURATION> [--dry-run]
+  clean-cache --all [--dry-run]
+
+DURATION is a `find -mtime`-style suffix: `7d`, `30d`, `90d` (days only).
+EOF
+    exit "$EX_FAIL"
+}
+
+mode=""
+days=""
+dry_run=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --all)
+            mode="all"
+            shift
+            ;;
+        --older-than)
+            mode="older-than"
+            shift
+            [ "$#" -gt 0 ] || usage
+            case "$1" in
+                *d) days="${1%d}" ;;
+                *)  log_warn "duration must end in 'd' (days), got: $1"; usage ;;
+            esac
+            case "$days" in
+                ''|*[!0-9]*) log_warn "duration days must be numeric, got: $1"; usage ;;
+            esac
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            log_warn "unknown argument: $1"
+            usage
+            ;;
+    esac
+done
+
+# Default to a no-op listing if no mode was given.
+[ -n "$mode" ] || mode="older-than-default"
+
+if ! cache_initialized; then
+    log_warn "cache not initialized: $(cache_root)"
+    exit "$EX_NO_CACHE"
+fi
+
+sources="$(sources_root)"
+
+# Collect targets into a temp list so we can preview and act consistently.
+list_file="$(mktemp -t api-discovery-clean.XXXXXX)"
+trap 'rm -f -- "$list_file"' EXIT
+
+case "$mode" in
+    all)
+        find "$sources" -mindepth 3 -maxdepth 3 -type d -print > "$list_file" 2>/dev/null || true
+        ;;
+    older-than)
+        find "$sources" -mindepth 3 -maxdepth 3 -type d -mtime "+$days" -print \
+            > "$list_file" 2>/dev/null || true
+        ;;
+    older-than-default)
+        log_warn "no mode specified; use --all or --older-than <N>d"
+        usage
+        ;;
+esac
+
+count="$(wc -l < "$list_file" | tr -d '[:space:]')"
+
+# Prune now-empty `<group>/` and `<group>/<artifact>/` parents so the cache
+# layout stays tidy. Two passes (artifact dirs first, then group dirs) so
+# that emptying a group's last artifact also reclaims the group dir.
+# Skipped under --dry-run so the command stays read-only.
+prune_empty_parents() {
+    find "$sources" -mindepth 2 -maxdepth 2 -type d -empty -exec rmdir -- {} + \
+        2>/dev/null || true
+    find "$sources" -mindepth 1 -maxdepth 1 -type d -empty -exec rmdir -- {} + \
+        2>/dev/null || true
+}
+
+if [ "$count" -eq 0 ]; then
+    log_warn "no entries match; cache untouched"
+    [ "$dry_run" -eq 0 ] && prune_empty_parents
+    exit "$EX_OK"
+fi
+
+if [ "$dry_run" -eq 1 ]; then
+    log_warn "would remove $count entr$( [ "$count" -eq 1 ] && printf 'y' || printf 'ies' ):"
+    cat -- "$list_file"
+    exit "$EX_OK"
+fi
+
+removed=0
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if rm -rf -- "$path"; then
+        removed=$((removed + 1))
+    else
+        log_warn "failed to remove: $path"
+    fi
+done < "$list_file"
+
+prune_empty_parents
+
+log_warn "removed $removed entr$( [ "$removed" -eq 1 ] && printf 'y' || printf 'ies' )"
+exit "$EX_OK"

--- a/.agents/scripts/api-discovery/discover
+++ b/.agents/scripts/api-discovery/discover
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Resolve the on-disk location of source code for a Maven artifact, so
+# agents can `Grep`/`Read` it directly instead of repeatedly `unzip`ing
+# sources JARs out of the Gradle cache.
+#
+# Strategy:
+#   1. Spine artifacts (group = io.spine / io.spine.tools / etc.) are
+#      served from a sibling clone under `<workspace-root>/<repo>/`. The
+#      sibling is identified from the `github.com/SpineEventEngine/<repo>`
+#      URL inside the matching `buildSrc/.../dependency/local/<X>.kt`
+#      file. Submodule paths are resolved by trying canonical name
+#      transformations (see `resolve_submodule_path`).
+#   2. Anything else (and Spine fallbacks when no sibling is on disk)
+#      is served from the per-workstation extraction cache populated by
+#      `extract-sources`.
+#
+# Usage:
+#   discover <group>:<artifact>:<version>
+#   discover <group>:<artifact>
+#   discover <artifact>
+#
+# Output:
+#   stdout: absolute path to a directory containing the source tree.
+#   stderr: freshness warnings and explanatory diagnostics. Always
+#           inspect stderr before relying on the resolved path.
+#
+# Exit codes (see lib/common.sh):
+#   0  — path resolved (path on stdout).
+#   1  — unresolvable (sibling missing AND extraction failed).
+#   10 — workstation cache directory not initialized; run the
+#        api-discovery bootstrap flow described in the skill.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SPINE_API_DISCOVERY_DIR="$SCRIPT_DIR"
+export SPINE_API_DISCOVERY_DIR
+# shellcheck source=lib/common.sh
+. "$SCRIPT_DIR/lib/common.sh"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: discover <query>
+
+Where <query> is one of:
+  group:artifact:version    e.g. io.spine:spine-base:2.0.0-SNAPSHOT.390
+  group:artifact            e.g. io.spine:spine-base
+  artifact                  e.g. spine-base
+
+Spine artifacts resolve to the local sibling clone; non-Spine
+artifacts resolve to the extracted-sources cache.
+EOF
+    exit "$EX_FAIL"
+}
+
+[ "$#" -eq 1 ] || usage
+
+parse_query "$1"
+group="$Q_GROUP"
+artifact="$Q_ARTIFACT"
+version="$Q_VERSION"
+
+if [ -z "$artifact" ]; then
+    log_warn "empty artifact in query: $1"
+    exit "$EX_FAIL"
+fi
+
+# Bootstrap check. The skill handles the user prompt on EX_NO_CACHE.
+if ! cache_initialized; then
+    log_warn "cache not initialized: $(cache_root)"
+    log_warn "run the api-discovery bootstrap flow (see SKILL.md) to create it"
+    exit "$EX_NO_CACHE"
+fi
+
+# Try the sibling path for Spine artifacts. If the group is empty we
+# still attempt the local-deps lookup; a hit means it's a Spine artifact.
+try_sibling() {
+    local dep_file
+    dep_file="$(find_local_dep_file_for_artifact "$artifact")"
+    [ -n "$dep_file" ] || return 1
+
+    local sibling_name workspace sibling_path
+    sibling_name="$(sibling_name_from_dep_file "$dep_file")"
+    workspace="$(workspace_root)" || return 1
+    sibling_path="$workspace/$sibling_name"
+
+    if [ ! -d "$sibling_path" ]; then
+        log_warn "sibling not on disk: $sibling_path (declared in $dep_file)"
+        return 1
+    fi
+
+    local module_path
+    module_path="$(resolve_submodule_path "$sibling_path" "$artifact")"
+
+    if [ ! -d "$module_path" ]; then
+        log_warn "resolved submodule path missing: $module_path"
+        return 1
+    fi
+
+    # Freshness check: declared version vs sibling's published version.
+    local declared sibling_v
+    declared="${version:-$(read_declared_version "$dep_file" || true)}"
+    sibling_v="$(read_sibling_version "$sibling_path" 2>/dev/null || true)"
+
+    if [ -n "$declared" ] && [ -n "$sibling_v" ] && \
+       [ "$declared" != "$sibling_v" ]; then
+        log_warn "STALE: $artifact declared $declared in $(basename -- "$dep_file") but sibling publishes $sibling_v"
+        log_warn "sources at $module_path may differ from the published artifact"
+    fi
+
+    printf '%s\n' "$module_path"
+    return 0
+}
+
+# Try sibling first when it could plausibly be a Spine artifact.
+if [ -z "$group" ] || is_spine_group "$group"; then
+    if try_sibling; then
+        exit "$EX_OK"
+    fi
+fi
+
+# Fall back to the extraction cache. This needs a full coordinate.
+if [ -z "$group" ] || [ -z "$artifact" ] || [ -z "$version" ]; then
+    # Try to fill in the missing pieces from a local dep file.
+    if [ -z "$version" ]; then
+        dep_file="$(find_local_dep_file_for_artifact "$artifact" || true)"
+        if [ -n "$dep_file" ]; then
+            version="$(read_declared_version "$dep_file" || true)"
+        fi
+    fi
+    if [ -z "$group" ]; then
+        # The local Spine objects all use Spine.group / Spine.toolsGroup.
+        # Without a sibling hit we can't disambiguate; require explicit group.
+        log_warn "cannot resolve $artifact without a Maven group"
+        log_warn "retry with <group>:<artifact>[:<version>]"
+        exit "$EX_FAIL"
+    fi
+    if [ -z "$version" ]; then
+        log_warn "cannot resolve $group:$artifact without a version"
+        log_warn "retry with <group>:<artifact>:<version>"
+        exit "$EX_FAIL"
+    fi
+fi
+
+# Delegate to extract-sources. It handles "already cached" by returning
+# the path immediately, so this path is fast on repeat queries.
+# The `|| exit $?` idiom propagates extract-sources' exit code under
+# `set -e`; do NOT split into `target=...; status=$?` — `set -e` may
+# terminate the script before the status check runs.
+target="$("$SCRIPT_DIR/extract-sources" "$group:$artifact:$version")" || exit $?
+
+printf '%s\n' "$target"

--- a/.agents/scripts/api-discovery/discover
+++ b/.agents/scripts/api-discovery/discover
@@ -28,8 +28,10 @@
 # Exit codes (see lib/common.sh):
 #   0  — path resolved (path on stdout).
 #   1  — unresolvable (sibling missing AND extraction failed).
-#   10 — workstation cache directory not initialized; run the
-#        api-discovery bootstrap flow described in the skill.
+#   10 — workstation cache directory not initialized AND the query
+#        requires the cache (i.e. sibling-first did not succeed).
+#        Spine-sibling resolution never triggers EX_NO_CACHE — the
+#        skill's "Non-cached" mode keeps working without bootstrap.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -65,12 +67,11 @@ if [ -z "$artifact" ]; then
     exit "$EX_FAIL"
 fi
 
-# Bootstrap check. The skill handles the user prompt on EX_NO_CACHE.
-if ! cache_initialized; then
-    log_warn "cache not initialized: $(cache_root)"
-    log_warn "run the api-discovery bootstrap flow (see SKILL.md) to create it"
-    exit "$EX_NO_CACHE"
-fi
+# NOTE: We intentionally do NOT check `cache_initialized` here. The
+# Spine-sibling path doesn't need the cache, and the skill's
+# "Non-cached" bootstrap option must keep that path working without
+# bootstrap. If we end up falling through to `extract-sources`, that
+# script enforces the cache check on its own and raises EX_NO_CACHE.
 
 # Try the sibling path for Spine artifacts. If the group is empty we
 # still attempt the local-deps lookup; a hit means it's a Spine artifact.

--- a/.agents/scripts/api-discovery/extract-sources
+++ b/.agents/scripts/api-discovery/extract-sources
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Extract a `-sources.jar` from the local Gradle cache into the workstation
+# api-discovery cache. Idempotent and race-safe: a second invocation that
+# observes an existing target returns immediately; concurrent first-time
+# extractions race on the atomic `mv` of a per-PID temp directory.
+#
+# Usage:
+#   extract-sources <group>:<artifact>:<version>
+#
+# Output:
+#   stdout: absolute path to the extracted source tree.
+#   stderr: explanatory diagnostics on cache misses or failures.
+#
+# Exit codes (see lib/common.sh for the shared definitions):
+#   0  — extraction successful (or already cached).
+#   1  — sources unavailable (missing JAR, no `-sources` variant, etc.).
+#   10 — workstation cache directory not initialized.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SPINE_API_DISCOVERY_DIR="$SCRIPT_DIR"
+export SPINE_API_DISCOVERY_DIR
+# shellcheck source=lib/common.sh
+. "$SCRIPT_DIR/lib/common.sh"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: extract-sources <group>:<artifact>:<version>
+
+Extracts the matching `-sources.jar` from the local Gradle cache into
+`<workspace>/.agents/caches/api-discovery/sources/<group>/<artifact>/<version>/`.
+EOF
+    exit "$EX_FAIL"
+}
+
+[ "$#" -eq 1 ] || usage
+
+parse_query "$1"
+group="$Q_GROUP"
+artifact="$Q_ARTIFACT"
+version="$Q_VERSION"
+
+if [ -z "$group" ] || [ -z "$artifact" ] || [ -z "$version" ]; then
+    log_warn "extract-sources requires a full coordinate <group>:<artifact>:<version>"
+    exit "$EX_FAIL"
+fi
+
+if ! cache_initialized; then
+    log_warn "cache not initialized: $(cache_root)"
+    log_warn "run the api-discovery bootstrap flow to create it"
+    exit "$EX_NO_CACHE"
+fi
+
+target="$(sources_root)/$group/$artifact/$version"
+
+if [ -d "$target" ] && [ -n "$(ls -A -- "$target" 2>/dev/null)" ]; then
+    printf '%s\n' "$target"
+    exit "$EX_OK"
+fi
+
+sources_jar="$(find_gradle_cache_jar "$group" "$artifact" "$version" -sources)"
+if [ -z "$sources_jar" ]; then
+    if [ -n "$(find_gradle_cache_jar "$group" "$artifact" "$version")" ]; then
+        log_warn "$group:$artifact:$version is in the Gradle cache but publishes no -sources.jar"
+        exit "$EX_FAIL"
+    fi
+    log_warn "$group:$artifact:$version is not in the local Gradle cache"
+    log_warn "run './gradlew dependencies' (or rebuild) to fetch it, then retry"
+    exit "$EX_FAIL"
+fi
+
+parent="$(dirname -- "$target")"
+mkdir -p -- "$parent"
+
+# Race-safe extraction:
+#   1) extract into a sibling temp dir whose name embeds our PID,
+#   2) check that the final target does not yet exist (race-lost
+#      detection); if it does, drop our temp and use the existing tree,
+#   3) otherwise `mv tmp target`. Note that on macOS/Linux, `mv` into an
+#      existing directory silently moves the source INSIDE it — we cannot
+#      rely on `mv` failing when the race is lost. The pre-test catches
+#      the common case; step 4 catches the narrow window between test
+#      and mv.
+#   4) post-mv, detect the rare race where `target` materialized between
+#      our existence test and the mv: in that case `target/<basename tmp>`
+#      now exists; remove it.
+tmp="${target}.tmp.$$"
+trap 'rm -rf -- "$tmp"' EXIT
+rm -rf -- "$tmp"
+mkdir -p -- "$tmp"
+
+if ! unzip -q -o -- "$sources_jar" -d "$tmp"; then
+    log_warn "unzip failed for $sources_jar"
+    exit "$EX_FAIL"
+fi
+
+if [ -e "$target" ]; then
+    # Another process beat us to it. Discard our temp; use theirs.
+    rm -rf -- "$tmp"
+else
+    if ! mv -- "$tmp" "$target"; then
+        log_warn "could not move extracted sources into $target"
+        exit "$EX_FAIL"
+    fi
+    # Close the narrow race window: if `target` appeared between the
+    # existence test and the mv, `mv` silently moved `$tmp` INSIDE the
+    # winning extraction. Clean up the nested debris.
+    nested="$target/$(basename -- "$tmp")"
+    if [ -e "$nested" ]; then
+        rm -rf -- "$nested"
+    fi
+fi
+trap - EXIT
+
+log_warn "extracted $group:$artifact:$version -> $target"
+printf '%s\n' "$target"

--- a/.agents/scripts/api-discovery/lib/common.sh
+++ b/.agents/scripts/api-discovery/lib/common.sh
@@ -49,8 +49,13 @@ workspace_root() {
     fi
     local pointer="$scripts_dir/.workspace-root"
     if [ -f "$pointer" ]; then
-        local custom
-        custom="$(head -n 1 "$pointer" | tr -d '[:space:]')"
+        # Read the first line verbatim. `IFS=` keeps internal spaces
+        # (paths like `/Users/me/Spine Workspace` must survive intact);
+        # `read -r` strips the trailing newline. Strip a stray CR for
+        # Windows-style line endings.
+        local custom=""
+        IFS= read -r custom < "$pointer" 2>/dev/null || true
+        custom="${custom%$'\r'}"
         if [ -n "$custom" ] && [ -d "$custom" ]; then
             printf '%s\n' "$custom"
             return 0

--- a/.agents/scripts/api-discovery/lib/common.sh
+++ b/.agents/scripts/api-discovery/lib/common.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the api-discovery scripts.
+# Sourced by ../discover, ../extract-sources, ../clean-cache.
+#
+# All functions write diagnostics to stderr; "return values" go to stdout.
+#
+# Conventions:
+#   - Bash 3.2 compatible (macOS default).
+#   - No external deps beyond coreutils, grep, sed, unzip.
+#   - `set -euo pipefail` is set by the caller, not here.
+
+# Exit codes used across the scripts.
+readonly EX_OK=0
+readonly EX_FAIL=1
+readonly EX_NO_CACHE=10        # cache uninitialized; agent runs bootstrap
+
+# Resolve the consumer repository root — the nearest ancestor of $PWD
+# containing `buildSrc/src/main/kotlin/io/spine/dependency/`. Falls back to
+# CLAUDE_PROJECT_DIR (set by Claude Code) if no such ancestor exists.
+# Prints the absolute path to stdout. Exits non-zero if it cannot resolve.
+consumer_repo_root() {
+    local dir="${1:-$PWD}"
+    while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+        if [ -d "$dir/buildSrc/src/main/kotlin/io/spine/dependency" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir="$(dirname -- "$dir")"
+    done
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+       [ -d "$CLAUDE_PROJECT_DIR/buildSrc/src/main/kotlin/io/spine/dependency" ]; then
+        printf '%s\n' "$CLAUDE_PROJECT_DIR"
+        return 0
+    fi
+    return 1
+}
+
+# Resolve the workspace root (parent of the consumer repo by default).
+# Honors an optional pointer file at
+# `<scripts-dir>/.workspace-root` containing an absolute path; used when the
+# user picks "alternative root" during bootstrap.
+workspace_root() {
+    local scripts_dir="${SPINE_API_DISCOVERY_DIR:-}"
+    if [ -z "$scripts_dir" ]; then
+        local repo
+        repo="$(consumer_repo_root)" || return 1
+        scripts_dir="$repo/.agents/scripts/api-discovery"
+    fi
+    local pointer="$scripts_dir/.workspace-root"
+    if [ -f "$pointer" ]; then
+        local custom
+        custom="$(head -n 1 "$pointer" | tr -d '[:space:]')"
+        if [ -n "$custom" ] && [ -d "$custom" ]; then
+            printf '%s\n' "$custom"
+            return 0
+        fi
+    fi
+    local repo
+    repo="$(consumer_repo_root)" || return 1
+    (cd "$repo/.." && pwd)
+}
+
+# Directory that holds the per-workstation api-discovery cache.
+cache_root() {
+    local ws
+    ws="$(workspace_root)" || return 1
+    printf '%s/.agents/caches/api-discovery\n' "$ws"
+}
+
+# Subdirectory under cache_root where extracted sources live.
+sources_root() {
+    local root
+    root="$(cache_root)" || return 1
+    printf '%s/sources\n' "$root"
+}
+
+# Returns 0 if the sources cache directory exists; 1 otherwise.
+cache_initialized() {
+    local s
+    s="$(sources_root)" || return 1
+    [ -d "$s" ]
+}
+
+# Returns the first Gradle-cache JAR path matching the coordinates and
+# optional suffix ("-sources" or empty). Empty stdout means "not found".
+find_gradle_cache_jar() {
+    local group="$1" artifact="$2" version="$3" suffix="${4:-}"
+    local base="$HOME/.gradle/caches/modules-2/files-2.1/$group/$artifact/$version"
+    [ -d "$base" ] || return 0
+    local jar
+    jar="$(find "$base" -maxdepth 2 -type f \
+              -name "${artifact}-${version}${suffix}.jar" 2>/dev/null \
+              | head -n 1)"
+    [ -n "$jar" ] && printf '%s\n' "$jar"
+    return 0
+}
+
+# Extract the canonical `const val version` value from a Spine local/<X>.kt
+# file. Anchors at line start (with optional access modifier) so that
+# `const val version` strings inside KDoc, comments, or other quoted text
+# do not match. Each local/<X>.kt is expected to declare exactly one
+# top-level `version` constant; multi-artifact files use different
+# constant names (e.g. `mcVersion`) for their non-canonical versions.
+read_declared_version() {
+    local file="$1"
+    [ -f "$file" ] || return 1
+    sed -nE 's/^[[:space:]]*(private[[:space:]]+|internal[[:space:]]+|public[[:space:]]+|protected[[:space:]]+)?const[[:space:]]+val[[:space:]]+version[[:space:]]*=[[:space:]]*"([^"]+)".*/\2/p' \
+        "$file" | head -n 1
+}
+
+# Read a `val <NAME>[: Type] by extra("VALUE")` declaration from a file.
+# Prints VALUE on stdout; empty if not found.
+_read_extra_val() {
+    local file="$1" name="$2"
+    sed -nE 's/^[[:space:]]*val[[:space:]]+'"$name"'([[:space:]]*:[[:space:]]*[A-Za-z]+)?[[:space:]]+by[[:space:]]+extra\("([^"]+)"\).*/\2/p' \
+        "$file" | head -n 1
+}
+
+# Read the sibling's "main" version from `<sibling>/version.gradle.kts`.
+# Tries (in order):
+#   1. `versionToPublish` — canonical name used by most siblings.
+#   2. `<camelCaseLower(basename(sibling))>Version` — e.g. `mcJavaVersion`
+#      for sibling `mc-java`, `protoDataVersion` for `ProtoData`.
+# Returns non-zero if neither is found; callers treat that as
+# "freshness check unavailable".
+read_sibling_version() {
+    local sibling="$1"
+    local file="$sibling/version.gradle.kts"
+    [ -f "$file" ] || return 1
+
+    local v
+    v="$(_read_extra_val "$file" "versionToPublish")"
+    if [ -n "$v" ]; then
+        printf '%s\n' "$v"
+        return 0
+    fi
+
+    local sibling_name camel
+    sibling_name="$(basename -- "$sibling")"
+    camel="$(camel_case_lower "$sibling_name")Version"
+    v="$(_read_extra_val "$file" "$camel")"
+    if [ -n "$v" ]; then
+        printf '%s\n' "$v"
+        return 0
+    fi
+
+    return 1
+}
+
+# Convert a PascalCase name to kebab-case.
+# Examples: Base -> base; CoreJvm -> core-jvm; CoreJvmCompiler -> core-jvm-compiler.
+kebab_case() {
+    printf '%s\n' "$1" | sed -E 's/([a-z0-9])([A-Z])/\1-\2/g; s/([A-Z]+)([A-Z][a-z])/\1-\2/g' \
+        | tr '[:upper:]' '[:lower:]'
+}
+
+# Convert a kebab-case or PascalCase name to camelCase (first letter lowercase).
+# Examples: base-libraries -> baseLibraries; mc-java -> mcJava;
+#          core-jvm-compiler -> coreJvmCompiler; ProtoData -> protoData.
+camel_case_lower() {
+    local input="$1"
+    local pascal
+    pascal="$(printf '%s\n' "$input" | awk -F- '{
+        out=""
+        for (i = 1; i <= NF; i++) {
+            out = out toupper(substr($i, 1, 1)) substr($i, 2)
+        }
+        print out
+    }')"
+    local first rest
+    first="$(printf '%s' "$pascal" | cut -c1 | tr '[:upper:]' '[:lower:]')"
+    rest="$(printf '%s' "$pascal" | cut -c2-)"
+    printf '%s%s\n' "$first" "$rest"
+}
+
+# Given a Spine local/<X>.kt file, deduce its sibling repository name.
+# Priority:
+#   1. `https://github.com/SpineEventEngine/<NAME>` URL inside the file.
+#   2. kebab-case of the file's basename (without `.kt`).
+sibling_name_from_dep_file() {
+    local file="$1"
+    [ -f "$file" ] || return 1
+    local from_url
+    from_url="$(sed -nE 's|.*github\.com/SpineEventEngine/([A-Za-z0-9._-]+).*|\1|p' \
+                "$file" | head -n 1)"
+    if [ -n "$from_url" ]; then
+        # Trim any trailing slash or punctuation.
+        from_url="${from_url%/}"
+        printf '%s\n' "$from_url"
+        return 0
+    fi
+    local base
+    base="$(basename -- "$file" .kt)"
+    kebab_case "$base"
+}
+
+# Returns 0 if the given directory contains a Kotlin/Java source set.
+# Recognizes plain `src/main` and Kotlin Multiplatform names such as
+# `src/commonMain`, `src/jvmMain`, `src/jsMain`, `src/nativeMain`.
+has_source_set() {
+    local dir="$1"
+    [ -d "$dir/src" ] || return 1
+    local candidate
+    for candidate in main commonMain jvmMain jsMain nativeMain; do
+        [ -d "$dir/src/$candidate" ] && return 0
+    done
+    return 1
+}
+
+# Resolve a submodule inside a sibling that owns a given artifact.
+# Tries candidate subdirectory names in order, returning the first that
+# contains a recognizable source set:
+#   1. Sibling root (single-module siblings such as `reflect`, `testlib`).
+#   2. `<sibling>/<artifact>`  (artifact name == submodule name).
+#   3. `<sibling>/<artifact-with-`spine-`-stripped>`
+#      (`spine-base` -> `base-libraries/base`).
+#   4. `<sibling>/<artifact-with-`spine-<lowercase-sibling>-`-stripped>`
+#      (`spine-protodata-backend` -> `ProtoData/backend`).
+#   5. `<sibling>/<sibling-name>`
+#      (covers `spine-tool-base` -> `tool-base/tool-base`).
+# Falls back to the sibling root when no candidate matches.
+resolve_submodule_path() {
+    local sibling="$1" artifact="$2"
+    [ -d "$sibling" ] || return 1
+
+    if has_source_set "$sibling"; then
+        printf '%s\n' "$sibling"
+        return 0
+    fi
+
+    local sibling_name lower_sibling
+    sibling_name="$(basename -- "$sibling")"
+    lower_sibling="$(printf '%s' "$sibling_name" | tr '[:upper:]' '[:lower:]')"
+
+    local candidates=()
+    candidates+=("$artifact")
+
+    case "$artifact" in
+        spine-*) candidates+=("${artifact#spine-}") ;;
+    esac
+
+    case "$artifact" in
+        spine-${lower_sibling}-*) candidates+=("${artifact#spine-${lower_sibling}-}") ;;
+        ${lower_sibling}-*)       candidates+=("${artifact#${lower_sibling}-}") ;;
+    esac
+
+    candidates+=("$sibling_name")
+
+    local cand
+    for cand in "${candidates[@]}"; do
+        [ -n "$cand" ] || continue
+        if has_source_set "$sibling/$cand"; then
+            printf '%s/%s\n' "$sibling" "$cand"
+            return 0
+        fi
+    done
+
+    printf '%s\n' "$sibling"
+}
+
+# Identify whether a Maven group belongs to the Spine sibling ecosystem.
+# Returns 0 (true) for Spine groups, 1 (false) otherwise.
+is_spine_group() {
+    case "$1" in
+        io.spine|io.spine.tools|io.spine.protodata|io.spine.validation)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Parse a query into group, artifact, version. Sets the globals
+# Q_GROUP, Q_ARTIFACT, Q_VERSION. Some may be empty.
+# Accepts: `group:artifact:version`, `group:artifact`, `artifact`, or a
+# free-form name that we treat as either an artifact or a sibling label.
+# Returns 0 always; the caller decides what an empty field means.
+parse_query() {
+    local q="$1"
+    Q_GROUP=""; Q_ARTIFACT=""; Q_VERSION=""
+    local rest
+    case "$q" in
+        *:*:*)
+            Q_GROUP="${q%%:*}"
+            rest="${q#*:}"
+            Q_ARTIFACT="${rest%%:*}"
+            Q_VERSION="${rest#*:}"
+            ;;
+        *:*)
+            Q_GROUP="${q%%:*}"
+            Q_ARTIFACT="${q#*:}"
+            ;;
+        *)
+            Q_ARTIFACT="$q"
+            ;;
+    esac
+}
+
+# Escape every non-alphanumeric character so the result is safe to embed
+# in a POSIX ERE pattern. Cheap overkill — Maven artifact names should
+# never need most of these, but the caller's input is untrusted.
+escape_ere() {
+    printf '%s' "$1" | sed 's/[^A-Za-z0-9]/\\&/g'
+}
+
+# Locate the consumer repo's local/<X>.kt file that declares a Maven artifact.
+# Some local files build artifact coordinates via Kotlin string templates
+# (`"$prefix-base"`, `"$group:$prefix-java:$version"`). To match those we
+# expand the per-file `prefix` constant before grepping. Other template
+# variables resolve to literals already present in the source, so a plain
+# grep finds them.
+# Returns the path of the first matching file (or empty).
+find_local_dep_file_for_artifact() {
+    local artifact="$1"
+    local repo
+    repo="$(consumer_repo_root)" || return 1
+    local local_dir="$repo/buildSrc/src/main/kotlin/io/spine/dependency/local"
+    [ -d "$local_dir" ] || return 0
+
+    # Validate the artifact name against the Maven convention before
+    # building a regex from it. Reject anything we cannot guarantee is
+    # safe; this prevents shell-quoted regex metacharacters in
+    # caller-supplied input from being interpreted by `grep -E`.
+    case "$artifact" in
+        ''|*[!A-Za-z0-9._-]*)
+            log_warn "invalid artifact name (allowed: A-Z a-z 0-9 . _ -): $artifact"
+            return 1
+            ;;
+    esac
+    local artifact_esc
+    artifact_esc="$(escape_ere "$artifact")"
+
+    local file prefix expanded
+    for file in "$local_dir"/*.kt; do
+        [ -f "$file" ] || continue
+        prefix="$(sed -nE 's/.*const[[:space:]]+val[[:space:]]+prefix[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+                  "$file" | head -1)"
+        if [ -n "$prefix" ]; then
+            expanded="$(sed -e 's|\$prefix|'"$prefix"'|g; s|\${prefix}|'"$prefix"'|g' "$file")"
+        else
+            expanded="$(cat -- "$file")"
+        fi
+        # Match the artifact as a complete coordinate component:
+        # delimited by `"`, `:`, or `-` on either side, never as a substring.
+        if printf '%s\n' "$expanded" | grep -qE "[\":-]${artifact_esc}[\":-]|[\":-]${artifact_esc}\$|^${artifact_esc}\$"; then
+            printf '%s\n' "$file"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Emit a stderr line tagged with the scripts' identity, so the agent can
+# distinguish them from unrelated noise.
+log_warn() {
+    printf 'api-discovery: %s\n' "$*" >&2
+}

--- a/.agents/scripts/api-discovery/update-sibling
+++ b/.agents/scripts/api-discovery/update-sibling
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Refresh a Spine sibling repo on disk so api-discovery returns sources
+# matching the most recent published version.
+#
+# Safe by design:
+#   - Pulls only when the sibling is on its default branch (master or
+#     main) with a clean working tree and a tracked upstream.
+#   - On any other branch, treats the local state as intentional (the
+#     user is "advancing multiple subprojects at the same time") and
+#     exits 0 without touching anything.
+#   - Refuses on detached HEAD, uncommitted changes, or missing upstream.
+#   - Never switches branches, never `--rebase`, never `--force`, never
+#     fetches a branch the user does not already track. The strictest
+#     action it performs is `git pull --ff-only`.
+#
+# This script is intended to be invoked by the api-discovery skill
+# after the agent has surfaced a STALE warning to the user AND received
+# explicit consent.
+#
+# Usage:
+#   update-sibling <sibling-name>           # resolved under <workspace-root>
+#   update-sibling <absolute-path>          # acts on that path directly
+#
+# Output:
+#   stdout: empty (action has no return value).
+#   stderr: progress and git output.
+#
+# Exit codes:
+#   0  — succeeded; stdout token names the outcome:
+#         `pulled`         — HEAD advanced to upstream tip.
+#         `up-to-date`     — already at upstream tip; nothing to do.
+#         `skipped-branch` — on a non-default branch; left untouched.
+#   1  — sibling not on disk.
+#   2  — not a git repository.
+#   3  — detached HEAD; refused.
+#   4  — uncommitted tracked changes; refused.
+#   5  — default branch has no upstream tracking; refused.
+#   6  — `git pull --ff-only` failed (divergence, conflict, network, etc.).
+#   64 — usage error (no/too many args).
+#
+# Output:
+#   stdout: exactly one stable token on success (see above). Empty on
+#           any failure path so callers cannot misread an error as a
+#           result.
+#   stderr: human-facing diagnostics, including git's own pull output.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SPINE_API_DISCOVERY_DIR="$SCRIPT_DIR"
+export SPINE_API_DISCOVERY_DIR
+# shellcheck source=lib/common.sh
+. "$SCRIPT_DIR/lib/common.sh"
+
+# Layered on top of the shared EX_OK / EX_FAIL / EX_NO_CACHE in common.sh.
+readonly EX_NOT_GIT=2
+readonly EX_DETACHED=3
+readonly EX_DIRTY=4
+readonly EX_NO_UPSTREAM=5
+readonly EX_PULL_FAILED=6
+readonly EX_USAGE=64           # BSD sysexits(3) convention.
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: update-sibling <sibling-name-or-path>
+
+Examples:
+  update-sibling base-libraries
+  update-sibling /Users/me/Projects/Spine/validation
+
+Pulls only when the sibling is on its default branch (master|main)
+with a clean working tree and a tracked upstream. Otherwise it leaves
+the sibling alone.
+
+On success, prints one of: pulled | up-to-date | skipped-branch.
+EOF
+    exit "$EX_USAGE"
+}
+
+[ "$#" -eq 1 ] || usage
+arg="$1"
+
+# Resolve to an absolute sibling path. Accept either a bare repo name
+# (looked up under <workspace-root>) or an absolute path.
+case "$arg" in
+    /*) sibling="$arg" ;;
+    *)
+        ws="$(workspace_root)" || {
+            log_warn "cannot resolve workspace root"
+            exit "$EX_FAIL"
+        }
+        sibling="$ws/$arg"
+        ;;
+esac
+
+if [ ! -d "$sibling" ]; then
+    log_warn "sibling not on disk: $sibling"
+    exit "$EX_FAIL"          # distinct from EX_USAGE so callers can tell
+                             # "you passed me a bad path" apart from
+                             # "you didn't pass me anything".
+fi
+
+# `.git` may be a directory (normal clone) or a file (worktree pointer).
+if [ ! -e "$sibling/.git" ]; then
+    log_warn "not a git repository: $sibling"
+    exit "$EX_NOT_GIT"
+fi
+
+branch="$(git -C "$sibling" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [ -z "$branch" ]; then
+    log_warn "failed to read current branch in $sibling"
+    exit "$EX_FAIL"
+fi
+if [ "$branch" = "HEAD" ]; then
+    log_warn "$sibling is in detached HEAD; not pulling"
+    exit "$EX_DETACHED"
+fi
+
+# Non-default branch: the user is intentionally on a feature branch.
+# Use the current code as-is.
+case "$branch" in
+    master|main)
+        ;;
+    *)
+        log_warn "$sibling is on '$branch' (not master/main); using local code as-is"
+        printf 'skipped-branch\n'
+        exit "$EX_OK"
+        ;;
+esac
+
+# Dirty-tree guard: refuse on TRACKED modifications, since a fast-forward
+# could conflict with them. Untracked files are tolerated: they don't
+# conflict with HEAD movement on their own, and any genuine overwrite
+# conflict (upstream adds a file whose path already exists untracked
+# locally) still surfaces below as EX_PULL_FAILED via git's own check.
+if [ -n "$(git -C "$sibling" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+    log_warn "$sibling has uncommitted tracked changes on '$branch'; not pulling"
+    exit "$EX_DIRTY"
+fi
+
+# Upstream guard: --ff-only against an undefined upstream is meaningless.
+if ! git -C "$sibling" rev-parse --abbrev-ref --symbolic-full-name '@{u}' \
+        >/dev/null 2>&1; then
+    log_warn "$sibling/$branch has no upstream tracking; not pulling"
+    exit "$EX_NO_UPSTREAM"
+fi
+
+# Capture HEAD before/after so we can report what changed.
+before="$(git -C "$sibling" rev-parse HEAD)"
+if ! git -C "$sibling" pull --ff-only >&2; then
+    log_warn "git pull --ff-only failed in $sibling"
+    exit "$EX_PULL_FAILED"
+fi
+after="$(git -C "$sibling" rev-parse HEAD)"
+
+if [ "$before" = "$after" ]; then
+    log_warn "$sibling already up-to-date on '$branch' ($after)"
+    printf 'up-to-date\n'
+else
+    log_warn "$sibling pulled '$branch': $before -> $after"
+    printf 'pulled\n'
+fi
+exit "$EX_OK"

--- a/.agents/scripts/api-discovery/update-sibling
+++ b/.agents/scripts/api-discovery/update-sibling
@@ -23,8 +23,10 @@
 #   update-sibling <absolute-path>          # acts on that path directly
 #
 # Output:
-#   stdout: empty (action has no return value).
-#   stderr: progress and git output.
+#   stdout: exactly one stable token on success (`pulled`, `up-to-date`,
+#           or `skipped-branch` — see Exit codes). Empty on any failure
+#           path so callers cannot misread an error as a result.
+#   stderr: human-facing diagnostics, including git's own pull output.
 #
 # Exit codes:
 #   0  — succeeded; stdout token names the outcome:
@@ -38,12 +40,6 @@
 #   5  — default branch has no upstream tracking; refused.
 #   6  — `git pull --ff-only` failed (divergence, conflict, network, etc.).
 #   64 — usage error (no/too many args).
-#
-# Output:
-#   stdout: exactly one stable token on success (see above). Empty on
-#           any failure path so callers cannot misread an error as a
-#           result.
-#   stderr: human-facing diagnostics, including git's own pull output.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/.agents/scripts/update-copyright.sh
+++ b/.agents/scripts/update-copyright.sh
@@ -11,11 +11,15 @@
 # Codex `apply_patch` passes the patch text in `tool_input.command`.
 # Exit:  0 always (post-tool-use; never block).
 #
-set -eu
+set -u
+
+# Required tools — silently no-op if either is missing so the hook never blocks.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
 
 input=$(cat)
-file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
-command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
 root="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 script="$root/.agents/skills/update-copyright/scripts/update_copyright.py"

--- a/.agents/skills/api-discovery/SKILL.md
+++ b/.agents/skills/api-discovery/SKILL.md
@@ -89,12 +89,91 @@ paths entirely.
 2. Use the returned path with `Grep`/`Read`/`Glob` directly. Do **not**
    `cd` into the directory — that adds path-prefix noise to tool calls
    and makes line citations harder to read.
-3. If stderr contains `STALE: ...`, the sibling repo on disk is at a
-   different version than what `buildSrc` declares. The sources are
-   close to but not identical to the published artifact. Mention this
-   when reporting findings.
+3. If stderr contains `STALE: ...`, the sibling on disk does not match
+   the version declared in `buildSrc`. Surface the warning AND offer
+   to refresh — see *Refreshing a stale sibling* below.
 4. If the script exits `1`, report the failure with its stderr
    message and stop. Do not try `unzip` as a workaround.
+
+## Refreshing a stale sibling
+
+The user keeps siblings cloned locally as the source of truth and
+sometimes works across several siblings at once with a feature branch
+checked out in each. So a `STALE` line has two possible meanings, and
+they require different handling:
+
+- **Sibling is behind `master`/`main`.** A `git pull --ff-only` will
+  bring it up to date.
+- **Sibling is on a feature branch.** This is *intentional* — the user
+  is staging changes across multiple subprojects. The local code is
+  the right code; **do not** pull.
+
+You cannot tell which case applies without inspecting the sibling. The
+companion script `update-sibling` handles both safely: it pulls only
+on the default branch with a clean tree and a tracked upstream, and
+exits `0` without touching anything when on a feature branch.
+
+### Procedure
+
+When you see a `STALE: ...` line from `discover`:
+
+1. Surface the warning to the user.
+2. Ask, in one short prompt:
+   > The sibling at `<path>` is stale. Want me to try updating it?
+   > I'll only `git pull --ff-only` if it's on `master`/`main` with
+   > a clean working tree; if you have a feature branch checked out,
+   > I'll leave it as-is.
+3. If the user agrees, run:
+   ```bash
+   .agents/scripts/api-discovery/update-sibling <sibling-path-or-name>
+   ```
+   `<sibling-path-or-name>` is either the absolute path shown by
+   `discover` (preferred — unambiguous) or just the sibling repo name
+   (resolved under `<workspace-root>`).
+4. Read **stdout** to decide what to do next — it is a single stable
+   token, not free-form English:
+   - `pulled` — HEAD advanced. Re-run `discover` so the STALE warning
+     clears (or, more rarely, reports a different discrepancy).
+   - `up-to-date` — sibling was already at upstream tip. The STALE
+     warning is informational — the declared `buildSrc` version and
+     the sibling's `versionToPublish` simply disagree. Proceed
+     without re-running `discover`.
+   - `skipped-branch` — sibling is on a feature branch and was left
+     untouched. Use the local code as-is; proceed without re-running.
+
+   stderr always carries the human-readable diagnostics; surface it
+   to the user, but do not parse it to drive control flow.
+5. If the user declines, proceed without pulling. Do not ask again
+   for the same sibling in the same session unless the user revisits.
+
+### `update-sibling` exit codes
+
+Exit 0 is split into three outcomes by the **stdout token** — read
+that, not the stderr text.
+
+| Code | stdout | Meaning | What you do |
+|---|---|---|---|
+| `0` | `pulled` | HEAD advanced to upstream tip. | Re-run `discover` so the STALE warning clears. |
+| `0` | `up-to-date` | Already at upstream tip; nothing to do. | Proceed; surface the STALE warning to the user as informational. |
+| `0` | `skipped-branch` | On a non-default branch; left untouched. | Use the local code as-is; proceed without re-running. |
+| `1` | _(empty)_ | Sibling not on disk. | Report the error. |
+| `2` | _(empty)_ | Not a git repository. | Report the error; do not retry. |
+| `3` | _(empty)_ | Detached HEAD — refused. | Tell the user; do not retry. |
+| `4` | _(empty)_ | Working tree dirty — refused. | Tell the user; do not retry. |
+| `5` | _(empty)_ | No upstream tracking on default branch — refused. | Tell the user. |
+| `6` | _(empty)_ | `git pull --ff-only` failed (divergence, network, etc.). | Surface the git error verbatim. |
+| `64` | _(empty)_ | Usage error (no/too many arguments). | Fix the invocation; do not retry blindly. |
+
+Failure paths produce **empty stdout** so the agent can never misread
+an error message as a result token.
+
+### "Don't ask me again"
+
+If the user says something like "stop offering" or "skip the prompt
+this session", remember that for the rest of the conversation and do
+not prompt on subsequent STALE warnings — just surface the warning
+and move on. This is **per-session** state; do not write it to
+auto-memory.
 
 ## Anti-patterns
 
@@ -133,7 +212,52 @@ api-discovery: sources at /Users/<you>/Projects/Spine/validation/java may differ
 /Users/<you>/Projects/Spine/validation/java
 ```
 
-Surface the `STALE` line to the user and proceed.
+Surface the `STALE` line, then offer to refresh — see *Refreshing a
+stale sibling*. After the user agrees and the pull succeeds, re-run
+`discover` and the warning clears.
+
+**Stale sibling, refresh on master:**
+
+```text
+$ .agents/scripts/api-discovery/update-sibling /Users/<you>/Projects/Spine/validation
+Updating abc1234..def5678
+Fast-forward
+ ...
+api-discovery: /Users/<you>/Projects/Spine/validation pulled 'master': abc1234... -> def5678...
+pulled
+$ echo $?
+0
+```
+
+Stdout is `pulled` — re-run `discover` to clear the STALE warning.
+
+**Stale sibling, already at upstream tip:**
+
+```text
+$ .agents/scripts/api-discovery/update-sibling /Users/<you>/Projects/Spine/validation
+Already up to date.
+api-discovery: /Users/<you>/Projects/Spine/validation already up-to-date on 'master' (def5678...)
+up-to-date
+$ echo $?
+0
+```
+
+Stdout is `up-to-date` — the sibling is fresh; the STALE warning
+reflects a declared-version vs. `versionToPublish` discrepancy that
+`git pull` cannot resolve. Surface it to the user as informational.
+
+**Stale sibling, feature branch (no-op):**
+
+```text
+$ .agents/scripts/api-discovery/update-sibling /Users/<you>/Projects/Spine/validation
+api-discovery: /Users/<you>/Projects/Spine/validation is on 'feature/new-rule' (not master/main); using local code as-is
+skipped-branch
+$ echo $?
+0
+```
+
+Stdout is `skipped-branch` — feature branch is intentional local
+state. Use the code as-is.
 
 **Non-Spine artifact, first use (extraction):**
 
@@ -160,4 +284,5 @@ Report the failure verbatim; do not try `unzip` as a workaround.
 ## Related
 
 - Implementation reference: `.agents/scripts/api-discovery/README.md`.
+- Sibling refresh on STALE: `.agents/scripts/api-discovery/update-sibling`.
 - Manual cache pruning: `.agents/scripts/api-discovery/clean-cache`.

--- a/.agents/skills/api-discovery/SKILL.md
+++ b/.agents/skills/api-discovery/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: api-discovery
+description: >
+  Resolve the on-disk location of a Maven artifact's source code,
+  so you can `Grep`/`Read` it directly instead of running `unzip`
+  against JARs in the Gradle cache. Use this whenever you need to
+  inspect a library's API or implementation — definitions of public
+  types, method signatures, KDoc, internal helpers, etc.
+---
+
+# API discovery
+
+Before reading library source code, run the `discover` script in
+`.agents/scripts/api-discovery/`. It returns a path you can hand
+straight to `Grep`, `Read`, or `Glob`.
+
+Do **not** run `find ~/.gradle/caches` or `unzip` against cache JARs.
+Each `unzip` decompresses the archive afresh — slow and token-heavy.
+
+## How to call it
+
+From the consumer repository root:
+
+```bash
+.agents/scripts/api-discovery/discover <query>
+```
+
+Where `<query>` is one of:
+
+| Form | Example | Notes |
+|---|---|---|
+| `group:artifact:version` | `io.spine:spine-base:2.0.0-SNAPSHOT.390` | Most explicit |
+| `group:artifact` | `io.spine:spine-base` | Version inferred from `buildSrc` |
+| `artifact` | `spine-base` | Spine-only; group inferred from `buildSrc` |
+
+The script writes the absolute resolved path to **stdout**, and any
+freshness/diagnostic warnings to **stderr**. Always read stderr — a
+silent stdout means clean resolution; a noisy stderr means caveats
+the user should know about.
+
+## Exit codes
+
+| Code | Meaning | What you do |
+|---|---|---|
+| `0` | Path on stdout is usable. | Pass it to `Grep`/`Read`/`Glob`. If stderr is non-empty, surface the warning to the user before relying on the path. |
+| `1` | Unresolvable (no sibling AND no JAR). | Report the failure. **Do not** fall back to `unzip ~/.gradle/caches/...`. |
+| `10` | Cache directory not initialized. | Run the **bootstrap flow** below. |
+
+## Bootstrap flow (exit 10)
+
+On the first run in a fresh workstation the per-workstation cache
+directory does not yet exist. The script exits `10` and names the
+path it would create. Ask the user:
+
+> The shared cache directory `<workspace-root>/.agents/caches/api-discovery/`
+> does not exist yet. How would you like to proceed?
+>
+> 1. **Approve** — create the directory at the default path.
+> 2. **Alternative root** — pick a different parent for the shared
+>    `.agents/` directory (e.g., `~/SpineWorkspace`, `/srv/spine`).
+> 3. **Non-cached** — skip the extraction cache. Sibling-first
+>    discovery still works for Spine artifacts; non-Spine deps will
+>    not be served by `api-discovery` in this repo.
+
+Then act on the user's reply:
+
+- **Approve** → `mkdir -p <workspace-root>/.agents/caches/api-discovery/sources`,
+  then re-run the original `discover` query.
+- **Alternative root** → ask for the absolute path `<alt-root>`, then:
+  ```bash
+  mkdir -p "<alt-root>/.agents/caches/api-discovery/sources"
+  printf '%s\n' "<alt-root>" \
+      > .agents/scripts/api-discovery/.workspace-root
+  ```
+  (the pointer file is gitignored). Then re-run `discover`.
+- **Non-cached** → record the choice in **per-developer auto-memory**
+  (project memory, type `feedback`), `name: api-discovery-cache-disabled`,
+  describing the user's choice and giving the "How to apply" rule:
+  *do not invoke `extract-sources` in this repo; for non-Spine deps
+  fall back to other investigation tools*. Then proceed with
+  sibling-first only.
+
+Check that memory at session start. If it exists, skip cache-touching
+paths entirely.
+
+## Workflow
+
+1. **Always** call `discover` before reading library source.
+2. Use the returned path with `Grep`/`Read`/`Glob` directly. Do **not**
+   `cd` into the directory — that adds path-prefix noise to tool calls
+   and makes line citations harder to read.
+3. If stderr contains `STALE: ...`, the sibling repo on disk is at a
+   different version than what `buildSrc` declares. The sources are
+   close to but not identical to the published artifact. Mention this
+   when reporting findings.
+4. If the script exits `1`, report the failure with its stderr
+   message and stop. Do not try `unzip` as a workaround.
+
+## Anti-patterns
+
+Stop doing these — they are exactly what this skill exists to replace:
+
+- `find ~/.gradle/caches/modules-2/files-2.1/ -name '*-sources.jar'`
+- `unzip -l <jar>` to list classes
+- `unzip -p <jar> path/in/jar` to read a file
+- Any chain of `unzip` + `grep` against a Gradle-cache JAR
+
+If you find yourself wanting to do those, run `discover` instead.
+
+## Examples
+
+**Spine artifact, fresh sibling on disk:**
+
+```text
+$ .agents/scripts/api-discovery/discover io.spine:spine-base
+/Users/<you>/Projects/Spine/base-libraries/base
+$ echo $?
+0
+```
+
+Tool calls then look like:
+
+- `Glob` pattern `**/*.kt`, path
+  `/Users/<you>/Projects/Spine/base-libraries/base`.
+- `Grep` pattern `class Identifier`, path the same.
+
+**Spine artifact, stale sibling:**
+
+```text
+$ .agents/scripts/api-discovery/discover io.spine.tools:validation-java
+api-discovery: STALE: validation-java declared 2.0.0-SNAPSHOT.433 in Validation.kt but sibling publishes 2.0.0-SNAPSHOT.440
+api-discovery: sources at /Users/<you>/Projects/Spine/validation/java may differ from the published artifact
+/Users/<you>/Projects/Spine/validation/java
+```
+
+Surface the `STALE` line to the user and proceed.
+
+**Non-Spine artifact, first use (extraction):**
+
+```text
+$ .agents/scripts/api-discovery/discover com.google.guava:guava:33.5.0-jre
+api-discovery: extracted com.google.guava:guava:33.5.0-jre -> .../guava/33.5.0-jre
+/Users/<you>/Projects/Spine/.agents/caches/api-discovery/sources/com.google.guava/guava/33.5.0-jre
+```
+
+Second call returns the same path with no stderr (already cached).
+
+**Unresolvable:**
+
+```text
+$ .agents/scripts/api-discovery/discover io.spine:does-not-exist:9.9.9
+api-discovery: io.spine:does-not-exist:9.9.9 is not in the local Gradle cache
+api-discovery: run './gradlew dependencies' (or rebuild) to fetch it, then retry
+$ echo $?
+1
+```
+
+Report the failure verbatim; do not try `unzip` as a workaround.
+
+## Related
+
+- Implementation reference: `.agents/scripts/api-discovery/README.md`.
+- Manual cache pruning: `.agents/scripts/api-discovery/clean-cache`.

--- a/.agents/tasks/api-discovery.md
+++ b/.agents/tasks/api-discovery.md
@@ -1,0 +1,83 @@
+---
+slug: api-discovery
+branch: improve-api-discovery
+owner: claude
+status: in-review
+started: 2026-05-21
+---
+
+## Goal
+
+Make Spine API discovery fast and token-efficient by directing agents
+to read library sources from local sibling clones first, and from a
+one-time-extracted sources-JAR cache otherwise — never via repeated
+`unzip` against Gradle-cache JARs.
+
+## Context
+
+Investigation transcripts (see
+`~/Desktop/gradle-caches-scanning-by-claude.png`) show agents running
+dozens of `find ~/.gradle/caches` + `unzip -l` + `unzip -p` calls per
+query. Each call decompresses the JAR; token usage is dominated by
+path noise and JAR listings. The user keeps every Spine repo cloned
+as a sibling under `/Users/sanders/Projects/Spine/`, so the raw
+sources are already on disk for ~14 of the 16 Spine local deps and
+just need to be reached directly.
+
+Detailed design in `~/.claude/plans/mellow-juggling-yeti.md`.
+
+## Plan
+
+- [x] Draft plan + design review (Plan agent)
+- [x] Write task file
+- [x] Implement `lib/common.sh` (shared bash helpers)
+- [x] Implement `discover` (main entry)
+- [x] Implement `extract-sources` (one-shot JAR extraction, race-safe)
+- [x] Implement `clean-cache` (manual pruning)
+- [x] Write `README.md` + `.gitignore` for `.agents/scripts/api-discovery/`
+- [x] Write `SKILL.md` for `.agents/skills/api-discovery/`
+- [x] Add one bullet to `CLAUDE.md` under Workflow Rules
+- [x] Smoke tests (#1–#7 from plan)
+- [ ] Human review / merge; delete file on merge to master
+
+## Log
+
+- 2026-05-21 — drafted plan; Plan-agent reviewed and pushed back on
+  over-engineering (manifest, sibling repo, exit codes). Adopted
+  simplifications.
+- 2026-05-21 — cache location: `<workspace>/.agents/caches/api-discovery/`
+  with first-use bootstrap prompt (approve / alt root / non-cached).
+  Scripts and skill live in the consumer repo's `.agents/`.
+- 2026-05-21 — implementation begins.
+- 2026-05-21 — implementation complete. All 7 smoke tests pass.
+  Resolved all 24 Spine artifacts end-to-end (Base/Change/Logging KMP/
+  multi-module ProtoData/Validation/Tool-base/Mc-java). Extension-cache
+  path tested with Jackson and Guava — concurrent extractions race
+  safely on atomic `mv` with no `.tmp.*` leftovers. `STALE` warning
+  fires for validation-java (declared .433 vs sibling .440). KMP
+  source sets (`src/commonMain`, `src/jvmMain`, …) recognized in
+  addition to plain `src/main`. Status flipped to `in-review` for
+  human merge; task file will be deleted on merge to `master`.
+- 2026-05-21 — code-review pass applied six fixes:
+  (1) `extract-sources`: pre-test `[ -e "$target" ]` plus post-mv
+      nested-debris cleanup. Previous version was unsafe because
+      `mv tmp target` into an existing directory silently moves tmp
+      INSIDE target on macOS/Linux instead of failing.
+  (2) `discover`: replaced `target=$(...); status=$?` with
+      `target=$(...) || exit $?` so `set -e` cannot terminate
+      between assignment and status check.
+  (3) `clean-cache`: added `prune_empty_parents()` and call it on
+      both removal and "no entries match" paths (skipped under
+      `--dry-run`). Empty `<group>/<artifact>/` dirs are now
+      reclaimed.
+  (4) `read_declared_version`: anchored regex at line start (with
+      optional access modifier) to avoid matching `const val version`
+      strings in KDoc / comments / nested code.
+  (5) Removed dead `find_dep_file_for_artifact` (callers all use
+      `find_local_dep_file_for_artifact`).
+  (6) `find_local_dep_file_for_artifact`: validate artifact name
+      against `[A-Za-z0-9._-]` and ERE-escape it via new
+      `escape_ere()` before grep, blocking regex-metachar injection.
+  All seven smoke tests still pass; race-safety verified by parallel
+  extractions of `guava-testlib:33.5.0-jre` (both exit 0, no `.tmp.*`
+  remnants, no nested `target/v.tmp.PID/` debris).

--- a/.agents/tasks/api-discovery.md
+++ b/.agents/tasks/api-discovery.md
@@ -38,7 +38,41 @@ Detailed design in `~/.claude/plans/mellow-juggling-yeti.md`.
 - [x] Write `SKILL.md` for `.agents/skills/api-discovery/`
 - [x] Add one bullet to `CLAUDE.md` under Workflow Rules
 - [x] Smoke tests (#1–#7 from plan)
+- [x] Code-review fixes (six findings, see Log)
+- [x] **Follow-up:** `update-sibling` script + skill workflow for STALE
 - [ ] Human review / merge; delete file on merge to master
+
+## Follow-up: sibling auto-update on STALE
+
+Originally deferred under "Out of scope" in the plan. User asked for
+it: when STALE fires, the agent should offer to refresh the sibling
+clone so api-discovery returns up-to-date sources. Constraints from
+the user's reply:
+
+- Pull only when the sibling is on its default branch (`master` or
+  `main`) — they explicitly use checked-out feature branches as a
+  staging area for "advancing multiple subprojects at the same time",
+  so a feature branch is *intentional* local state and must be left
+  alone.
+- The action must be confirmed by the user, never autonomous.
+
+Design:
+
+- New script `update-sibling`:
+  - Resolves a sibling by bare name (under `<workspace-root>`) or by
+    absolute path.
+  - Branch ∈ {`master`,`main`} + clean tree + tracked upstream
+    → `git pull --ff-only`.
+  - Any other branch → no-op, exit 0 with "using local code as-is".
+  - Detached HEAD / dirty tree / no upstream → distinct exit codes
+    (3 / 4 / 5) with descriptive stderr.
+  - Pull failure → exit 6.
+  - Never switches branches, never `--rebase`, never `--force`, never
+    fetches a branch the user does not track.
+- SKILL.md gains a "When STALE fires" section: surface the warning,
+  ask the user, run `update-sibling` on consent, re-run `discover`
+  if a pull happened.
+- README.md documents the new script + adds it to the Layout table.
 
 ## Log
 
@@ -58,7 +92,46 @@ Detailed design in `~/.claude/plans/mellow-juggling-yeti.md`.
   source sets (`src/commonMain`, `src/jvmMain`, …) recognized in
   addition to plain `src/main`. Status flipped to `in-review` for
   human merge; task file will be deleted on merge to `master`.
-- 2026-05-21 — code-review pass applied six fixes:
+- 2026-05-21 — added `update-sibling` follow-up: a guarded
+  `git pull --ff-only` for stale Spine siblings. Branch ∈
+  {`master`,`main`} + clean tracked tree + tracked upstream → pull;
+  any other branch → no-op exit 0 ("intentional local state");
+  detached / dirty / no-upstream → distinct refusals (exit 3/4/5);
+  pull failure → exit 6. Uses `--untracked-files=no` so build
+  artifacts and editor scratch don't block pulls. SKILL.md and
+  scripts/README.md document the workflow; the agent must ask the
+  user before invoking. Verified all 8 paths: successful FF on a
+  synthetic master + upstream, no-op on `validation` (`address-issues`
+  branch), exit 4 on `base-libraries` (dirty), exit 1 on missing,
+  exit 2 on non-repo, exit 3 on detached HEAD, exit 5 on no upstream,
+  exit 1 on missing args. The `main` default branch is also accepted.
+- 2026-05-21 — `update-sibling` code-review pass applied five fixes:
+  (a) README exit-0 row was missing the `already up-to-date` outcome.
+  (b) `usage()` exited `EX_FAIL` (1), conflating "bad invocation" with
+      "sibling not on disk". Added `EX_USAGE=64` (BSD `sysexits(3)`)
+      and routed `usage()` to it; `sibling not on disk` keeps exit 1.
+  (c) Reworded the dirty-tree guard comment: untracked files don't
+      block FF on their own, but a genuine overwrite conflict (upstream
+      adds a path that exists untracked locally) still surfaces via
+      git's own check as `EX_PULL_FAILED`. Original "no effect on
+      semantics" wording was misleading.
+  (d) Exit 0 conflated three outcomes (pulled / up-to-date /
+      skipped-branch) and the skill had to parse free-form English log
+      lines to tell them apart. Now each success path emits a single
+      stable stdout token (`pulled`, `up-to-date`, `skipped-branch`);
+      failure paths emit empty stdout. Stderr keeps the human text.
+  (e) `SKILL.md` rewritten around the token contract: the exit-code
+      table splits exit 0 into three token-keyed sub-rows, procedure
+      step 4 branches on the token (not stderr), and a new
+      `up-to-date` example was added. `README.md` exit-code table got
+      the same split plus an `EX_USAGE=64` row.
+  Smoke-tested all eight paths end-to-end: synthetic upstream FF emits
+  `pulled`, re-run on the same clone emits `up-to-date`, `validation`
+  on `address-issues` emits `skipped-branch`, `base-libraries` (dirty)
+  exits 4, missing path exits 1, non-repo exits 2, no-args/too-many
+  exit 64. All failure paths produce empty stdout — agent can never
+  misread an error message as a result token.
+- 2026-05-21 — earlier code-review pass applied six fixes:
   (1) `extract-sources`: pre-test `[ -e "$target" ]` plus post-mv
       nested-debris cleanup. Previous version was unsafe because
       `mv tmp target` into an existing directory silently moves tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 - Write the plan to `.agents/tasks/<slug>.md` before coding. See `.agents/tasks/README.md` for format and lifecycle.
 - If something goes wrong — STOP and re-plan immediately.
 - One focused task per subagent.
+- Before reading library source code from `~/.gradle/caches`, follow the `api-discovery` skill — never `unzip` JARs directly.
 - **Never `git commit`, `git push`, `git tag`, or otherwise rewrite git history** unless
   the active skill's `SKILL.md` has a `## Commit authorization` section, or the *current* user
   prompt explicitly tells you to. Authorization does not carry over between turns.


### PR DESCRIPTION
This PR introduces the `api-discovery` skill that lets agents resolve the on-disk location of a Maven artifact's source code without repeatedly `unzip`-ing JARs from the Gradle cache.

### Features

* **Sibling-first discovery.** For every Spine artifact, the `discover` script maps to a sibling clone under `<workspace-root>/<repo>/` and returns the matching submodule path directly.
* **One-shot extraction cache.** Non-Spine artifacts (Jackson, Guava, etc.) have their `-sources.jar` extracted once to `<workspace-root>/.agents/caches/api-discovery/`, with race-safe concurrent extractions and manual pruning via `clean-cache`.
* **`STALE` warnings + guarded refresh.** When the sibling's `versionToPublish` disagrees with the declared dependency version, `discover` warns on stderr. A companion `update-sibling` script does a safety-guarded `git pull --ff-only` — only on `master`/`main` with a clean tracked tree and a tracked upstream; otherwise it leaves the sibling untouched. Success paths emit a stable stdout token (`pulled` / `up-to-date` / `skipped-branch`) so the skill never parses English log lines.
* **First-use bootstrap.** Missing cache directory exits `10` and triggers a three-option user prompt (approve / alternative root / non-cached).

### Other notable changes

* `update-copyright.sh` got a small follow-up fix from a Copilot comment on the earlier dependency-bump PR.