### PR TITLE
Bring `check-links` skill from Validation

### DIFF
--- a/.agents/skills/check-links/SKILL.md
+++ b/.agents/skills/check-links/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: check-links
+description: >
+  Validate the Hugo documentation site under `docs/` for broken links.
+  Builds the site, starts the Hugo server locally, runs Lychee against the
+  rendered HTML using the repo's `lychee.toml`, and reports any broken URLs
+  grouped by source Markdown page. Use locally before pushing changes that
+  touch `docs/**`, when CI's `Check Links` job fails, or whenever the user
+  asks to "check doc links". Read-only with respect to the project sources.
+  Does **not** cover Javadoc/KDoc (out of scope for this skill).
+---
+
+# Check links in the Hugo docs (repo-specific)
+
+You are the documentation link checker for this Spine Event Engine project.
+You build the site under `docs/`, serve it locally on port `1414`, run Lychee
+against the rendered HTML, and report broken URLs. You mirror what the
+`.github/workflows/check-links.yml` workflow does in CI: same Hugo version,
+same Lychee version, same Hugo environment (`development`), and the same
+`lychee.toml`. Two deliberate differences remain: the skill serves on port
+`1414` (CI uses `1313`) to avoid clashing with a developer's local
+`hugo server`, and the skill writes a local sentinel that CI does not.
+Both differences are harmless because `--base-url` is rewritten to match
+the local port and the sentinel is consumed only by the local `pre-pr`
+skill.
+
+### Pinned versions
+
+`.github/workflows/check-links.yml` is the **single source of truth** for the
+Hugo and Lychee pins. This file does not duplicate the current values
+because duplicates inevitably drift; see the workflow's `env:` block for
+the canonical `HUGO_VERSION` and `LYCHEE_VERSION_TAG`. The auto-download
+step (§2) reads `LYCHEE_VERSION_TAG` out of the workflow at runtime, so a
+workflow bump propagates automatically. Hugo is not auto-installed; the
+skill uses whichever `hugo` is on `$PATH` and only warns (does not block)
+if the installed version is older than the workflow's `HUGO_VERSION` —
+Hugo's HTML output is stable enough across minor versions that a small
+skew does not invalidate link-check results.
+
+The authoritative shared config is `lychee.toml` at the repo root. Do not
+fork its exclude list — fix the source link or, if the failing URL is a known
+flaky external endpoint, add it to `lychee.toml` once (the change applies to
+both the skill and CI).
+
+## When to run
+
+- Any change touches `docs/**` (including reference links, `embed-code`
+  blocks, sidenav YAML files, content under `docs/content/`).
+- A change touches `lychee.toml` itself.
+- CI reported broken links and you want a fast local repro.
+- The user asks to "check the doc links" or invokes `/check-links`.
+
+If none of the above is true, decline with a one-line note rather than
+running the (~30 s) build+check.
+
+## Tooling
+
+The skill needs four binaries:
+
+| Tool   | Purpose                                  | Install hint                  |
+|--------|------------------------------------------|-------------------------------|
+| Hugo   | Build and serve the site                 | `brew install hugo` (extended)|
+| Node   | Hugo theme dependencies (`npm ci`)       | `brew install node`           |
+| npm    | Same                                     | bundled with Node             |
+| Lychee | Link checker                             | `brew install lychee`         |
+
+For **Lychee**, prefer a pre-installed binary on `$PATH`. If none is found,
+download the pinned release (see `LYCHEE_VERSION_TAG` in
+`.github/workflows/check-links.yml` — the dynamic-read pattern in step 2 below
+keeps this version in lock-step with CI) into
+`.agents/skills/check-links/.cache/lychee/` and use that path. The pinned
+version matches what the CI workflow uses, so behavior is identical.
+
+`.agents/skills/check-links/.cache/` is git-ignored (see `.gitignore`).
+
+## Procedure
+
+Execute the steps in order. On the first failure, stop, write a `FAIL`
+sentinel (step 8), and report the failure with the next action.
+
+### 1. Scope check
+
+Run `git diff <base>...HEAD --name-only` (default `<base>` = `master` unless
+the user provides another). If the change set has **no** files under `docs/**`
+and no changes to `lychee.toml`, and the user did not explicitly ask, decline
+and exit cleanly.
+
+### 2. Preflight binaries
+
+- `hugo version` → must succeed; capture the version. If missing, stop with
+  Must-fix: "Install Hugo extended (`brew install hugo`)." If installed but
+  older than the workflow's `HUGO_VERSION` (parse with
+  `grep -E '^[[:space:]]+HUGO_VERSION:' .github/workflows/check-links.yml | sed -E 's/.*: *"?([^"]+)"?$/\1/'`), warn but
+  continue.
+- `node -v` and `npm -v` → must succeed. If missing, stop with Must-fix:
+  "Install Node (`brew install node`) at the major version pinned by
+  `node-version:` in `.github/workflows/check-links.yml`."
+- `lychee --version` → if it succeeds, record the path and version.
+- If `lychee` is missing:
+  1. Read the canonical pin from the workflow file so the skill cannot drift
+     from CI:
+     ```bash
+     LYCHEE_VERSION_TAG=$(
+       grep -E '^[[:space:]]+LYCHEE_VERSION_TAG:' .github/workflows/check-links.yml \
+         | sed -E 's/.*: *"?([^"]+)"?$/\1/'
+     )
+     ```
+     Expected shape: `lychee-vX.Y.Z` (the leading `lychee-` is part of the
+     upstream release tag, not a typo).
+  2. Determine platform via `uname -s` / `uname -m`. Map to the matching
+     Lychee asset (recent releases — `v0.24.2` and later — drop the
+     version from the asset filename):
+     - `Darwin` + `arm64`   → `lychee-aarch64-apple-darwin.tar.gz`
+     - `Darwin` + `x86_64`  → `lychee-x86_64-apple-darwin.tar.gz`
+     - `Linux`  + `x86_64`  → `lychee-x86_64-unknown-linux-gnu.tar.gz`
+     - `Linux`  + `aarch64` → `lychee-aarch64-unknown-linux-gnu.tar.gz`
+     - any other combination (e.g. Windows, FreeBSD, 32-bit) → stop with
+       Must-fix: "Unsupported platform for Lychee auto-download — install
+       Lychee manually (`brew install lychee` / `cargo install lychee`)
+       and rerun."
+  3. Ensure the cache directory exists *before* the download —
+     `mkdir -p .agents/skills/check-links/.cache/lychee/` —
+     because the path is git-ignored and absent on a fresh clone,
+     and `tar -xzf … -C <dir>` will fail with "no such file or
+     directory" if the target does not exist yet. This mirrors the
+     `mkdir -p lychee` that `check-links.yml` does before its own
+     extract step.
+  4. Download from
+     `https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION_TAG}/<asset>`
+     into `.agents/skills/check-links/.cache/lychee/` and extract
+     with `tar -xzf <asset> --strip-components=1 -C .agents/skills/check-links/.cache/lychee/`
+     so the binary lands at
+     `.agents/skills/check-links/.cache/lychee/lychee`.
+  5. Use `.agents/skills/check-links/.cache/lychee/lychee` for the rest of this run.
+  6. Print a one-line note: "Using auto-downloaded Lychee. For faster runs,
+     install with `brew install lychee`."
+
+### 3. Install Hugo deps
+
+Run `( cd docs/_preview && npm ci )`. We deliberately use `npm ci` (matching
+the CI workflow's `Install Dependencies` step in `check-links.yml`) rather
+than `npm install`:
+
+- `npm ci` installs exactly the versions pinned by `package-lock.json`;
+  `npm install` is allowed to update the lockfile and may resolve to
+  different transitive versions than CI, which defeats the "render
+  identical HTML to CI" goal.
+- If `package.json` and `package-lock.json` drift out of sync, `npm ci`
+  fails fast with a clear error rather than silently healing the
+  lockfile — a divergence we want to surface, not paper over.
+
+The helper script `docs/_script/install-dependencies` exists for interactive
+use but does a relative `cd _preview` and therefore only works when invoked
+from `docs/` — calling it from the repo root (the skill's default CWD)
+would fail with "No such file or directory: _preview".
+
+### 4. Build the site
+
+Run `( cd docs/_preview && hugo -e development )`.
+This emits `docs/_preview/public/**/*.html`. The `-e development` flag matches
+what CI uses in `check-links.yml` so the two builds render identical HTML.
+(The helper `docs/_script/hugo-build` exists for interactive use but defaults
+to `production`; we invoke `hugo` directly to keep the env in lock-step with CI.)
+
+### 5. Start the Hugo server in the background
+
+The server must survive across multiple `Bash` tool calls (steps 5 → 6 → 8
+typically run in separate shells), so we rely on `nohup` alone — a `trap …
+EXIT` would fire when *this* shell exits and kill the server before Lychee
+can query it. Teardown happens explicitly in step 8.
+
+Before launching, kill any leftover server from a previous crashed run so a
+stale process does not hold port `1414`:
+
+```bash
+pkill -F /tmp/check-links.hugo.pid 2>/dev/null || true
+rm -f /tmp/check-links.hugo.pid
+
+( cd docs/_preview && nohup hugo server --environment development --port 1414 \
+    > /tmp/check-links.hugo.out 2>&1 & echo $! > /tmp/check-links.hugo.pid )
+sleep 5
+
+# Verify the captured PID is alive before relying on it. `$!` for
+# `nohup foo &` is reliable on bash but not portable across shells; the
+# pgrep check turns a silent "Lychee fetches an empty port" failure into
+# a clear error.
+if ! pgrep -F /tmp/check-links.hugo.pid > /dev/null 2>&1; then
+  echo "ERROR: Hugo server failed to start. Tail of log:" >&2
+  tail -20 /tmp/check-links.hugo.out >&2 || true
+  exit 1
+fi
+```
+
+Port `1414` is chosen to avoid clashing with a developer's local `hugo server`
+(default `1313`). The `--environment development` flag matches CI's build env.
+
+### 6. Run Lychee
+
+```bash
+<lychee-path> --config lychee.toml --timeout 60 \
+  --base-url http://localhost:1414/ \
+  'docs/_preview/public/**/*.html'
+```
+
+Capture exit code. Any non-zero exit means at least one broken link.
+
+### 7. Report
+
+Group the broken URLs from Lychee's output by source page. To reverse-map
+an HTML path to its Markdown source:
+
+`docs/_preview/public/docs/<section>/<page>/index.html`
+↔ `docs/content/docs/<section>/<page>.md` (or `<page>/_index.md`).
+
+Report in this shape:
+
+```
+## Doc link check (<branch> vs <base>)
+
+Hugo: <version>
+Lychee: <version> (<path>)
+Pages scanned: <N>
+Broken URLs: <K>
+
+### docs/content/docs/<...>/<page>.md
+- <broken URL> — <Lychee reason / HTTP status>
+- <broken URL> — ...
+
+### docs/content/docs/<...>/<other-page>.md
+- ...
+```
+
+If `K == 0`, report a single line: "All links OK."
+
+### 8. Tear down and sentinel
+
+- Kill the Hugo server (and clean up its pid file):
+
+  ```bash
+  pkill -F /tmp/check-links.hugo.pid 2>/dev/null || true
+  rm -f /tmp/check-links.hugo.pid /tmp/check-links.hugo.out
+  ```
+
+  Run this even if Lychee failed — leaving a server on port `1414` would
+  poison the next invocation.
+- Write `.git/check-links.ok` at the repo root:
+
+  ```
+  head=<full HEAD SHA>
+  branch=<current branch>
+  status=PASS|FAIL
+  timestamp=<ISO-8601 UTC>
+  hugo=<version>
+  lychee=<version>
+  pages=<N>
+  broken=<K>
+  ```
+
+The sentinel is consumed by the `pre-pr` skill's reviewer step: when it
+sees a sentinel whose `head=` matches the current HEAD SHA and
+`status=PASS`, it skips re-dispatching `check-links` and records it
+as APPROVE with the note "cached from `.git/check-links.ok`". Any
+HEAD advance (commit, amend, rebase) invalidates the cache automatically.
+
+## Notes
+
+- This skill does **not** modify tracked sources. It does, however, write
+  several git-ignored build artifacts during a run — listed here so a future
+  reader does not mistake them for unrelated side-effects:
+  - `.agents/skills/check-links/.cache/lychee/` — auto-downloaded
+    Lychee binary, when the system Lychee was unavailable.
+  - `docs/_preview/node_modules/` — installed by `npm ci` in step 3.
+  - `docs/_preview/public/` — Hugo's rendered HTML (the corpus Lychee
+    scans).
+  - `docs/_preview/resources/` — Hugo's asset-pipeline cache.
+  - `.lycheecache` at the repo root — Lychee's per-URL result cache
+    (honoured for `max_cache_age = "3d"` per `lychee.toml`).
+  - `/tmp/check-links.hugo.{pid,out}` — server PID file and log, both
+    removed in step 8's teardown.
+
+  Every path above is matched by an existing `.gitignore` entry; none is
+  committed.
+- The `lychee.toml` exclude list is the single source of truth for flaky
+  external endpoints. If a real link must be excluded, add it there and
+  explain why in a comment so CI and local runs stay in sync.
+- The skill assumes the docs build succeeds. A Hugo build error is treated
+  the same as a link failure — surface it and stop.
+- The `include_verbatim = false` setting in `lychee.toml` skips links inside
+  code blocks. That is intentional today; flip it on if you specifically need
+  to validate examples.
+
+## Related skills
+
+- `review-docs` — prose, KDoc/Javadoc, and Markdown style review. Runs in
+  parallel with `check-links` when invoked by `pre-pr`.
+- `pre-pr` — composes the above and gates `gh pr create`.

--- a/.agents/skills/pre-pr/SKILL.md
+++ b/.agents/skills/pre-pr/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Run the pre-PR checklist for this repo: apply the version gate only when
   the repository has a root `version.gradle.kts`, run the configured
   build/check command per `.agents/running-builds.md`, and invoke the
-  configured reviewers (`kotlin-review`, `review-docs`, `dependency-audit`)
-  against the branch diff. On success, write a sentinel file at
+  configured reviewers (`kotlin-review`, `review-docs`, `dependency-audit`,
+  `check-links`) against the branch diff. On success, write a sentinel file at
   `.git/pre-pr.ok` so the `gh pr create` hook can verify the checklist ran
   for the current HEAD. Use before opening a PR, or when CI rejected a
   branch and you want a fast local repro.
@@ -32,7 +32,9 @@ The authoritative standards live in `.agents/`:
 - `.agents/safety-rules.md` and `.agents/advanced-safety-rules.md` — hard
   constraints checked by the reviewers.
 - The reviewer skills/agents themselves: `kotlin-review` (Claude agent),
-  `review-docs` (skill + Claude agent), `dependency-audit` (Claude agent).
+  `review-docs` (skill + Claude agent), `dependency-audit` (Claude agent),
+  `check-links` (skill — runs Lychee against the rendered Hugo site
+  under `docs/`).
 
 ## Procedure
 
@@ -61,6 +63,9 @@ Execute the steps in order. If a step fails, stop, write a `FAIL` sentinel
   - **docs** — any `*.md` file or doc-only edits inside sources changed.
   - **deps** — any file under `buildSrc/src/main/kotlin/io/spine/dependency/`
     changed.
+  - **site** — any file under `docs/**` changed, or `lychee.toml` changed
+    (independent of **docs**; triggers the Hugo link check; pure `README.md`
+    edits or KDoc-only changes do *not* count as **site**).
 
 ### 2. Version-bump check
 
@@ -98,7 +103,20 @@ Dispatch the relevant reviewers concurrently and collect their verdicts:
 
 - Always: `kotlin-review` (if **code** changed) and `review-docs` (if
   **docs** or KDoc changed).
+- If **site** changed: `check-links` (runs in parallel with any other
+  dispatched reviewers), **unless** the sentinel short-circuit below applies.
 - If **deps** changed: `dependency-audit`.
+
+**`check-links` sentinel short-circuit.** Before dispatching
+`check-links`, read `.git/check-links.ok` (if present) and parse the
+`head=` and `status=` fields. If `head=` equals the current HEAD SHA (full,
+not short) and `status=PASS`, skip the dispatch and record the reviewer as
+`APPROVE` with the note "cached from `.git/check-links.ok`". Any HEAD
+advance — commit, amend, rebase — automatically invalidates the cache because
+the recorded SHA no longer matches. If the file is missing, malformed, or the
+`head=` does not match, dispatch the reviewer normally. Other reviewers do not
+use this pattern today; only `check-links` does, because its rebuild+serve
+cycle is slow (~30 s) and the result is deterministic for a given HEAD.
 
 Pass each reviewer the base ref, changed-file list, build/check result, and
 version-check result. When the version check is `N/A`, say explicitly:
@@ -145,13 +163,14 @@ Report in this shape:
 ```
 ## Pre-PR checklist (<branch> vs <base>)
 
-| Check         | Status | Notes                                  |
-|---------------|--------|----------------------------------------|
-| Version check | …      | <old> → <new>, introduced, or N/A      |
-| Build/check   | …      | <command>                              |
-| kotlin-review | …      | <verdict + count of Must/Should>       |
-| review-docs   | …      | <verdict + count of Must/Should>       |
-| dep audit     | …      | <verdict + count of Must/Should>       |
+| Check            | Status | Notes                                  |
+|------------------|--------|----------------------------------------|
+| Version check    | …      | <old> → <new>, introduced, or N/A      |
+| Build/check      | …      | <command>                              |
+| kotlin-review    | …      | <verdict + count of Must/Should>       |
+| review-docs      | …      | <verdict + count of Must/Should>       |
+| check-links      | …      | <K broken URLs across N pages>         |
+| dep audit        | …      | <verdict + count of Must/Should>       |
 
 **Overall: PASS|FAIL**
 Sentinel: .git/pre-pr.ok (status=PASS|FAIL, head=<SHA>)

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,169 @@
+name: Check Links
+
+# Trigger only when the docs site, the link checker config, or this workflow
+# itself changes — unrelated PRs do not need to pay the build+check cost.
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'lychee.toml'
+      - '.github/workflows/check-links.yml'
+  workflow_dispatch:
+
+env:
+  HUGO_VERSION: 0.161.1
+  LYCHEE_RELEASE: "lychee-x86_64-unknown-linux-gnu.tar.gz"
+  LYCHEE_VERSION_TAG: "lychee-v0.24.2"
+  # SHA256 of the above tarball, pinned at download time. Update alongside
+  # LYCHEE_VERSION_TAG whenever the binary is upgraded.
+  LYCHEE_SHA256: "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+  # Force Hugo to write its module cache where the cache step actually
+  # restores from. Hugo's default on Linux is `~/.cache/hugo_cache`
+  # (or `$TMPDIR/hugo_cache_$USER`), neither of which matches the
+  # `path: /tmp/hugo_cache` cache step below — without this env var,
+  # the cache would silently never hit.
+  HUGO_CACHEDIR: /tmp/hugo_cache
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      # `actions/setup-node@v4` ships with built-in npm caching that hashes
+      # the lockfile and restores `~/.npm`. We use that instead of a
+      # standalone `actions/cache@v4` block so there is only one source of
+      # truth for the cache key (no drift between two layers).
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: 'npm'
+          cache-dependency-path: docs/_preview/package-lock.json
+
+      # `HUGO_CACHEDIR=/tmp/hugo_cache` (set in `env:` above) makes Hugo
+      # actually write to the path this step restores from. The key hashes
+      # `docs/_preview/go.sum` + `docs/go.sum`, so adding/removing a Hugo
+      # module invalidates the cache deterministically.
+      - name: Cache Hugo Modules
+        uses: actions/cache@v4
+        with:
+          path: /tmp/hugo_cache
+          key: ${{ runner.os }}-hugomod-${{ hashFiles('docs/**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-hugomod-
+
+      - name: Install Dependencies
+        working-directory: docs/_preview
+        run: npm ci
+
+      - name: Build Validation docs
+        working-directory: docs/_preview
+        run: hugo -e development
+
+      # Cache Lychee results to avoid hitting rate limits.
+      # Key on the lychee.toml hash so that exclude-list edits (e.g. removing
+      # an exclude pattern) invalidate the cache deterministically; otherwise
+      # stale `200 OK` entries for the now-checked URLs would be trusted until
+      # `max_cache_age` expires.
+      - name: Cache Lychee results
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ runner.os }}-${{ hashFiles('lychee.toml') }}
+          restore-keys: |
+            cache-lychee-${{ runner.os }}-
+
+      # The cache key includes LYCHEE_VERSION_TAG so a version bump
+      # automatically pulls a fresh binary instead of reusing the old one.
+      # The restore-keys fallback lets a release-filename tweak (rare) reuse
+      # the existing cached binary for the same version-tag instead of paying
+      # for a fresh download.
+      - name: Cache Lychee executable
+        id: cache-lychee
+        uses: actions/cache@v4
+        with:
+          path: lychee
+          key: ${{ runner.os }}-${{ env.LYCHEE_VERSION_TAG }}-${{ env.LYCHEE_RELEASE }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.LYCHEE_VERSION_TAG }}-
+
+      # We use Lychee directly instead of a GitHub Action because it
+      # must have access to the local Hugo server, which is not visible
+      # from the Docker-based action.
+      #
+      # `if:` gating uses `hashFiles('lychee/lychee')` rather than
+      # `steps.cache-lychee.outputs.cache-hit != 'true'`. Per `actions/cache`
+      # docs, `cache-hit` is only `'true'` on an EXACT key match — a restore
+      # via `restore-keys` reports `cache-hit == 'false'`, even though the
+      # binary is present in the workspace. Re-downloading in that case
+      # would defeat the point of the fallback. `hashFiles` returns an empty
+      # string when the file is absent, so this guard runs the download iff
+      # neither the exact key nor any restore-key restored the binary.
+      - name: Download Lychee executable
+        uses: robinraju/release-downloader@v1.7
+        if: hashFiles('lychee/lychee') == ''
+        with:
+          repository: "lycheeverse/lychee"
+          tag: ${{ env.LYCHEE_VERSION_TAG }}
+          fileName: ${{ env.LYCHEE_RELEASE }}
+
+      - name: Verify Lychee checksum
+        if: hashFiles('lychee/lychee') == ''
+        run: |
+          echo "${{ env.LYCHEE_SHA256 }}  ${{ env.LYCHEE_RELEASE }}" | sha256sum --check --strict
+
+      # The v0.24.2 tarball contains a top-level directory
+      # (e.g. `lychee-x86_64-unknown-linux-gnu/lychee`), so `--strip-components=1`
+      # flattens it to `lychee/lychee` — matching what the companion
+      # `check-links` skill does locally and what the next step expects.
+      - name: Extract Lychee executable
+        if: hashFiles('lychee/lychee') == ''
+        run: |
+          mkdir -p lychee &&
+          tar -xzf ${{ env.LYCHEE_RELEASE }} --strip-components=1 -C lychee
+
+      # 1. In the generated HTML, some inner links will have absolute URLs and
+      #    the link checker will attempt to fetch them. That's why we need
+      #    a server. Sadly, link checkers have no settings to address this.
+      # 2. Output redirection is necessary for nohup in GitHub Actions.
+      # 3. Sleep + `curl` readiness check make sure the server is actually
+      #    serving HTTP before the next step runs Lychee. Without the curl
+      #    probe a silent startup failure (port already bound, missing
+      #    Hugo module, build error surfacing after `nohup` returns 0)
+      #    would manifest 60 s later as "every URL unreachable" Lychee
+      #    errors instead of pointing at the real cause. Mirrors the
+      #    `pgrep -F` guard in the companion `check-links` skill.
+      # 4. `--port 1313` is set explicitly (not relying on Hugo's default) so
+      #    the coupling with `--base-url http://localhost:1313/` in the next
+      #    Lychee step is visible — change one, change the other.
+      - name: Start Hugo server
+        working-directory: docs/_preview
+        run: |
+          nohup hugo server \
+          --environment development \
+          --port 1313 \
+          > nohup.out 2> nohup.err < /dev/null &
+          sleep 5
+          if ! curl -sf http://localhost:1313/ > /dev/null; then
+            echo "ERROR: Hugo server did not respond on port 1313." >&2
+            echo "--- stdout ---" >&2; cat nohup.out >&2 || true
+            echo "--- stderr ---" >&2; cat nohup.err >&2 || true
+            exit 1
+          fi
+
+      - name: Check links
+        run: |
+          ./lychee/lychee --config lychee.toml --timeout 60 \
+          --base-url http://localhost:1313/ \
+          'docs/_preview/public/**/*.html'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -34,7 +34,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # This workflow is shared across Spine repositories via a common
+      # template. Some repos (e.g. `config`) do not host a Hugo docs site
+      # under `docs/_preview/` — in that case there is nothing to link-check,
+      # so we detect the absence of the lockfile and short-circuit the rest
+      # of the job to a success. Without this guard, `actions/setup-node`'s
+      # `cache-dependency-path: docs/_preview/package-lock.json` step fails
+      # with "Some specified paths were not resolved, unable to cache
+      # dependencies", and the workflow goes red on every PR that touches
+      # `lychee.toml` or this file.
+      - name: Detect docs site
+        id: docs
+        run: |
+          if [ -f docs/_preview/package-lock.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No docs/_preview/package-lock.json — this repo has no Hugo docs site; skipping link check."
+          fi
+
       - name: Setup Hugo
+        if: steps.docs.outputs.present == 'true'
         uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: ${{ env.HUGO_VERSION }}
@@ -45,6 +65,7 @@ jobs:
       # standalone `actions/cache@v4` block so there is only one source of
       # truth for the cache key (no drift between two layers).
       - name: Setup Node
+        if: steps.docs.outputs.present == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '26'
@@ -56,6 +77,7 @@ jobs:
       # `docs/_preview/go.sum` + `docs/go.sum`, so adding/removing a Hugo
       # module invalidates the cache deterministically.
       - name: Cache Hugo Modules
+        if: steps.docs.outputs.present == 'true'
         uses: actions/cache@v4
         with:
           path: /tmp/hugo_cache
@@ -64,10 +86,12 @@ jobs:
             ${{ runner.os }}-hugomod-
 
       - name: Install Dependencies
+        if: steps.docs.outputs.present == 'true'
         working-directory: docs/_preview
         run: npm ci
 
       - name: Build Validation docs
+        if: steps.docs.outputs.present == 'true'
         working-directory: docs/_preview
         run: hugo -e development
 
@@ -77,6 +101,7 @@ jobs:
       # stale `200 OK` entries for the now-checked URLs would be trusted until
       # `max_cache_age` expires.
       - name: Cache Lychee results
+        if: steps.docs.outputs.present == 'true'
         uses: actions/cache@v4
         with:
           path: .lycheecache
@@ -90,6 +115,7 @@ jobs:
       # the existing cached binary for the same version-tag instead of paying
       # for a fresh download.
       - name: Cache Lychee executable
+        if: steps.docs.outputs.present == 'true'
         id: cache-lychee
         uses: actions/cache@v4
         with:
@@ -112,14 +138,14 @@ jobs:
       # neither the exact key nor any restore-key restored the binary.
       - name: Download Lychee executable
         uses: robinraju/release-downloader@v1.7
-        if: hashFiles('lychee/lychee') == ''
+        if: steps.docs.outputs.present == 'true' && hashFiles('lychee/lychee') == ''
         with:
           repository: "lycheeverse/lychee"
           tag: ${{ env.LYCHEE_VERSION_TAG }}
           fileName: ${{ env.LYCHEE_RELEASE }}
 
       - name: Verify Lychee checksum
-        if: hashFiles('lychee/lychee') == ''
+        if: steps.docs.outputs.present == 'true' && hashFiles('lychee/lychee') == ''
         run: |
           echo "${{ env.LYCHEE_SHA256 }}  ${{ env.LYCHEE_RELEASE }}" | sha256sum --check --strict
 
@@ -128,7 +154,7 @@ jobs:
       # flattens it to `lychee/lychee` — matching what the companion
       # `check-links` skill does locally and what the next step expects.
       - name: Extract Lychee executable
-        if: hashFiles('lychee/lychee') == ''
+        if: steps.docs.outputs.present == 'true' && hashFiles('lychee/lychee') == ''
         run: |
           mkdir -p lychee &&
           tar -xzf ${{ env.LYCHEE_RELEASE }} --strip-components=1 -C lychee
@@ -148,6 +174,7 @@ jobs:
       #    the coupling with `--base-url http://localhost:1313/` in the next
       #    Lychee step is visible — change one, change the other.
       - name: Start Hugo server
+        if: steps.docs.outputs.present == 'true'
         working-directory: docs/_preview
         run: |
           nohup hugo server \
@@ -163,6 +190,7 @@ jobs:
           fi
 
       - name: Check links
+        if: steps.docs.outputs.present == 'true'
         run: |
           ./lychee/lychee --config lychee.toml --timeout 60 \
           --base-url http://localhost:1313/ \

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: docs/_preview
         run: npm ci
 
-      - name: Build Validation docs
+      - name: Build docs preview site
         if: steps.docs.outputs.present == 'true'
         working-directory: docs/_preview
         run: hugo -e development

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,10 @@ __pycache__/
 # Lychee link-checker cache (created by the `check-links` skill and
 # the `Check Links` workflow when run locally).
 .lycheecache
+
+# Hugo docs preview site build artifacts (used by the `check-links`
+# skill and the `Check Links` workflow in repos that contain a
+# `docs/_preview` Hugo site).
+docs/_preview/node_modules/
+docs/_preview/public/
+docs/_preview/resources/

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,10 @@ __pycache__/
 
 # Claude working files
 /.claude/worktrees/
+
+# Auto-downloaded Lychee binary used by the `check-links` skill.
+/.agents/skills/check-links/.cache/
+
+# Lychee link-checker cache (created by the `check-links` skill and
+# the `Check Links` workflow when run locally).
+.lycheecache

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,76 @@
+# Lychee configuration for the `check-links` skill and the
+# `Check Links` GitHub workflow.
+#
+# Mirrors the configuration used by the sibling
+# `SpineEventEngine/SpineEventEngine.github.io` repository, with the same
+# exclude list of flaky external endpoints.
+
+# Exclude URLs and mail addresses from checking (supports regex).
+#
+# The entries are interpreted as Rust regexes, NOT shell globs:
+#   - `.` is escaped (`\.`) because an unescaped dot matches any character
+#     and would silently over-match (e.g. `fonts.googleapis.com` would
+#     also match `fontsXgoogleapisYcomZ`, masking real broken links).
+#   - `/.*` replaces the shell-style `/*` so a trailing path of any length
+#     matches (zero-or-more of any character, not zero-or-more slashes).
+# TOML literal strings (single-quoted) are used so backslashes stay
+# literal — basic strings (double quotes) would treat `\.` as an unknown
+# escape and either error out or strip the backslash.
+exclude = [
+    # Links that return errors during checks, but work for the user.
+    'fonts\.googleapis\.com/.*',
+    'fonts\.gstatic\.com/.*',
+    'chromium\.googlesource\.com/.*',
+    'chromereleases\.googleblog\.com/.*',
+    'clients4\.google\.com/.*',
+    'ssl\.gstatic\.com/.*',
+    'googletagmanager\.com/.*',
+    'x\.com/.*',
+
+    'stackoverflow\.com/questions/.*',
+    'openjdk\.org/.*',
+    'npmjs\.com/.*',
+    'medium\.com/.*',
+    'levelup\.gitconnected\.com/.*',
+]
+# Deliberately NOT excluded: `raw.githubusercontent.com/SpineEventEngine/*`.
+# Catching broken refs into our own raw GitHub content is part of the reason
+# this skill exists. If rate-limit flake appears, prefer narrowing the
+# pattern to the specific failing path rather than re-adding the broad rule.
+# Existing `max_retries`/`retry_wait_time` below should absorb transient 429s.
+
+# Exclude these filesystem paths from getting checked.
+exclude_path = []
+
+# Do NOT check links inside `<code>` and `<pre>` blocks or
+# Markdown code blocks (verbatim/code sections are excluded).
+include_verbatim = false
+
+# Verbose program output
+verbose = "error"
+
+# Don't show the interactive progress bar while checking links. Both
+# consumers (CI and the `check-links` skill) run non-interactively, so
+# the progress bar adds noise to logs without value.
+no_progress = true
+
+# Comma-separated list of accepted status codes for valid links.
+# `429` (Too Many Requests) is accepted as a tradeoff against CI flake: some
+# providers rate-limit unauthenticated link probes from CI runners even when
+# the URL is healthy. Combined with `max_retries`/`retry_wait_time` below,
+# this avoids spurious failures on healthy-but-rate-limited URLs. The
+# downside: a URL that is genuinely broken AND returns `429` (rare) will
+# pass. Revisit this if false negatives accumulate.
+accept = ["200..=204", "429"]
+
+# Link caching to avoid checking the same links on multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "3d"
+
+# Maximum number of allowed retries before a link is declared dead.
+max_retries = 3
+
+# Minimum wait time in seconds between retries of failed requests.
+retry_wait_time = 2


### PR DESCRIPTION
This PR adds the `check-links` skill which we recently adopted in Validation. 

The workflow `check-links` was updated to tolerate the absence of the `docs/` directory in the repository.

It is expected that this skill and workflow are going to be propagated to the Documentation and spine.io repositories once we figure out the best way to do it.