### PR TITLE
Add Hugo docs repo support to `migrate`

### DIFF
--- a/.agents/skills/check-links/SKILL.md
+++ b/.agents/skills/check-links/SKILL.md
@@ -1,27 +1,27 @@
 ---
 name: check-links
 description: >
-  Validate the Hugo documentation site under `docs/` for broken links.
-  Builds the site, starts the Hugo server locally, runs Lychee against the
-  rendered HTML using the repo's `lychee.toml`, and reports any broken URLs
+  Validate the Hugo documentation site under `docs/` or `site/` for broken
+  links. Builds the site, starts the Hugo server locally, runs Lychee against
+  the rendered HTML using the repo's `lychee.toml`, and reports any broken URLs
   grouped by source Markdown page. Use locally before pushing changes that
-  touch `docs/**`, when CI's `Check Links` job fails, or whenever the user
-  asks to "check doc links". Read-only with respect to the project sources.
-  Does **not** cover Javadoc/KDoc (out of scope for this skill).
+  touch `docs/**` or `site/**`, when CI's `Check Links` job fails, or whenever
+  the user asks to "check doc links". Read-only with respect to the project
+  sources. Does **not** cover Javadoc/KDoc (out of scope for this skill).
 ---
 
 # Check links in the Hugo docs (repo-specific)
 
 You are the documentation link checker for this Spine Event Engine project.
-You build the site under `docs/`, serve it locally on port `1414`, run Lychee
-against the rendered HTML, and report broken URLs. You mirror what the
-`.github/workflows/check-links.yml` workflow does in CI: same Hugo version,
-same Lychee version, same Hugo environment (`development`), and the same
-`lychee.toml`. Two deliberate differences remain: the skill serves on port
-`1414` (CI uses `1313`) to avoid clashing with a developer's local
-`hugo server`, and the skill writes a local sentinel that CI does not.
-Both differences are harmless because `--base-url` is rewritten to match
-the local port and the sentinel is consumed only by the local `pre-pr`
+You build the site under `docs/` or `site/` (auto-detected; see step 0), serve
+it locally on port `1414`, run Lychee against the rendered HTML, and report
+broken URLs. You mirror what the `.github/workflows/check-links.yml` workflow
+does in CI: same Hugo version, same Lychee version, same Hugo environment
+(`development`), and the same `lychee.toml`. Two deliberate differences remain:
+the skill serves on port `1414` (CI uses `1313`) to avoid clashing with a
+developer's local `hugo server`, and the skill writes a local sentinel that CI
+does not. Both differences are harmless because `--base-url` is rewritten to
+match the local port and the sentinel is consumed only by the local `pre-pr`
 skill.
 
 ### Pinned versions
@@ -44,8 +44,8 @@ both the skill and CI).
 
 ## When to run
 
-- Any change touches `docs/**` (including reference links, `embed-code`
-  blocks, sidenav YAML files, content under `docs/content/`).
+- Any change touches `docs/**` or `site/**` (including reference links,
+  `embed-code` blocks, sidenav YAML files, content under `<SITE_DIR>/content/`).
 - A change touches `lychee.toml` itself.
 - CI reported broken links and you want a fast local repro.
 - The user asks to "check the doc links" or invokes `/check-links`.
@@ -78,12 +78,35 @@ version matches what the CI workflow uses, so behavior is identical.
 Execute the steps in order. On the first failure, stop, write a `FAIL`
 sentinel (step 8), and report the failure with the next action.
 
+### 0. Detect site root
+
+Before any other step, determine `SITE_DIR` — the directory that contains the
+Hugo config file:
+
+```bash
+SITE_DIR=""
+for dir in docs site; do
+  for cfg in hugo.toml hugo.yaml; do
+    if [ -f "$dir/$cfg" ]; then
+      SITE_DIR="$dir"
+      break 2
+    fi
+  done
+done
+if [ -z "$SITE_DIR" ]; then
+  echo "ERROR: No Hugo config found under docs/ or site/." >&2
+  exit 1
+fi
+```
+
+Use `$SITE_DIR` everywhere a directory path is needed in the steps below.
+
 ### 1. Scope check
 
 Run `git diff <base>...HEAD --name-only` (default `<base>` = `master` unless
-the user provides another). If the change set has **no** files under `docs/**`
-and no changes to `lychee.toml`, and the user did not explicitly ask, decline
-and exit cleanly.
+the user provides another). If the change set has **no** files under
+`$SITE_DIR/**` and no changes to `lychee.toml`, and the user did not
+explicitly ask, decline and exit cleanly.
 
 ### 2. Preflight binaries
 
@@ -137,9 +160,9 @@ and exit cleanly.
 
 ### 3. Install Hugo deps
 
-Run `( cd docs/_preview && npm ci )`. We deliberately use `npm ci` (matching
-the CI workflow's `Install Dependencies` step in `check-links.yml`) rather
-than `npm install`:
+Run `( cd ${SITE_DIR}/_preview && npm ci )`. We deliberately use `npm ci`
+(matching the CI workflow's `Install Dependencies` step in `check-links.yml`)
+rather than `npm install`:
 
 - `npm ci` installs exactly the versions pinned by `package-lock.json`;
   `npm install` is allowed to update the lockfile and may resolve to
@@ -149,18 +172,19 @@ than `npm install`:
   fails fast with a clear error rather than silently healing the
   lockfile — a divergence we want to surface, not paper over.
 
-The helper script `docs/_script/install-dependencies` exists for interactive
-use but does a relative `cd _preview` and therefore only works when invoked
-from `docs/` — calling it from the repo root (the skill's default CWD)
-would fail with "No such file or directory: _preview".
+The helper script `${SITE_DIR}/_script/install-dependencies` exists for
+interactive use but does a relative `cd _preview` and therefore only works
+when invoked from `${SITE_DIR}/` — calling it from the repo root (the skill's
+default CWD) would fail with "No such file or directory: _preview".
 
 ### 4. Build the site
 
-Run `( cd docs/_preview && hugo -e development )`.
-This emits `docs/_preview/public/**/*.html`. The `-e development` flag matches
-what CI uses in `check-links.yml` so the two builds render identical HTML.
-(The helper `docs/_script/hugo-build` exists for interactive use but defaults
-to `production`; we invoke `hugo` directly to keep the env in lock-step with CI.)
+Run `( cd ${SITE_DIR}/_preview && hugo -e development )`.
+This emits `${SITE_DIR}/_preview/public/**/*.html`. The `-e development` flag
+matches what CI uses in `check-links.yml` so the two builds render identical
+HTML. (The helper `${SITE_DIR}/_script/hugo-build` exists for interactive use
+but defaults to `production`; we invoke `hugo` directly to keep the env in
+lock-step with CI.)
 
 ### 5. Start the Hugo server in the background
 
@@ -176,7 +200,7 @@ stale process does not hold port `1414`:
 pkill -F /tmp/check-links.hugo.pid 2>/dev/null || true
 rm -f /tmp/check-links.hugo.pid
 
-( cd docs/_preview && nohup hugo server --environment development --port 1414 \
+( cd ${SITE_DIR}/_preview && nohup hugo server --environment development --port 1414 \
     > /tmp/check-links.hugo.out 2>&1 & echo $! > /tmp/check-links.hugo.pid )
 sleep 5
 
@@ -199,7 +223,7 @@ Port `1414` is chosen to avoid clashing with a developer's local `hugo server`
 ```bash
 <lychee-path> --config lychee.toml --timeout 60 \
   --base-url http://localhost:1414/ \
-  'docs/_preview/public/**/*.html'
+  "${SITE_DIR}/_preview/public/**/*.html"
 ```
 
 Capture exit code. Any non-zero exit means at least one broken link.
@@ -209,8 +233,8 @@ Capture exit code. Any non-zero exit means at least one broken link.
 Group the broken URLs from Lychee's output by source page. To reverse-map
 an HTML path to its Markdown source:
 
-`docs/_preview/public/docs/<section>/<page>/index.html`
-↔ `docs/content/docs/<section>/<page>.md` (or `<page>/_index.md`).
+`${SITE_DIR}/_preview/public/docs/<section>/<page>/index.html`
+↔ `${SITE_DIR}/content/docs/<section>/<page>.md` (or `<page>/_index.md`).
 
 Report in this shape:
 
@@ -222,11 +246,11 @@ Lychee: <version> (<path>)
 Pages scanned: <N>
 Broken URLs: <K>
 
-### docs/content/docs/<...>/<page>.md
+### <SITE_DIR>/content/docs/<...>/<page>.md
 - <broken URL> — <Lychee reason / HTTP status>
 - <broken URL> — ...
 
-### docs/content/docs/<...>/<other-page>.md
+### <SITE_DIR>/content/docs/<...>/<other-page>.md
 - ...
 ```
 
@@ -269,10 +293,10 @@ HEAD advance (commit, amend, rebase) invalidates the cache automatically.
   reader does not mistake them for unrelated side-effects:
   - `.agents/skills/check-links/.cache/lychee/` — auto-downloaded
     Lychee binary, when the system Lychee was unavailable.
-  - `docs/_preview/node_modules/` — installed by `npm ci` in step 3.
-  - `docs/_preview/public/` — Hugo's rendered HTML (the corpus Lychee
+  - `${SITE_DIR}/_preview/node_modules/` — installed by `npm ci` in step 3.
+  - `${SITE_DIR}/_preview/public/` — Hugo's rendered HTML (the corpus Lychee
     scans).
-  - `docs/_preview/resources/` — Hugo's asset-pipeline cache.
+  - `${SITE_DIR}/_preview/resources/` — Hugo's asset-pipeline cache.
   - `.lycheecache` at the repo root — Lychee's per-URL result cache
     (honoured for `max_cache_age = "3d"` per `lychee.toml`).
   - `/tmp/check-links.hugo.{pid,out}` — server PID file and log, both

--- a/.claude/settings-hugo.json
+++ b/.claude/settings-hugo.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git switch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git restore:*)",
+      "Bash(git stash:*)",
+      "Bash(git fetch:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git mv:*)",
+      "Bash(git submodule status:*)",
+      "Bash(hugo:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(find:*)",
+      "Bash(rg:*)",
+      "Bash(grep:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(python3 .agents/skills/update-copyright/scripts/update_copyright.py:*)",
+      "Bash(./config/pull)",
+      "Bash(./config/migrate)"
+    ],
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -fdx:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh release create:*)"
+    ],
+    "ask": [
+      "Bash(git commit:*)",
+      "Bash(git rebase:*)",
+      "Bash(git merge:*)",
+      "Bash(git cherry-pick:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.agents/scripts/sanitize-source-code.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.agents/scripts/update-copyright.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -47,8 +47,13 @@ jobs:
             for cfg in hugo.toml hugo.yaml; do
               if [ -f "$dir/$cfg" ]; then
                 echo "site_dir=$dir" >> "$GITHUB_OUTPUT"
-                echo "present=true" >> "$GITHUB_OUTPUT"
-                echo "::notice::Hugo site found under $dir/"
+                if [ -f "$dir/_preview/package-lock.json" ]; then
+                  echo "present=true" >> "$GITHUB_OUTPUT"
+                  echo "::notice::Hugo site found under $dir/"
+                else
+                  echo "present=false" >> "$GITHUB_OUTPUT"
+                  echo "::notice::Hugo config found in $dir/ but $dir/_preview/package-lock.json is missing — skipping link check."
+                fi
                 exit 0
               fi
             done

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - 'site/**'
       - 'lychee.toml'
       - '.github/workflows/check-links.yml'
   workflow_dispatch:
@@ -34,24 +35,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # This workflow is shared across Spine repositories via a common
-      # template. Some repos (e.g. `config`) do not host a Hugo docs site
-      # under `docs/_preview/` — in that case there is nothing to link-check,
-      # so we detect the absence of the lockfile and short-circuit the rest
-      # of the job to a success. Without this guard, `actions/setup-node`'s
-      # `cache-dependency-path: docs/_preview/package-lock.json` step fails
-      # with "Some specified paths were not resolved, unable to cache
-      # dependencies", and the workflow goes red on every PR that touches
-      # `lychee.toml` or this file.
+      # Detect the Hugo site root (`docs/` or `site/`) by looking for a Hugo
+      # config file. Outputs `present=true|false` and `site_dir=docs|site`.
+      # When neither directory has a Hugo config, the job short-circuits to a
+      # success so that this shared workflow stays green on repos that do not
+      # host a Hugo site at all.
       - name: Detect docs site
         id: docs
         run: |
-          if [ -f docs/_preview/package-lock.json ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No docs/_preview/package-lock.json — this repo has no Hugo docs site; skipping link check."
-          fi
+          for dir in docs site; do
+            for cfg in hugo.toml hugo.yaml; do
+              if [ -f "$dir/$cfg" ]; then
+                echo "site_dir=$dir" >> "$GITHUB_OUTPUT"
+                echo "present=true" >> "$GITHUB_OUTPUT"
+                echo "::notice::Hugo site found under $dir/"
+                exit 0
+              fi
+            done
+          done
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No Hugo site found under docs/ or site/ — skipping link check."
 
       - name: Setup Hugo
         if: steps.docs.outputs.present == 'true'
@@ -70,29 +73,29 @@ jobs:
         with:
           node-version: '26'
           cache: 'npm'
-          cache-dependency-path: docs/_preview/package-lock.json
+          cache-dependency-path: ${{ steps.docs.outputs.site_dir }}/_preview/package-lock.json
 
       # `HUGO_CACHEDIR=/tmp/hugo_cache` (set in `env:` above) makes Hugo
       # actually write to the path this step restores from. The key hashes
-      # `docs/_preview/go.sum` + `docs/go.sum`, so adding/removing a Hugo
-      # module invalidates the cache deterministically.
+      # both possible go.sum locations so adding/removing a Hugo module
+      # invalidates the cache deterministically regardless of site root.
       - name: Cache Hugo Modules
         if: steps.docs.outputs.present == 'true'
         uses: actions/cache@v4
         with:
           path: /tmp/hugo_cache
-          key: ${{ runner.os }}-hugomod-${{ hashFiles('docs/**/go.sum') }}
+          key: ${{ runner.os }}-hugomod-${{ hashFiles('docs/**/go.sum', 'site/**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-hugomod-
 
       - name: Install Dependencies
         if: steps.docs.outputs.present == 'true'
-        working-directory: docs/_preview
+        working-directory: ${{ steps.docs.outputs.site_dir }}/_preview
         run: npm ci
 
       - name: Build docs preview site
         if: steps.docs.outputs.present == 'true'
-        working-directory: docs/_preview
+        working-directory: ${{ steps.docs.outputs.site_dir }}/_preview
         run: hugo -e development
 
       # Cache Lychee results to avoid hitting rate limits.
@@ -175,7 +178,7 @@ jobs:
       #    Lychee step is visible — change one, change the other.
       - name: Start Hugo server
         if: steps.docs.outputs.present == 'true'
-        working-directory: docs/_preview
+        working-directory: ${{ steps.docs.outputs.site_dir }}/_preview
         run: |
           nohup hugo server \
           --environment development \
@@ -194,4 +197,4 @@ jobs:
         run: |
           ./lychee/lychee --config lychee.toml --timeout 60 \
           --base-url http://localhost:1313/ \
-          'docs/_preview/public/**/*.html'
+          '${{ steps.docs.outputs.site_dir }}/_preview/public/**/*.html'

--- a/migrate
+++ b/migrate
@@ -78,6 +78,8 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -f ../.agents/scripts/protect-version-file.sh
     rm -f ../.agents/scripts/publish-version-gate.sh
     rm -rf ../.agents/scripts/api-discovery
+    # Remove JVM-specific task file
+    rm -f ../.agents/tasks/api-discovery.md
 
     echo "Updating \`.claude\` directory (Hugo subset)"
     rm -rf ../.claude
@@ -103,6 +105,8 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     # Use Hugo-specific Claude settings; drop settings.local.json (references version-bumped)
     cp .claude/settings-hugo.json ../.claude/settings.json
     rm -f ../.claude/settings.local.json
+    # Remove the template file — it's been applied as settings.json and is not needed in the target
+    rm -f ../.claude/settings-hugo.json
 
     echo "Updating GitHub workflows"
     mkdir -p ../.github/workflows
@@ -116,6 +120,8 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -f ../.github/workflows/detekt-code-analysis.yml
     rm -f ../.github/workflows/gradle-wrapper-validation.yml
     cp .github/workflows/check-links.yml ../.github/workflows/
+
+    cd ..
 
 else
 
@@ -134,6 +140,8 @@ else
     rm -rf ../.claude
     if [ -d ".claude" ]; then
         cp -a .claude ..
+        # Remove the Hugo-only settings template — it has no use in a JVM repo
+        rm -f ../.claude/settings-hugo.json
     fi
 
     # Update existing workflows with more recent versions

--- a/migrate
+++ b/migrate
@@ -62,7 +62,8 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -rf ../.agents/skills/dependency-update
     rm -rf ../.agents/skills/java-to-kotlin
     rm -rf ../.agents/skills/kotlin-review
-    rm -rf ../.agents/skills/version-bumped
+    # Remove dead-link TOC (references JVM-specific files that were pruned above)
+    rm -f ../.agents/_TOC.md
     # Remove JVM-specific guidelines
     rm -f ../.agents/quick-reference-card.md
     rm -f ../.agents/coding-guidelines.md
@@ -95,7 +96,6 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -rf ../.claude/skills/dependency-update
     rm -rf ../.claude/skills/java-to-kotlin
     rm -rf ../.claude/skills/kotlin-review
-    rm -rf ../.claude/skills/version-bumped
     # Remove JVM-specific agents
     rm -f ../.claude/agents/kotlin-review.md
     rm -f ../.claude/agents/dependency-audit.md
@@ -103,6 +103,7 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     cp .claude/settings-hugo.json ../.claude/settings.json
 
     echo "Updating GitHub workflows"
+    mkdir -p ../.github/workflows
     cp .github/workflows/check-links.yml ../.github/workflows/
 
 else

--- a/migrate
+++ b/migrate
@@ -61,7 +61,6 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -rf ../.agents/skills/dependency-update
     rm -rf ../.agents/skills/java-to-kotlin
     rm -rf ../.agents/skills/kotlin-review
-    rm -rf ../.agents/skills/version-bumped
     # Remove dead-link TOC (references JVM-specific files that were pruned above)
     rm -f ../.agents/_TOC.md
     # Remove JVM-specific guidelines
@@ -98,7 +97,6 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -rf ../.claude/skills/dependency-update
     rm -rf ../.claude/skills/java-to-kotlin
     rm -rf ../.claude/skills/kotlin-review
-    rm -rf ../.claude/skills/version-bumped
     # Remove JVM-specific agents
     rm -f ../.claude/agents/kotlin-review.md
     rm -f ../.claude/agents/dependency-audit.md
@@ -150,72 +148,8 @@ else
     cp -a .github/workflows/. ../.github/workflows
     rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
 
-    # 2026-04-06 Remove `LicenseReport.kt` as the dependency object is not used.
-    # We use the `LicenseReportPlugin` class via the dependency in `buildSrc/build.gradle.kts`.
-    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/build/LicenseReport.kt
-
-    # 2025-11-20 Remove renamed `Runtime.kt` file.
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/Runtime.kt
-
-    # 2025-11-17 Remove old Dokka configuration scripts.
-    rm -f ../buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
-    rm -f ../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
-
-    # 2025-11-17 Remove duplicated Dokka-related extensions.
-    rm -r ../buildSrc/src/main/kotlin/io/spine/gradle/dokka/
-
-    # 2025-11-11 Remove the older `detekt-analysis.yml` workflow.
-    # See: https://github.com/SpineEventEngine/config/issues/434
-    rm -f ../.github/workflows/detekt-analysis.yml
-
-    # 2025-10-28 Remove `ArtifactVersion.kt` and `Text.kt`.
-    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
-    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
-
-    # 2025-10-28 Remove `compile-protobuf.gradle.kts`.
-    # It no longer needed because we have `io.spine.protobuf-setup` plugin instead.
-    rm -f ../buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
-
-    # 2025-10-27 Remove `VersionWriter.kt` and `ProtoTaskExtensions.kt`
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/VersionWriter.kt
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
-
-    # 2025-10-01 Remove renamed `CoreJava.kt`
-    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
-
-    # 2025-05-02 Remove the refactored file.
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/javadoc/TaskContainerExtensions.kt
-
-    # 2025-04-25 Remove the refactored files moved to subpackages
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/Repositories.kt
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/RepoSlug.kt
-
-    # 2025-04-22 Remove the refactored file to avoid "duplicated declarations" error.
-    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/publish/Publications.kt
-
-    # 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
     cp -a gradle.properties ..
-
-    # 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
     cp -a .gitignore ..
-
-    # 2024-10-28
-    echo "Removing old packages under \`buildSrc/src/main/kotlin/\`"
-    rm -r ../buildSrc/src/main/kotlin/io/spine/internal/
-
-    # 2023-07-12, remove outdated files.
-    rm -f ../buildSrc/src/main/kotlin/java-module.gradle.kts
-    rm -f ../buildSrc/src/main/kotlin/kotlin-jvm-module.gradle.kts
-    rm -f ../buildSrc/src/main/kotlin/jacoco-kmm-jvm.gradle.kts
-    rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
-    rm -f ../buildSrc/src/main/kotlin/Repositories.kt
-
-    # 2023-07-30, remove outdated files.
-    rm -f ../.lift.toml
-
-    # 2023-11-24, remove `license-report.md` in favor of `dependencies.md`
-    # See `config#498` for more.
-    rm -f ../license-report.md
 
     echo "Updating Gradle \`buildSrc\`"
 

--- a/migrate
+++ b/migrate
@@ -44,7 +44,6 @@ function initialize() {
 
 initialize .gitattributes
 initialize .gitignore
-initialize .github
 
 if [ "$IS_HUGO_DOCS" = "true" ]; then
 
@@ -62,6 +61,7 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -rf ../.agents/skills/dependency-update
     rm -rf ../.agents/skills/java-to-kotlin
     rm -rf ../.agents/skills/kotlin-review
+    rm -rf ../.agents/skills/version-bumped
     # Remove dead-link TOC (references JVM-specific files that were pruned above)
     rm -f ../.agents/_TOC.md
     # Remove JVM-specific guidelines
@@ -96,17 +96,30 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     rm -rf ../.claude/skills/dependency-update
     rm -rf ../.claude/skills/java-to-kotlin
     rm -rf ../.claude/skills/kotlin-review
+    rm -rf ../.claude/skills/version-bumped
     # Remove JVM-specific agents
     rm -f ../.claude/agents/kotlin-review.md
     rm -f ../.claude/agents/dependency-audit.md
-    # Use Hugo-specific Claude settings
+    # Use Hugo-specific Claude settings; drop settings.local.json (references version-bumped)
     cp .claude/settings-hugo.json ../.claude/settings.json
+    rm -f ../.claude/settings.local.json
 
     echo "Updating GitHub workflows"
     mkdir -p ../.github/workflows
+    # Remove any JVM workflows that may exist from a previous non-Hugo pull
+    rm -f ../.github/workflows/build-on-ubuntu.yml
+    rm -f ../.github/workflows/build-on-windows.yml
+    rm -f ../.github/workflows/ensure-reports-updated.yml
+    rm -f ../.github/workflows/increment-guard.yml
+    rm -f ../.github/workflows/publish.yml
+    rm -f ../.github/workflows/remove-obsolete-artifacts-from-packages.yaml
+    rm -f ../.github/workflows/detekt-code-analysis.yml
+    rm -f ../.github/workflows/gradle-wrapper-validation.yml
     cp .github/workflows/check-links.yml ../.github/workflows/
 
 else
+
+    initialize .github
 
     echo "Updating Codecov settings"
     cp .codecov.yml ..

--- a/migrate
+++ b/migrate
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Detect if the target repo is a Hugo docs-only repository.
+IS_HUGO_DOCS=false
+for hugo_dir in docs site; do
+  for hugo_cfg in hugo.toml hugo.yaml; do
+    if [ -f "../$hugo_dir/$hugo_cfg" ]; then
+      IS_HUGO_DOCS=true
+      echo "Detected Hugo docs repository."
+      break 2
+    fi
+  done
+done
+
 echo "Updating IDEA configuration"
 cp -R .idea ..
 
@@ -9,31 +21,16 @@ cp CONTRIBUTING.md ..
 echo "Updating Contributor Covenant"
 cp CODE_OF_CONDUCT.md ..
 
-echo "Updating Codecov settings"
-cp .codecov.yml ..
-
-echo "Updating \\\`AGENTS.md\\\`"
+echo "Updating \`AGENTS.md\`"
 cp AGENTS.md ..
 
-echo "Updating \\\`CLAUDE.md\\\`"
+echo "Updating \`CLAUDE.md\`"
 cp CLAUDE.md ..
 
 echo "Updating Junie guidelines"
 rm -rf ../.junie
 if [ -d ".junie" ]; then
     cp -R .junie ..
-fi
-
-echo "Updating \\\`.agents\\\` directory"
-rm -rf ../.agents
-if [ -d ".agents" ]; then
-    cp -R .agents ..
-fi
-
-echo "Updating \\\`.claude\\\` directory"
-rm -rf ../.claude
-if [ -d ".claude" ]; then
-    cp -a .claude ..
 fi
 
 # Copies the file or directory passed as the first parameter to the upper directory,
@@ -49,106 +46,183 @@ initialize .gitattributes
 initialize .gitignore
 initialize .github
 
-# Update existing workflows with more recent versions
-echo "Updating GitHub workflows"
-cp -a .github-workflows/. ../.github/workflows
-cp -a .github/workflows/. ../.github/workflows
-rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
+if [ "$IS_HUGO_DOCS" = "true" ]; then
 
-# 2026-04-06 Remove `LicenseReport.kt` as the dependency object is not used.
-# We use the `LicenseReportPlugin` class via the dependency in `buildSrc/build.gradle.kts`.
-rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/build/LicenseReport.kt
+    echo "Updating lychee.toml"
+    cp lychee.toml ..
 
-# 2025-11-20 Remove renamed `Runtime.kt` file.
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/Runtime.kt
+    echo "Updating \`.agents\` directory (Hugo subset)"
+    rm -rf ../.agents
+    cp -R .agents ..
+    # Remove JVM-specific skills
+    rm -rf ../.agents/skills/api-discovery
+    rm -rf ../.agents/skills/bump-gradle
+    rm -rf ../.agents/skills/bump-version
+    rm -rf ../.agents/skills/dependency-audit
+    rm -rf ../.agents/skills/dependency-update
+    rm -rf ../.agents/skills/java-to-kotlin
+    rm -rf ../.agents/skills/kotlin-review
+    rm -rf ../.agents/skills/version-bumped
+    # Remove JVM-specific guidelines
+    rm -f ../.agents/quick-reference-card.md
+    rm -f ../.agents/coding-guidelines.md
+    rm -f ../.agents/testing.md
+    rm -f ../.agents/version-policy.md
+    rm -f ../.agents/project-overview.md
+    rm -f ../.agents/running-builds.md
+    rm -f ../.agents/refactoring-guidelines.md
+    rm -f ../.agents/common-tasks.md
+    rm -f ../.agents/project-structure-expectations.md
+    # Remove JVM-specific scripts
+    rm -f ../.agents/scripts/protect-version-file.sh
+    rm -f ../.agents/scripts/publish-version-gate.sh
+    rm -rf ../.agents/scripts/api-discovery
 
-# 2025-11-17 Remove old Dokka configuration scripts.
-rm -f ../buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
+    echo "Updating \`.claude\` directory (Hugo subset)"
+    rm -rf ../.claude
+    cp -a .claude ..
+    # Remove JVM-specific commands
+    rm -f ../.claude/commands/bump-gradle.md
+    rm -f ../.claude/commands/bump-version.md
+    rm -f ../.claude/commands/dependency-update.md
+    rm -f ../.claude/commands/java-to-kotlin.md
+    rm -f ../.claude/commands/run-build.md
+    # Remove JVM-specific skills
+    rm -rf ../.claude/skills/api-discovery
+    rm -rf ../.claude/skills/bump-gradle
+    rm -rf ../.claude/skills/bump-version
+    rm -rf ../.claude/skills/dependency-audit
+    rm -rf ../.claude/skills/dependency-update
+    rm -rf ../.claude/skills/java-to-kotlin
+    rm -rf ../.claude/skills/kotlin-review
+    rm -rf ../.claude/skills/version-bumped
+    # Remove JVM-specific agents
+    rm -f ../.claude/agents/kotlin-review.md
+    rm -f ../.claude/agents/dependency-audit.md
+    # Use Hugo-specific Claude settings
+    cp .claude/settings-hugo.json ../.claude/settings.json
 
-# 2025-11-17 Remove duplicated Dokka-related extensions.
-rm -r ../buildSrc/src/main/kotlin/io/spine/gradle/dokka/
+    echo "Updating GitHub workflows"
+    cp .github/workflows/check-links.yml ../.github/workflows/
 
-# 2025-11-11 Remove the older `detekt-analysis.yml` workflow.
-# See: https://github.com/SpineEventEngine/config/issues/434
-rm -f ../.github/workflows/detekt-analysis.yml
+else
 
-# 2025-10-28 Remove `ArtifactVersion.kt` and `Text.kt`.
-rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
+    echo "Updating Codecov settings"
+    cp .codecov.yml ..
 
-# 2025-10-28 Remove `compile-protobuf.gradle.kts`.
-# It no longer needed because we have `io.spine.protobuf-setup` plugin instead.
-rm -f ../buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
+    echo "Updating \`.agents\` directory"
+    rm -rf ../.agents
+    if [ -d ".agents" ]; then
+        cp -R .agents ..
+    fi
 
-# 2025-10-27 Remove `VersionWriter.kt` and `ProtoTaskExtensions.kt`
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/VersionWriter.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
+    echo "Updating \`.claude\` directory"
+    rm -rf ../.claude
+    if [ -d ".claude" ]; then
+        cp -a .claude ..
+    fi
 
-# 2025-10-01 Remove renamed `CoreJava.kt`
-rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+    # Update existing workflows with more recent versions
+    echo "Updating GitHub workflows"
+    cp -a .github-workflows/. ../.github/workflows
+    cp -a .github/workflows/. ../.github/workflows
+    rm -f ../.github/workflows/detekt-code-analysis.yml # This one is `config`-only workflow.
 
-# 2025-05-02 Remove the refactored file.
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/javadoc/TaskContainerExtensions.kt
+    # 2026-04-06 Remove `LicenseReport.kt` as the dependency object is not used.
+    # We use the `LicenseReportPlugin` class via the dependency in `buildSrc/build.gradle.kts`.
+    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/build/LicenseReport.kt
 
-# 2025-04-25 Remove the refactored files moved to subpackages
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/Repositories.kt
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/RepoSlug.kt
+    # 2025-11-20 Remove renamed `Runtime.kt` file.
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/Runtime.kt
 
-# 2025-04-22 Remove the refactored file to avoid "duplicated declarations" error.
-rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/publish/Publications.kt
+    # 2025-11-17 Remove old Dokka configuration scripts.
+    rm -f ../buildSrc/src/main/kotlin/dokka-for-kotlin.gradle.kts
+    rm -f ../buildSrc/src/main/kotlin/dokka-for-java.gradle.kts
 
-# 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
-cp -a gradle.properties ..
+    # 2025-11-17 Remove duplicated Dokka-related extensions.
+    rm -r ../buildSrc/src/main/kotlin/io/spine/gradle/dokka/
 
-# 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
-cp -a .gitignore ..
+    # 2025-11-11 Remove the older `detekt-analysis.yml` workflow.
+    # See: https://github.com/SpineEventEngine/config/issues/434
+    rm -f ../.github/workflows/detekt-analysis.yml
 
-# 2024-10-28
-echo "Removing old packages under \\\`buildSrc/src/main/kotlin/\\\`"
-rm -r ../buildSrc/src/main/kotlin/io/spine/internal/
+    # 2025-10-28 Remove `ArtifactVersion.kt` and `Text.kt`.
+    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
+    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
 
-# 2023-07-12, remove outdated files.
+    # 2025-10-28 Remove `compile-protobuf.gradle.kts`.
+    # It no longer needed because we have `io.spine.protobuf-setup` plugin instead.
+    rm -f ../buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
 
-rm -f ../buildSrc/src/main/kotlin/java-module.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/kotlin-jvm-module.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/jacoco-kmm-jvm.gradle.kts
-rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
-rm -f ../buildSrc/src/main/kotlin/Repositories.kt
+    # 2025-10-27 Remove `VersionWriter.kt` and `ProtoTaskExtensions.kt`
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/VersionWriter.kt
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
 
-# 2023-07-30, remove outdated files.
-rm -f ../.lift.toml
+    # 2025-10-01 Remove renamed `CoreJava.kt`
+    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
 
-# 2023-11-24, remove `license-report.md` in favor of `dependencies.md`
-# See `config#498` for more.
-rm -f ../license-report.md
+    # 2025-05-02 Remove the refactored file.
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/javadoc/TaskContainerExtensions.kt
 
-echo "Updating Gradle \\\`buildSrc\\\`"
+    # 2025-04-25 Remove the refactored files moved to subpackages
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/Repositories.kt
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/RepoSlug.kt
 
-# Preserve an existing project's `module.gradle.kts` (do not overwrite it).
-DEST_MODULE="../buildSrc/src/main/kotlin/module.gradle.kts"
-PRESERVE_TMP=""
-if [ -f "$DEST_MODULE" ]; then
-  echo "Preserving existing \\\`module.gradle.kts\\\`"
-  PRESERVE_TMP=$(mktemp)
-  cp -a "$DEST_MODULE" "$PRESERVE_TMP"
+    # 2025-04-22 Remove the refactored file to avoid "duplicated declarations" error.
+    rm -f ../buildSrc/src/main/kotlin/io/spine/gradle/publish/Publications.kt
+
+    # 2025-04-16 — Overwrite `gradle.properties` to support Dokka transition mode.
+    cp -a gradle.properties ..
+
+    # 2025-04-16 — Overwrite `.gitignore` to propagate recent changes
+    cp -a .gitignore ..
+
+    # 2024-10-28
+    echo "Removing old packages under \`buildSrc/src/main/kotlin/\`"
+    rm -r ../buildSrc/src/main/kotlin/io/spine/internal/
+
+    # 2023-07-12, remove outdated files.
+    rm -f ../buildSrc/src/main/kotlin/java-module.gradle.kts
+    rm -f ../buildSrc/src/main/kotlin/kotlin-jvm-module.gradle.kts
+    rm -f ../buildSrc/src/main/kotlin/jacoco-kmm-jvm.gradle.kts
+    rm -f ../buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+    rm -f ../buildSrc/src/main/kotlin/Repositories.kt
+
+    # 2023-07-30, remove outdated files.
+    rm -f ../.lift.toml
+
+    # 2023-11-24, remove `license-report.md` in favor of `dependencies.md`
+    # See `config#498` for more.
+    rm -f ../license-report.md
+
+    echo "Updating Gradle \`buildSrc\`"
+
+    # Preserve an existing project's `module.gradle.kts` (do not overwrite it).
+    DEST_MODULE="../buildSrc/src/main/kotlin/module.gradle.kts"
+    PRESERVE_TMP=""
+    if [ -f "$DEST_MODULE" ]; then
+      echo "Preserving existing \`module.gradle.kts\`"
+      PRESERVE_TMP=$(mktemp)
+      cp -a "$DEST_MODULE" "$PRESERVE_TMP"
+    fi
+
+    cp -R buildSrc ..
+
+    # Restore preserved `module.gradle.kts`, if any.
+    if [ -n "$PRESERVE_TMP" ] && [ -f "$PRESERVE_TMP" ]; then
+      echo "Restoring existing \`module.gradle.kts\`"
+      cp -a "$PRESERVE_TMP" "$DEST_MODULE"
+      rm -f "$PRESERVE_TMP"
+    fi
+
+    echo "Updating Gradle Wrapper"
+    cp -R ./gradle ..
+    cp gradlew ..
+    cp gradlew.bat ..
+
+    cd ..
+
+    echo "Adding \`buildSrc\` sources to Git..."
+    git add ./buildSrc/src
+
 fi
-
-cp -R buildSrc ..
-
-# Restore preserved `module.gradle.kts`, if any.
-if [ -n "$PRESERVE_TMP" ] && [ -f "$PRESERVE_TMP" ]; then
-  echo "Restoring existing \\\`module.gradle.kts\\\`"
-  cp -a "$PRESERVE_TMP" "$DEST_MODULE"
-  rm -f "$PRESERVE_TMP"
-fi
-
-echo "Updating Gradle Wrapper"
-cp -R ./gradle ..
-cp gradlew ..
-cp gradlew.bat ..
-
-cd ..
-
-echo "Adding \\\`buildSrc\\\` sources to Git..."
-git add ./buildSrc/src


### PR DESCRIPTION
## Summary

- Auto-detects Hugo docs repos by looking for `hugo.toml` or `hugo.yaml` under `docs/` or `site/` at the repo root
- For Hugo repos: skips `buildSrc/`, `gradle/`, `gradle.properties`, `.codecov.yml`, and all JVM-specific agent content
- Copies a filtered subset of `.agents/` (keeps `review-docs`, `check-links`, `write-docs`, `move-files`, `update-copyright`, `pre-pr`, `writer`) and `.claude/` (same set of skills/commands)
- Installs `.claude/settings-hugo.json` as `settings.json` — drops Gradle permissions/hooks, adds `hugo` command, keeps doc-relevant hooks
- Copies `lychee.toml` and only the `check-links.yml` workflow for Hugo repos
- JVM repos: behaviour unchanged

https://claude.ai/code/session_01PYz9otfWNo5LAPHCcQfqhq