### PR TITLE
Improve agent instructions

### DIFF
--- a/.agents/coding-guidelines.md
+++ b/.agents/coding-guidelines.md
@@ -21,10 +21,12 @@
 - **Generic parameters** over explicit variable types (`val list = mutableList<Dependency>()`)  
 - **Java interop annotations** only when needed (`@file:JvmName`, `@JvmStatic`)
 - **Kotlin DSL** for Gradle files
+- **Kotlin Protobuf DSL** (`myMessage { field = value }`) over Java builder chains
 
 ### ❌ Avoid
 - Mutable data structures
 - Java-style verbosity (builders with setters)
+- Java Protobuf builders in Kotlin code (`newBuilder()`, `toBuilder()`) unless interop requires them
 - Redundant null checks (`?.let` misuse)
 - Using `!!` unless clearly justified
 - Type names in variable names (`userObject`, `itemList`)

--- a/.agents/documentation-guidelines.md
+++ b/.agents/documentation-guidelines.md
@@ -6,6 +6,11 @@
 - When using TODO comments, follow the format on the [dedicated page][todo-comments].
 - File and directory names should be formatted as code.
 
+## Protobuf file headers
+- In `.proto` files, a multi-paragraph documentation header must end with a
+  trailing empty comment line (`//`).
+- Single-paragraph headers do not require the trailing empty comment line.
+
 ## Avoid widows, runts, orphans, or rivers
 
 Agents should **AVOID** text flow patters illustrated

--- a/.agents/skills/kotlin-review/SKILL.md
+++ b/.agents/skills/kotlin-review/SKILL.md
@@ -32,6 +32,7 @@ live in `.agents/`:
    nullability, and idiomatic refactors require surrounding context.
 3. Check against `.agents/coding-guidelines.md`:
    - Kotlin idioms (extension functions, `when`, smart casts, data/sealed classes).
+   - Kotlin Protobuf DSL (`message { ... }`) preferred over Java builders (`newBuilder()`, `toBuilder()`) in Kotlin.
    - Immutability by default.
    - No `!!` without justification.
    - No type names in variable names.

--- a/.agents/skills/review-docs/SKILL.md
+++ b/.agents/skills/review-docs/SKILL.md
@@ -34,6 +34,7 @@ The authoritative standards live in `.agents/`:
    `git diff <base>...HEAD` depending on what the user describes. Restrict
    to files matching:
    - `**/*.kt`, `**/*.kts`, `**/*.java` (for KDoc/Javadoc inside sources)
+   - `**/*.proto` (for file-level documentation headers)
    - `**/*.md` (Markdown docs)
    Do **not** review the full repo — only what changed.
    Filter out config-distributed files (see `AGENTS.md § Code review` for the
@@ -68,6 +69,9 @@ The authoritative standards live in `.agents/`:
   `// TODO: …` without owner/issue reference is a Should-fix.
 - **File and directory names rendered as code.** Within KDoc/Javadoc prose,
   `path/to/file.kt` and `module-name` must use backticks.
+- **Multi-paragraph Protobuf headers end with an empty comment line.** In
+  `.proto` files, if the file-level documentation header has more than one
+  paragraph, it must end with a trailing empty comment line (`//`).
 
 ### B. Markdown docs
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,8 +15,11 @@ Additional guidelines are in `.agents/` — see `.agents/_TOC.md` for the index
 
 ## Do not review
 
-If the current repository is `config`, review these files normally: they are
-authoritative there. In other repositories, the following files are managed by
+Never review `gradlew` or `gradlew.bat` in any repository, including `config`.
+These files are provided by Gradle and are not edited manually.
+
+If the current repository is `config`, review its files normally unless noted
+above: they are authoritative there. In other repositories, the following files are managed by
 the `config` submodule and must be reviewed in the `config` repository, not
 here. In those consumer repositories, skip them without comment:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,9 @@ Ruthlessly iterate until mistakes stop repeating.
 
 ## Code review
 
+Never review `gradlew` or `gradlew.bat` in any repository, including `config`.
+These files are provided by Gradle and are not edited manually.
+
 When reviewing a pull request or diff in a consumer repository, skip any
 file that the `config` module distributes. Those files belong in a review
 of the `config` repo, not the consumer repo — reviewing them there adds
@@ -87,7 +90,7 @@ noise without value.
 
 Do **not** apply this skip rule when reviewing the `config` repository
 itself. In `config`, these files are source files owned by the current
-repo and must be reviewed normally.
+repo and must be reviewed normally, except `gradlew` and `gradlew.bat`.
 
 In consumer repositories, skip without comment any path matching:
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.433"
+    const val version = "2.0.0-SNAPSHOT.443"
 
     /**
      * The last version of Validation compatible with ProtoData.
@@ -46,7 +46,8 @@ object Validation {
     const val group = Spine.toolsGroup
     private const val prefix = "validation"
 
-    const val gradlePluginLib = "$group:$prefix-gradle-plugin:$version"
+    const val gradlePluginModule = "$group:$prefix-gradle-plugin"
+    const val gradlePluginLib = "$gradlePluginModule:$version"
 
     const val runtimeModule = "${Spine.group}:spine-$prefix-jvm-runtime"
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.443"
+    const val version = "2.0.0-SNAPSHOT.444"
 
     /**
      * The last version of Validation compatible with ProtoData.


### PR DESCRIPTION
This PR instruct agents:
 * Do not review `gradlew` and `gradlew.bat` files ever.
 * Prefer Kotlin Protobuf DSL over Java builders.
 * Add and track trailing empty comment in Protobuf multi-paragraph header doc blocks.

### Other changes
 * The `Validation` dependency object got `gradlePluginModule` which is needed in Validation project.
 * Validation was bumped to the latest published version.