### PR TITLE
Fail "Build on Ubuntu" workflow when CodeCov upload fails

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -34,5 +34,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This PR sets the flag `fail_ci_if_error` to `true` so that the `build-on-ubuntu.yml` workflow fails when the upload to CodeCov fails.