### PR TITLE
Replace deprecated PMD rule `GenericsNaming` with `TypeParameterNamingConventions`

### DIFF
--- a/buildSrc/quality/pmd.xml
+++ b/buildSrc/quality/pmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2025, TeamDev. All rights reserved.
+  ~ Copyright 2026, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -60,10 +60,10 @@
     <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
-    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
     <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
     <rule ref="category/java/codestyle.xml/NoPackage"/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
 


### PR DESCRIPTION
## Summary

PMD 7.25.0 deprecated `category/java/codestyle.xml/GenericsNaming` (since PMD 7.17.0, scheduled for removal in PMD 8.0.0). `pmdMain` emits a deprecation warning for it in every repository that consumes the distributed `buildSrc/quality/pmd.xml`.

This replaces the rule with its official successor `TypeParameterNamingConventions`, which applies the same single-uppercase-letter convention for type parameters by default.

`config` is the source of truth that distributes `buildSrc/quality/pmd.xml`, so this clears the warning org-wide. The identical change is applied in the repo where the warning surfaced: `SpineEventEngine/tool-base#177` (the two `pmd.xml` files are byte-identical).

## Verification

Validated against PMD 7.25.0's own ruleset XML: the successor rule exists, is not deprecated, and defaults to the same convention. Static-configuration change only.

https://claude.ai/code/session_014TVLouXfDWCg1sTQVW3ssM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TVLouXfDWCg1sTQVW3ssM)_