### PR TITLE
Check the version increment only for PRs into default branches

### DIFF
--- a/.agents/tasks/version-guard-aux-base-branches.md
+++ b/.agents/tasks/version-guard-aux-base-branches.md
@@ -1,0 +1,45 @@
+---
+slug: version-guard-aux-base-branches
+branch: claude/modest-thompson-0aqffs
+owner: claude
+status: in-review
+started: 2026-06-10
+---
+
+## Goal
+
+PRs with a base branch other than a default (or release-line) one must not
+fail `Version Guard`, `JUnit Test Report (push)`, or `License Reports`
+because of a missing version increment. Only a branch heading into a
+default/protected branch is responsible for bumping the version; auxiliary
+branches stay out of the release cycle.
+
+## Context
+
+- `IncrementGuard` enables `checkVersionIncrement` on `push` to any branch
+  not ending with `master`/`main` — it cannot know the merge target of
+  a push, so feature branches of auxiliary branches fail.
+- `checkVersionIncrement` is wired into `check`, so `Ubuntu CI` (`on: push`)
+  fails the whole build; tests never run and `JUnit Test Report (push)`
+  fails with "no test reports found".
+- `License Reports` requires the dependency reports (which embed the
+  version) to be touched in every PR, including PRs to auxiliary branches.
+- The only reliable signal of "aims to merge into X" is a pull request
+  with base `X` → use `pull_request` events and `GITHUB_BASE_REF`.
+
+## Plan
+
+- [x] `IncrementGuard.kt`: enable the task only for `pull_request` events
+      whose `GITHUB_BASE_REF` ends with `master`/`main`; drop the
+      `push`-event logic; update KDoc; keep the decision a pure function.
+- [x] `increment-guard.yml`: trigger on `pull_request` with base filter
+      `'**master'`/`'**main'` instead of `push` to all branches.
+- [x] `ensure-reports-updated.yml`: same base filter, so PRs into
+      auxiliary branches do not require report updates.
+- [x] Add `IncrementGuardTest` for the decision function.
+- [x] Run buildSrc tests and detekt.
+
+## Log
+
+- 2026-06-10 — drafted and started.
+- 2026-06-10 — implemented; buildSrc tests and detekt pass.

--- a/.agents/tasks/version-guard-aux-base-branches.md
+++ b/.agents/tasks/version-guard-aux-base-branches.md
@@ -32,9 +32,10 @@ branches stay out of the release cycle.
 - [x] `IncrementGuard.kt`: enable the task only for `pull_request` events
       whose `GITHUB_BASE_REF` ends with `master`/`main`; drop the
       `push`-event logic; update KDoc; keep the decision a pure function.
-- [x] `increment-guard.yml`: trigger on `pull_request` with base filter
-      `'**master'`/`'**main'` instead of `push` to all branches.
-- [x] `ensure-reports-updated.yml`: same base filter, so PRs into
+- [x] `increment-guard.yml`: trigger on `pull_request` (instead of `push`
+      to all branches) and skip the job unless the base branch ends with
+      `master`/`main`.
+- [x] `ensure-reports-updated.yml`: same job-level base gate, so PRs into
       auxiliary branches do not require report updates.
 - [x] Add `IncrementGuardTest` for the decision function.
 - [x] Run buildSrc tests and detekt.
@@ -43,3 +44,7 @@ branches stay out of the release cycle.
 
 - 2026-06-10 — drafted and started.
 - 2026-06-10 — implemented; buildSrc tests and detekt pass.
+- 2026-06-10 — review (PR #686): replaced the `branches` filters with
+  job-level `if` conditions — a workflow skipped by branch filtering
+  leaves a required check `Pending` (blocking the PR), while a skipped
+  job satisfies it.

--- a/.github-workflows/ensure-reports-updated.yml
+++ b/.github-workflows/ensure-reports-updated.yml
@@ -4,20 +4,23 @@
 # a release-line (e.g. `2.x-jdk8-master`) branch. The report files embed the project
 # version, so they are refreshed by the branches which bump it. Pull requests
 # targeting auxiliary branches are not checked.
+#
+# The base branch is checked inside the job rather than via the `branches` filter:
+# a workflow skipped by branch filtering leaves its check in the `Pending` state,
+# blocking PRs which require it, while a job skipped via `if` reports `skipped`,
+# which satisfies required status checks.
 
 name: License Reports
 
 on:
   pull_request:
-    branches:
-      # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
-      - '**master'
-      - '**main'
 
 jobs:
   check:
     name: Ensure license reports are updated
     runs-on: ubuntu-latest
+    # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
+    if: endsWith(github.base_ref, 'master') || endsWith(github.base_ref, 'main')
 
     steps:
       - uses: actions/checkout@v6

--- a/.github-workflows/ensure-reports-updated.yml
+++ b/.github-workflows/ensure-reports-updated.yml
@@ -1,11 +1,18 @@
 # Ensures that the license report files were modified in this PR.
+#
+# The check runs only for pull requests targeting a default (`master`/`main`) or
+# a release-line (e.g. `2.x-jdk8-master`) branch. The report files embed the project
+# version, so they are refreshed by the branches which bump it. Pull requests
+# targeting auxiliary branches are not checked.
 
 name: License Reports
 
 on:
   pull_request:
     branches:
-      - '**'
+      # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
+      - '**master'
+      - '**main'
 
 jobs:
   check:

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -1,12 +1,19 @@
-# Ensures that the current lib version is not yet published but executing the Gradle
+# Ensures that the current lib version is not yet published by executing the Gradle
 # `checkVersionIncrement` task.
+#
+# The check runs only for pull requests targeting a default (`master`/`main`) or
+# a release-line (e.g. `2.x-jdk8-master`) branch. It is the responsibility of a branch
+# which aims to merge into such a branch to bump the version. Auxiliary branches
+# do not deal with the versions in the release cycle and are not guarded.
 
 name: Version Guard
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**'
+      # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
+      - '**master'
+      - '**main'
 
 jobs:
   check:

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -5,20 +5,23 @@
 # a release-line (e.g. `2.x-jdk8-master`) branch. It is the responsibility of a branch
 # which aims to merge into such a branch to bump the version. Auxiliary branches
 # do not deal with the versions in the release cycle and are not guarded.
+#
+# The base branch is checked inside the job rather than via the `branches` filter:
+# a workflow skipped by branch filtering leaves its check in the `Pending` state,
+# blocking PRs which require it, while a job skipped via `if` reports `skipped`,
+# which satisfies required status checks.
 
 name: Version Guard
 
 on:
   pull_request:
-    branches:
-      # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
-      - '**master'
-      - '**main'
 
 jobs:
   check:
     name: Check version increment
     runs-on: ubuntu-latest
+    # Default and release-line branches, e.g. `master`, `main`, `2.x-jdk8-master`.
+    if: endsWith(github.base_ref, 'master') || endsWith(github.base_ref, 'main')
 
     steps:
       - uses: actions/checkout@v6

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -40,7 +40,23 @@ import org.gradle.api.Project
 class IncrementGuard : Plugin<Project> {
 
     companion object {
+
         const val taskName = "checkVersionIncrement"
+
+        /**
+         * Tells whether the version increment must be verified for the given
+         * GitHub Actions event and the base branch of the pull request.
+         *
+         * The version is guarded only for pull requests targeting a default or
+         * a release-line branch, i.e. a branch with the name ending with `master`
+         * or `main`. For example: `master`, `main`, `2.x-jdk8-master`, `2.x-jdk8-main`.
+         */
+        internal fun shouldCheckVersion(event: String?, baseBranch: String?): Boolean {
+            if (event != "pull_request" || baseBranch == null) {
+                return false
+            }
+            return baseBranch.endsWith("master") || baseBranch.endsWith("main")
+        }
     }
 
     /**
@@ -48,11 +64,15 @@ class IncrementGuard : Plugin<Project> {
      *
      * The task is created anyway, but it is enabled only if:
      *  1. The project is built on GitHub CI, and
-     *  2. The job is a pull request.
+     *  2. The job is a pull request targeting a default (`master` or `main`) or
+     *     a release-line (e.g. `2.x-jdk8-master`) branch.
      *
-     * The task only runs on non-master branches on GitHub Actions.
-     * This is done to prevent unexpected CI fails when re-building `master` multiple times,
-     * creating git tags, and in other cases that go outside the "usual" development cycle.
+     * It is the responsibility of a branch which aims to merge into a default
+     * (or otherwise protected) branch to bump the version. Auxiliary branches do not
+     * deal with the versions in the release cycle, so pull requests targeting them,
+     * direct pushes, and tag builds do not run the check. This also prevents unexpected
+     * CI fails when re-building `master` multiple times, creating git tags, and in other
+     * cases that go outside the "usual" development cycle.
      */
     override fun apply(target: Project) {
         val tasks = target.tasks
@@ -64,7 +84,8 @@ class IncrementGuard : Plugin<Project> {
 
             if (!shouldCheckVersion()) {
                 logger.info(
-                    "The build does not represent a GitHub Actions feature branch job, " +
+                    "The build does not represent a GitHub Actions pull request job " +
+                            "targeting a default or a release-line branch, " +
                             "the `checkVersionIncrement` task is disabled."
                 )
                 this.enabled = false
@@ -73,40 +94,19 @@ class IncrementGuard : Plugin<Project> {
     }
 
     /**
-     * Returns `true` if the current build is a GitHub Actions build which represents a push
-     * to a feature branch.
+     * Returns `true` if the current build is a GitHub Actions build of a pull request
+     * targeting a default (`master` or `main`) or a release-line branch,
+     * such as `2.x-jdk8-master`.
      *
-     * Returns `false` if the associated reference is not a branch (e.g., a tag) or if it has
-     * the name which ends with `master` or `main`.
-     *
-     * For example, on the following branches the method would return `false`:
-     *
-     * 1. `master`.
-     * 2. `main`.
-     * 3. `2.x-jdk8-master`.
-     * 4. `2.x-jdk8-main`.
+     * Returns `false` for all other builds, including direct pushes, tag builds,
+     * and pull requests targeting auxiliary branches.
      *
      * @see <a href="https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables">
      *     List of default environment variables provided for GitHub Actions builds</a>
      */
     private fun shouldCheckVersion(): Boolean {
         val event = System.getenv("GITHUB_EVENT_NAME")
-        val reference = System.getenv("GITHUB_REF")
-        if (event != "push" || reference == null) {
-            return false
-        }
-        val branch = branchName(reference)
-        return when {
-            branch == null -> false
-            branch.endsWith("master") -> false
-            branch.endsWith("main") -> false
-            else -> true
-        }
-    }
-
-    private fun branchName(gitHubRef: String): String? {
-        val matches = Regex("refs/heads/(.+)").matchEntire(gitHubRef)
-        val branch = matches?.let { it.groupValues[1] }
-        return branch
+        val baseBranch = System.getenv("GITHUB_BASE_REF")
+        return shouldCheckVersion(event, baseBranch)
     }
 }

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.publish
+
+import io.kotest.matchers.shouldBe
+import io.spine.gradle.publish.IncrementGuard.Companion.shouldCheckVersion
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`IncrementGuard` should")
+class IncrementGuardTest {
+
+    @Nested
+    inner class `require the version check` {
+
+        @Test
+        fun `for pull requests targeting default branches`() {
+            shouldCheckVersion("pull_request", "master") shouldBe true
+            shouldCheckVersion("pull_request", "main") shouldBe true
+        }
+
+        @Test
+        fun `for pull requests targeting release-line branches`() {
+            shouldCheckVersion("pull_request", "2.x-jdk8-master") shouldBe true
+            shouldCheckVersion("pull_request", "2.x-jdk8-main") shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `not require the version check` {
+
+        @Test
+        fun `for pull requests targeting auxiliary branches`() {
+            shouldCheckVersion("pull_request", "epic-feature") shouldBe false
+            shouldCheckVersion("pull_request", "master-fixes") shouldBe false
+        }
+
+        @Test
+        fun `for push events`() {
+            shouldCheckVersion("push", "master") shouldBe false
+            shouldCheckVersion("push", null) shouldBe false
+        }
+
+        @Test
+        fun `for pull request events without a base branch`() {
+            shouldCheckVersion("pull_request", null) shouldBe false
+        }
+
+        @Test
+        fun `outside GitHub Actions`() {
+            shouldCheckVersion(null, null) shouldBe false
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The `Version Guard` workflow — and, by cascade, `JUnit Test Report (push)` — failed for PRs whose base branch is not the default one (`master`). The guard triggered on `push` to any branch and enabled `checkVersionIncrement` for any branch not ending with `master`/`main`, with no awareness of where the branch intends to merge. Since `checkVersionIncrement` is wired into `check`, the `Ubuntu CI` build failed before tests produced reports, taking the JUnit report check down with it (`require_tests: true`).

A version increment is the responsibility of a branch which aims to merge into a default (or otherwise protected) branch. Auxiliary branches do not deal with the versions in the release cycle.

## Changes

- **`IncrementGuard`** now enables the `checkVersionIncrement` task only for `pull_request` events whose base branch name ends with `master` or `main` (covers `master`, `main`, and release-line branches such as `2.x-jdk8-master`). The `push`-event logic and the `GITHUB_REF` parsing are gone; the decision is a pure function covered by the new `IncrementGuardTest`.
- **`Version Guard` workflow** triggers on `pull_request` instead of `push` to all branches. The base branch is checked by a job-level `if` mirroring the `IncrementGuard` logic: for a PR into an auxiliary branch the job reports `skipped`, which satisfies required status checks (a workflow skipped via the `branches` filter would leave a required check in the `Pending` state, blocking the PR) and occupies no runner.
- **`License Reports` workflow** gets the same job-level gate: the dependency report files embed the project version, so they are refreshed by the version-bumping branches. PRs into auxiliary branches no longer require touching them. (`ensure-reports-updated.sh` itself needs no change — it already works off `GITHUB_BASE_REF`.)

## Behavioral notes

- The guard now fires on PR events (`opened`/`synchronize`) rather than on pushes, so a branch without an open PR is never version-checked. Coverage for master-bound work is unchanged: every push to a PR'd branch triggers `synchronize`.
- Pushes no longer fail `Ubuntu CI`/`JUnit Test Report` over a stale version. Instead, for PRs into `master`-like bases, the enabled task participates in `check` on `Windows CI` (a `pull_request` build) alongside the dedicated `Version Guard` run — the same signal, moved from push-side to PR-side.
- Required status check configurations keep working: the job names are unchanged, and skipped jobs satisfy them.

## Verification

- `./gradlew -p buildSrc test` — passes, including the new `IncrementGuardTest`.
- `./gradlew detekt` — passes.
- Both workflow files parse as valid YAML with the expected `pull_request` triggers and job conditions.

Consumer repositories receive the fix via the usual `./config/pull` cycle.

https://claude.ai/code/session_01Et5WtRbSBtjL6ZiXynsDfr