### PR TITLE
Credit sibling-module test coverage in Kover reports

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.400"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.400"
+    const val version = "2.0.0-SNAPSHOT.404"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.404"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
@@ -276,7 +276,7 @@ class KoverConfig private constructor(
             .flatMap { root ->
                 root.walk()
                     .filter { !it.isDirectory }
-                    .flatMap { it.fqnsRelativeTo(root).asSequence() }
+                    .flatMap { it.classNamesIn(root).asSequence() }
             }
             .distinct()
             .toList()
@@ -359,7 +359,7 @@ private fun KotlinSourceSet.isMainSourceSet(): Boolean =
  *
  * Returns an empty list if this file is not under [root].
  */
-private fun File.fqnsRelativeTo(root: File): List<String> {
+internal fun File.classNamesIn(root: File): List<String> {
     if (!startsWith(root)) {
         return emptyList()
     }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/SiblingCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/SiblingCoverage.kt
@@ -26,9 +26,13 @@
 
 package io.spine.gradle.report.coverage
 
+import java.io.File
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskCollection
+import org.gradle.api.tasks.testing.Test
 
 /**
  * Credits the test coverage produced by the [contributor] module for the classes
@@ -37,16 +41,23 @@ import org.gradle.api.Task
  * Some modules' production classes are exercised only by the tests of a sibling
  * module — for example, the language-neutral `psi` classes are tested through
  * the Java-PSI fixtures that live in `psi-java`. Kover's per-module report sees
- * only this module's own `test` execution data, so that cross-module coverage is
+ * only this module's own test execution data, so that cross-module coverage is
  * otherwise missing from the per-module report (which is what Codecov consumes),
  * even though the root aggregated report already accounts for it.
  *
  * This function adds the [contributor]'s JaCoCo execution data to this project's
- * `total` report as an additional binary report. Only this project's classes are
- * credited from it — coverage of unrelated classes in the same execution data is
- * ignored, because a Kover report is scoped to the owning project's classes. The
- * report tasks are wired to run after the contributor's `test` task so the data
- * is present when a report is generated.
+ * `total` report as additional binary reports. Only this project's classes are
+ * credited from them — coverage of unrelated classes in the same execution data
+ * is ignored, because a Kover report is scoped to the owning project's classes.
+ * The report tasks are wired to run after the contributor's JVM test tasks so the
+ * data is present when a report is generated.
+ *
+ * The contributor's JVM test tasks are discovered by type rather than by name, so
+ * the helper works regardless of the module convention: a `jvm-module` contributes
+ * through its `test` task, a `kmp-module` through `jvmTest`, and any additional
+ * JVM test tasks are picked up as well. Non-JVM Kotlin test tasks (`*Native`,
+ * `*Js`, …) are not of type [Test] and are correctly ignored — Kover instruments
+ * only JVM test tasks.
  *
  * Requires the Kover plugin to be applied to this project.
  * A cross-project **task** dependency is used, not a project dependency,
@@ -54,24 +65,40 @@ import org.gradle.api.Task
  * already depends on this project.
  */
 fun Project.creditTestCoverageFrom(contributor: Project) {
-    val execFile = contributor.layout.buildDirectory.file(TEST_EXEC_FILE)
+    val contributorTests = contributor.tasks.withType(Test::class.java)
     extensions.configure(KoverProjectExtension::class.java) {
         reports {
             total {
-                additionalBinaryReports.add(execFile.map { it.asFile })
+                additionalBinaryReports.addAll(contributor.execFilesOf(contributorTests))
             }
         }
     }
     tasks.matching { it.consumesCoverageBinaryReports() }.configureEach {
-        dependsOn("${contributor.path}:test")
+        dependsOn(contributorTests)
     }
 }
 
 /**
- * The Kover/JaCoCo execution-data file produced by a module's `test` task when
- * the coverage engine is pinned to JaCoCo via `useJacoco(...)`.
+ * Lazy `Provider` of the JaCoCo execution-data files produced by [testTasks]
+ * of this project.
+ *
+ * When the coverage engine is pinned to JaCoCo via `useJacoco(...)`, Kover writes
+ * one binary report per instrumented JVM test task at `build/`[BIN_REPORTS_DIR]
+ * `/<taskName>.exec`, so the file name follows the task name. Resolved at
+ * task-graph time, after the contributor's test tasks have been registered.
  */
-private const val TEST_EXEC_FILE: String = "kover/bin-reports/test.exec"
+private fun Project.execFilesOf(testTasks: TaskCollection<Test>): Provider<Iterable<File>> {
+    val binReports = layout.buildDirectory.dir(BIN_REPORTS_DIR)
+    return provider {
+        testTasks.map { binReports.get().file("${it.name}.exec").asFile }
+    }
+}
+
+/**
+ * The directory under a module's `build/` where Kover writes the per-test-task
+ * binary execution-data files.
+ */
+private const val BIN_REPORTS_DIR: String = "kover/bin-reports"
 
 /**
  * Tells whether this is a Kover task that reads the binary reports and therefore

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/SiblingCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/SiblingCoverage.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.report.coverage
+
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+/**
+ * Credits the test coverage produced by the [contributor] module for the classes
+ * of this project to this project's own Kover report.
+ *
+ * Some modules' production classes are exercised only by the tests of a sibling
+ * module — for example, the language-neutral `psi` classes are tested through
+ * the Java-PSI fixtures that live in `psi-java`. Kover's per-module report sees
+ * only this module's own `test` execution data, so that cross-module coverage is
+ * otherwise missing from the per-module report (which is what Codecov consumes),
+ * even though the root aggregated report already accounts for it.
+ *
+ * This function adds the [contributor]'s JaCoCo execution data to this project's
+ * `total` report as an additional binary report. Only this project's classes are
+ * credited from it — coverage of unrelated classes in the same execution data is
+ * ignored, because a Kover report is scoped to the owning project's classes. The
+ * report tasks are wired to run after the contributor's `test` task so the data
+ * is present when a report is generated.
+ *
+ * Requires the Kover plugin to be applied to this project.
+ * A cross-project **task** dependency is used, not a project dependency,
+ * so it does not introduce a dependency cycle even when the [contributor]
+ * already depends on this project.
+ */
+fun Project.creditTestCoverageFrom(contributor: Project) {
+    val execFile = contributor.layout.buildDirectory.file(TEST_EXEC_FILE)
+    extensions.configure(KoverProjectExtension::class.java) {
+        reports {
+            total {
+                additionalBinaryReports.add(execFile.map { it.asFile })
+            }
+        }
+    }
+    tasks.matching { it.consumesCoverageBinaryReports() }.configureEach {
+        dependsOn("${contributor.path}:test")
+    }
+}
+
+/**
+ * The Kover/JaCoCo execution-data file produced by a module's `test` task when
+ * the coverage engine is pinned to JaCoCo via `useJacoco(...)`.
+ */
+private const val TEST_EXEC_FILE: String = "kover/bin-reports/test.exec"
+
+/**
+ * Tells whether this is a Kover task that reads the binary reports and therefore
+ * must run only after the [contributor's][creditTestCoverageFrom] test data exists.
+ *
+ * This matches both the report tasks (`koverXmlReport`, `koverHtmlReport`,
+ * `koverBinaryReport`) and the verification tasks (`koverVerify` and its
+ * cacheable companion `koverCachedVerify`) — the suffix test covers the
+ * `Cached*` variants Kover registers, which are the ones that actually consume
+ * the binary reports.
+ */
+private fun Task.consumesCoverageBinaryReports(): Boolean =
+    name.startsWith("kover") && (name.endsWith("Report") || name.endsWith("Verify"))

--- a/buildSrc/src/test/kotlin/io/spine/gradle/report/coverage/FileExtensionsTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/report/coverage/FileExtensionsTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.report.coverage
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import java.io.File
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@DisplayName("`File.classNamesIn` should")
+class FileExtensionsTest {
+
+    @TempDir
+    lateinit var sourceRoot: File
+
+    @Nested
+    inner class `for Java sources` {
+
+        @Test
+        fun `return a single FQN`() {
+            val file = sourceRoot.touch("io/spine/example/Foo.java")
+
+            file.classNamesIn(sourceRoot) shouldBe listOf("io.spine.example.Foo")
+        }
+
+        @Test
+        fun `handle files placed directly under the source root`() {
+            val file = sourceRoot.touch("Top.java")
+
+            file.classNamesIn(sourceRoot) shouldBe listOf("Top")
+        }
+    }
+
+    @Nested
+    inner class `for Kotlin sources` {
+
+        @Test
+        fun `return both the declared class and the synthetic file class`() {
+            val file = sourceRoot.touch("io/spine/example/Foo.kt")
+
+            file.classNamesIn(sourceRoot) shouldContainExactlyInAnyOrder listOf(
+                "io.spine.example.Foo",
+                "io.spine.example.FooKt"
+            )
+        }
+
+        @Test
+        fun `handle the 'Kt'-suffixed file names emitted by 'protoc-gen-kotlin'`() {
+            val file = sourceRoot.touch("io/spine/example/ValidationErrorKt.kt")
+
+            file.classNamesIn(sourceRoot) shouldContainExactlyInAnyOrder listOf(
+                "io.spine.example.ValidationErrorKt",
+                "io.spine.example.ValidationErrorKtKt"
+            )
+        }
+    }
+
+    @Nested
+    inner class `for proto-file-scoped Kotlin sources` {
+
+        @Test
+        fun `strip the two-part 'proto-kt' suffix`() {
+            val file = sourceRoot.touch("io/spine/example/ValidationErrorProtoKt.proto.kt")
+
+            file.classNamesIn(sourceRoot) shouldContainExactlyInAnyOrder listOf(
+                "io.spine.example.ValidationErrorProtoKt",
+                "io.spine.example.ValidationErrorProtoKtKt"
+            )
+        }
+    }
+
+    @Nested
+    inner class `for unsupported inputs` {
+
+        @Test
+        fun `return an empty list for non-source files`() {
+            val file = sourceRoot.touch("io/spine/example/notes.txt")
+
+            file.classNamesIn(sourceRoot) shouldBe emptyList()
+        }
+
+        @Test
+        fun `return an empty list for files outside the source root`() {
+            val outsideRoot = File(sourceRoot.parentFile, "outside-${System.nanoTime()}")
+            try {
+                val file = outsideRoot.touch("io/spine/example/Foo.java")
+
+                file.classNamesIn(sourceRoot) shouldBe emptyList()
+            } finally {
+                outsideRoot.deleteRecursively()
+            }
+        }
+    }
+}
+
+private fun File.touch(relativePath: String): File {
+    val file = this.resolve(relativePath)
+    file.parentFile.mkdirs()
+    file.createNewFile()
+    return file
+}


### PR DESCRIPTION
## Overview

Applies changes brought over from the **ToolBase** repository. Three independent edits:

### 1. Credit sibling-module test coverage — `SiblingCoverage.kt` (new)

Adds `Project.creditTestCoverageFrom(contributor)`. Some modules' production
classes are exercised only by a sibling module's tests (e.g. the language-neutral
`psi` classes are tested through the `psi-java` fixtures). Kover's per-module
report — the one Codecov consumes — sees only the module's own `test` execution
data, so that cross-module coverage is otherwise lost from the per-module report.

The function feeds the contributor's JaCoCo execution data into this project's
`total` report as an additional binary report (only this project's classes are
credited from it) and wires the report/verify tasks to run after the
contributor's `test` task. A cross-project **task** dependency is used rather
than a project dependency, so no dependency cycle is introduced even when the
contributor already depends on this project.

### 2. Tests for `File.classNamesIn` — `FileExtensionsTest.kt` (new)

Covers the source-file → fully-qualified-class-name mapping: Java sources, Kotlin
sources (declared class + synthetic `…Kt` file class), the `Kt`-suffixed names
emitted by `protoc-gen-kotlin`, the two-part `.proto.kt` suffix, and the
unsupported-input fallbacks (non-source files and files outside the source root).

To make the helper testable, the existing `File.fqnsRelativeTo` in
`KoverConfig.kt` was renamed to `classNamesIn` and widened from `private` to
`internal` — matching the name the applied test expects.

### 3. Dependency bump — `Base.kt`

`spine-base`: `2.0.0-SNAPSHOT.400` → `2.0.0-SNAPSHOT.404`.
