### PR TITLE
Local dependencies and symlinks on Windows CI

### DIFF
--- a/.github-workflows/build-on-windows.yml
+++ b/.github-workflows/build-on-windows.yml
@@ -8,14 +8,6 @@ jobs:
     name: Build on Windows
 
     steps:
-      - name: Configure Git for Windows symlink compatibility
-        shell: pwsh
-        run: |
-          # Avoid creating/expecting native symlinks on Windows runners.
-          # This helps when repository paths (like .agents/guidelines) are represented
-          # via links that can trigger EPERM on stat/access.
-          git config --global core.symlinks false
-
       - uses: actions/checkout@v6
         with:
           submodules: recursive

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.404"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.404"
+    const val version = "2.0.0-SNAPSHOT.410"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.410"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.046"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.051"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.046"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.051"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.069"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.070"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.069"
+    const val version = "2.0.0-SNAPSHOT.070"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.068"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.069"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.068"
+    const val version = "2.0.0-SNAPSHOT.069"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.381"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.381"
+    const val version = "2.0.0-SNAPSHOT.400"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.400"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"


### PR DESCRIPTION
This PR:
 * Bumps local dependencies for consuming projects.
 * Restores `build-on-window.yml` workflow so that Window builds at CI can enjoy symlinks back.
