### PR TITLE
Run Dokka in the PR build to catch doc warnings before merge

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
 
       # `build` does not run Dokka — its tasks are gated to the publishing
       # graph — so `dokkaGenerate` is appended to surface documentation
-      # warnings here, during PR review, instead of in the post-merge
+      # warnings on each push, before merge, instead of only in the post-merge
       # `Publish` job. `failOnWarning` is enabled in the Dokka setup.
       - name: Build project, run tests, and check documentation
         shell: bash

--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -19,9 +19,13 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
-      - name: Build project and run tests
+      # `build` does not run Dokka — its tasks are gated to the publishing
+      # graph — so `dokkaGenerate` is appended to surface documentation
+      # warnings here, during PR review, instead of in the post-merge
+      # `Publish` job. `failOnWarning` is enabled in the Dokka setup.
+      - name: Build project, run tests, and check documentation
         shell: bash
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build dokkaGenerate --stacktrace
 
       # See: https://github.com/marketplace/actions/junit-report-action
       - name: Publish Test Report


### PR DESCRIPTION
## Problem

CI repeatedly fails on Dokka documentation warnings during **publishing** — i.e. *after* a PR is merged.

The distributed `build-on-ubuntu.yml` ran only `./gradlew build`, which does **not** run Dokka: Dokka tasks are gated to the publishing graph (`isInPublishingGraph()` in `buildSrc/.../DokkaExts.kt`). With `failOnWarning` enabled, Dokka first ran in the post-merge **Publish to Maven repositories** job, so documentation warnings surfaced only after the PR was already merged.

## Fix

Append `dokkaGenerate` to the Ubuntu build step, so the command becomes `./gradlew build dokkaGenerate --stacktrace`.

The same Dokka run (with `failOnWarning`) now executes during PR review, on every push to the branch — matching what the `pre-pr` skill already runs locally. The `Publish` job keeps its own Dokka run as a backstop, so publish-time behaviour is unchanged.

Because `.github-workflows/` is merged into each consumer repo's `.github/workflows/` by `./config/pull`, this gate ships org-wide on the next update.

## Notes

- Added to the Ubuntu build only; Dokka output is platform-independent, so duplicating it on the Windows job would add no coverage for extra CI time.
- `failOnWarning` is unchanged — still enabled in the shared Dokka setup.

## Companion PR

`SpineEventEngine/agents` (branch `claude/magical-cerf-hp5u51`) updates the guidelines and skills that previously stated Dokka runs "only in the publish CI job".

https://claude.ai/code/session_01QcJcahKjYEXfaVrVrYo5sj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcJcahKjYEXfaVrVrYo5sj)_