### PR TITLE
Fix Maven scope and version selection in the POM dependency report

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -10,6 +10,8 @@ See [README.md](README.md) for the format and routing rules.
 ## Project (durable context & rationale)
 
 - [spine-compiler-replaces-protodata](project/spine-compiler-replaces-protodata.md) — ProtoData is archived; Spine Compiler (`compiler` repo, `io.spine.compiler`) supersedes it as the active code-generation plugin.
+- [porting-buildsrc-from-consumer-repos](project/porting-buildsrc-from-consumer-repos.md) — To back-port buildSrc improvements from a consumer repo, diff after its last "Update `config`" commit; consumer-owned files never port.
+- [config-build-verification](project/config-build-verification.md) — config root has no `build` task; verify buildSrc via `./gradlew :buildSrc:test detekt` with JAVA_HOME exported.
 - [plugin-testkit-assertions-live-in-tool-base](project/plugin-testkit-assertions-live-in-tool-base.md) — Generic Gradle-plugin functional-test assertions (testkit-truth) belong in tool-base/plugin-testlib, not per-plugin `*-testlib` modules.
 
 ## Reference (external systems)

--- a/.agents/memory/project/config-build-verification.md
+++ b/.agents/memory/project/config-build-verification.md
@@ -1,0 +1,22 @@
+---
+name: config-build-verification
+description: config root has no `build` task — verify buildSrc changes with `./gradlew :buildSrc:test detekt`, exporting JAVA_HOME first.
+metadata:
+  type: project
+  since: 2026-06-11
+---
+
+The root project of `config` applies no Java/Kotlin plugin, so the generic
+`./gradlew build` from `running-builds.md` fails with "Task 'build' is
+ambiguous". The Kotlin code lives in `buildSrc`, and Gradle 8+ no longer
+runs `buildSrc` tests as part of the main build.
+
+**Why:** `running-builds.md` is shared guidance from the floating
+`.agents/shared` submodule and cannot encode per-repo exceptions. CI in
+this repo runs only `detekt` (plus link and wrapper checks), so there is
+no workflow file documenting a local test command either.
+
+**How to apply:** to verify `buildSrc` changes in `config`, run
+`./gradlew :buildSrc:test detekt`. In a CLI session, export `JAVA_HOME`
+first (e.g. `export JAVA_HOME=$(/usr/libexec/java_home)`) — the Gradle
+Doctor plugin fails the configuration phase without it.

--- a/.agents/memory/project/porting-buildsrc-from-consumer-repos.md
+++ b/.agents/memory/project/porting-buildsrc-from-consumer-repos.md
@@ -1,0 +1,28 @@
+---
+name: porting-buildsrc-from-consumer-repos
+description: To back-port buildSrc improvements from a consumer repo, diff after its last "Update `config`" commit; consumer-owned files never port.
+metadata:
+  type: project
+  since: 2026-06-11
+---
+
+Consumer repos receive `buildSrc` from `config` via `./config/pull`, recorded
+as "Update `config`" commits. Improvements made in a consumer repo are exactly
+its `git diff <last-update-config-commit>..HEAD -- buildSrc/`; a raw tree diff
+overstates the delta.
+
+**Why:** A tree diff between the consumer repo and `config` mixes four
+unrelated things: genuine improvements, `config` having moved ahead since the
+sync, consumer-owned files, and stale leftovers the pull script never deletes
+(e.g. ProtoTap kept `io/spine/dependency/local/ProtoData.kt` after `config`
+removed it).
+
+**How to apply:** When asked to "bring buildSrc improvements from repo X to
+`config`", find X's newest "Update `config`" commit and diff `buildSrc/` from
+there to HEAD. Never port consumer-owned files: `module.gradle.kts` (a
+template stub in `config` by design — same list as the AGENTS.md code-review
+filter) and repo-local convention plugins/helpers living in X's `buildSrc`
+(e.g. ProtoTap's `version-to-resources.gradle.kts`,
+`PatchGeneratedTemplateString.kt`). Cross-check direction on each remaining
+file — if `config` HEAD is newer (version bumps), the consumer copy is stale,
+not improved.

--- a/.agents/tasks/archive/pom-report-scope-merge.md
+++ b/.agents/tasks/archive/pom-report-scope-merge.md
@@ -1,0 +1,95 @@
+---
+slug: pom-report-scope-merge
+branch: group-of-fixes
+owner: claude
+status: in-review
+started: 2026-06-11
+---
+
+## Goal
+
+The aggregated dependency report (`docs/dependencies/pom.xml` in consumer
+repos) must never mark a production dependency as `<scope>test</scope>`
+just because a test-only module also uses it. When the retained version of
+an artifact comes from several configurations, the higher-ranked Maven scope
+wins (`compile` over `provided` over `runtime` over `test`).
+
+## Context
+
+Observed in `SpineEventEngine/core-jvm-compiler` PR #94: after adding the
+test-only `annotation-tests` module, `io.spine:spine-base` — an `api`
+dependency of production modules — flipped to `test` scope in
+`docs/dependencies/pom.xml`. Root cause: `deduplicate()` in
+`buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt`
+collapsed same-GAV entries with `distinctBy { it.gav }`, keeping the
+first-encountered occurrence — whose configuration then dictated the scope.
+
+## Plan
+
+- [x] Rework `deduplicate()`: group by `group:name`, retain the newest
+      version, and among the usages of that version pick the occurrence
+      with the widest scope, ranked by the existing
+      `ScopedDependency.dependencyPriority()` (compile < runtime < test <
+      other). No new API surface; the "several versions" log keeps its
+      old semantics via per-group `distinctBy { it.gav }`.
+- [x] Document in `dependencyPriority()` KDoc that the same ordering
+      drives scope selection for duplicated dependencies.
+- [x] Add `DependencyWriterSpec` (JUnit 5 + Kotest, `ProjectBuilder`):
+      compile-over-test, runtime-over-test, compile-over-runtime,
+      newest-version-with-widest-scope, scope-taken-from-newest-version-
+      usages-only, test-only-stays-test, known-scope-over-unknown-config,
+      undefined-scope-omitted, and the end-to-end `pom.xml` regression.
+- [x] Update copyright years; run `:buildSrc:test`; run review agents.
+- [x] Replace the lexicographic newest-version pick in `deduplicate()` with
+      a version-aware comparison: new `internal object VersionComparator`
+      (numeric segments compared as numbers, release > pre-release,
+      SemVer-flavored, no new dependency) in the same package, used via
+      `maxWith(compareBy(VersionComparator) { it.version ?: "" })`.
+      Scope selection among the newest version's usages stays as is.
+- [x] Cover the comparator directly in `VersionComparatorSpec` (7 tests)
+      and end-to-end in `DependencyWriterSpec` (9.2.0 vs 10.0.0,
+      SNAPSHOT.99 vs SNAPSHOT.100, release vs snapshot, widest scope
+      taken from the numerically newest version).
+- [x] Follow-up: rank `provided` between `compile` and `runtime` in
+      `dependencyPriority()` — the conventional Maven scope order
+      (compile < provided < runtime < test < system < undefined,
+      as an exhaustive `when` over the scope enum) — so
+      `compileOnly`/`annotationProcessor` usages are no longer reported
+      as `test`, and the former `provided`-vs-undefined tie no longer
+      depends on traversal order. The single ranking is kept for both
+      scope selection and layout, so `provided` entries move above
+      `runtime` in the regenerated `docs/dependencies/pom.xml` of
+      consumer repos (one-time, toward the Maven convention).
+
+## Log
+
+- 2026-06-11 — drafted from the user's directive; executing autonomously.
+- 2026-06-11 — implemented and verified: full `:buildSrc:test` green,
+  `DependencyWriterSpec` 9 tests / 0 failures. Stash-check against the
+  old logic: the order-dependence tests fail as expected, proving the
+  spec captures the regression. `spine-code-review` and `kotlin-engineer`
+  reviewers: APPROVE. Known deferred item: version comparison is
+  lexicographic (pre-existing), e.g. `9.2.0` outranks `10.0.0` — separate
+  follow-up.
+- 2026-06-11 — review-fix pass applied (`review-docs` included): non-null
+  `maxBy`/`minBy` pipeline, `val` test fixture, spec constants, KDoc
+  wording aligned with the actual ranking, doc drive-bys.
+- 2026-06-11 — `VersionComparator` follow-up completed across the two
+  parallel sessions: comparator wired into `deduplicate()`, covered by
+  `VersionComparatorSpec` (7 tests) and end-to-end cases. Final state:
+  51 buildSrc tests / 0 failures, `detekt` clean
+  (`./gradlew :buildSrc:test detekt`). The `provided`-vs-`test` ranking
+  gap flagged as a follow-up chip; build-verification lesson recorded in
+  memory `config-build-verification`. Status: in-review; change set
+  staged for the user to commit.
+- 2026-06-11 — `provided` follow-up done: re-ranked into the conventional
+  Maven order in `dependencyPriority()` (with a `MagicNumber` suppression
+  per `coding.md`); KDoc aligned in `ScopedDependency.kt` and
+  `DependencyWriter.kt`; 6 new `DependencyWriterSpec` cases — 57 buildSrc
+  tests, 0 failures, `detekt` clean. Old-ranking check: the 4
+  behavior-pinning tests fail against the previously staged state, as
+  expected. Layout effect accepted: consumer `pom.xml` reports list
+  `provided` before `runtime` on next regeneration; pinned end-to-end by
+  the new layout-order test. `spine-code-review` and `review-docs`:
+  APPROVE; their non-blocking items applied (exhaustive `when` over the
+  scope enum, end-to-end layout test, doc wording alignments).

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/SshKey.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/SshKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ internal class SshKey(
         val gitHubAccessKey = gitHubKey()
         log { "Obtained the key file at ${gitHubAccessKey.absolutePath}." }
         val sshConfigFile = sshConfigFile()
-        log { "Located the SSH key file at ${sshConfigFile.absolutePath}." }
+        log { "Located the SSH config file at ${sshConfigFile.absolutePath}." }
         sshConfigFile.appendPublisher(gitHubAccessKey)
         log { "SSH config file appended." }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,9 @@ import org.gradle.kotlin.dsl.withGroovyBuilder
  * ```
  *
  * When there are several versions of the same dependency, only the one with
- * the newest version is retained.
+ * the newest version is retained. If the retained version is used in several
+ * configurations, the highest-ranking Maven scope is reported, e.g. `compile`
+ * wins over `test`.
  *
  * @see PomGenerator
  */
@@ -65,7 +67,7 @@ private constructor(
     internal companion object {
 
         /**
-         * Creates the `ProjectDependenciesAsXml` for the passed [project].
+         * Creates the `DependencyWriter` for the passed [project].
          */
         fun of(project: Project): DependencyWriter {
             return DependencyWriter(project.dependencies())
@@ -75,7 +77,7 @@ private constructor(
     /**
      * Writes the dependencies in their `pom.xml` format to the passed [out] writer.
      *
-     * <p>Used writer will not be closed.
+     * The used writer will not be closed.
      */
     fun writeXmlTo(out: Writer) {
         val xml = MarkupBuilder(out)
@@ -170,17 +172,30 @@ private fun Dependency.isExternal(): Boolean {
  * But for our `pom.xml`, which has clearly representative character, a single version
  * of a dependency is quite enough.
  *
+ * Versions are compared by [VersionComparator] rather than as plain text, so `10.0.0`
+ * is recognized as newer than `9.2.0`, and `2.0.0-SNAPSHOT.100` — as newer
+ * than `2.0.0-SNAPSHOT.99`.
+ *
+ * When the newest version comes from several configurations, the occurrence with
+ * the highest-ranking Maven scope (as defined by [ScopedDependency.dependencyPriority])
+ * is retained. For example, a dependency declared via `api` in one module and via
+ * `testImplementation` in another is reported with the `compile` scope, so a production
+ * dependency is not misrepresented as a test-scoped one. Likewise, an artifact coming
+ * from `compileOnly` or `annotationProcessor` in one module and from a test
+ * configuration in another is reported as `provided`.
+ *
  * The rejected duplicates are logged.
  */
 private fun Project.deduplicate(dependencies: Set<ModuleDependency>): List<ModuleDependency> {
-    val groups = dependencies.distinctBy { it.gav }
-        .groupBy { it.run { "$group:$name" } }
+    val groups = dependencies.groupBy { it.run { "$group:$name" } }
 
-    logDuplicates(groups)
+    logDuplicates(groups.mapValues { (_, deps) -> deps.distinctBy { it.gav } })
 
-    val filtered = groups.map { group ->
-        group.value.maxByOrNull { dep -> dep.version ?: "" }
-    }.filterNotNull()
+    val filtered = groups.values.map { sameArtifact ->
+        val newest = sameArtifact.maxWith(compareBy(VersionComparator) { it.version ?: "" })
+        sameArtifact.filter { it.version == newest.version }
+            .minBy { it.scoped.dependencyPriority() }
+    }
     return filtered
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ScopedDependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ScopedDependency.kt
@@ -112,12 +112,13 @@ private constructor(
          *  * Compares the scope of the dependency first. Dependency with a lower scope priority
          *  number goes first.
          *
-         *  * For dependencies with the same scope does the lexicographical group name comparison.
-         *
-         *  * For dependencies within the same group, does the lexicographical artifact
+         *  * For dependencies with the **same scope** does the lexicographical group
          *  name comparison.
          *
-         *  * For dependencies with the same artifact name, does the lexicographical artifact
+         *  * For dependencies within the **same group**, does the lexicographical artifact
+         *  name comparison.
+         *
+         *  * For dependencies with the **same artifact name**, does the lexicographical artifact
          *  version comparison.
          */
         private val COMPARATOR: Comparator<ScopedDependency> =

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ScopedDependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ScopedDependency.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ package io.spine.gradle.report.pom
 import io.spine.gradle.report.pom.DependencyScope.compile
 import io.spine.gradle.report.pom.DependencyScope.provided
 import io.spine.gradle.report.pom.DependencyScope.runtime
+import io.spine.gradle.report.pom.DependencyScope.system
 import io.spine.gradle.report.pom.DependencyScope.test
 import io.spine.gradle.report.pom.DependencyScope.undefined
 import org.gradle.api.artifacts.Configuration
@@ -106,12 +107,12 @@ private constructor(
             configurationName.startsWith("test", ignoreCase = true)
 
         /**
-         * Performs comparison of {@code DependencyWithScope} instances according to these rules:
+         * Performs comparison of `ScopedDependency` instances according to these rules:
          *
-         * * Compares the scope of the dependency first. Dependency with lower scope priority
-         * number goes first.
+         *  * Compares the scope of the dependency first. Dependency with a lower scope priority
+         *  number goes first.
          *
-         *  * For dependencies with same scope, does the lexicographical group name comparison.
+         *  * For dependencies with the same scope does the lexicographical group name comparison.
          *
          *  * For dependencies within the same group, does the lexicographical artifact
          *  name comparison.
@@ -138,7 +139,7 @@ private constructor(
         return dependency
     }
 
-    /** Obtains the scope name of this dependency .*/
+    /** Obtains the scope name of this dependency. */
     fun scopeName(): String {
         return scope.name
     }
@@ -147,14 +148,24 @@ private constructor(
      * Obtains the layout priority of a scope.
      *
      * Layout priority determines what scopes come first in the generated `pom.xml` file.
-     * Dependencies with a lower priority number go on top.
+     * Dependencies with a lower priority number go on top, following the conventional
+     * Maven scope order: `compile`, `provided`, `runtime`, `test`, and `system`.
+     * Dependencies with an undefined scope go last.
+     *
+     * The same ordering also drives the scope selection when the same dependency
+     * comes from several configurations: the occurrence with the lowest priority
+     * number is reported. So, a scope required by production code wins over `test`,
+     * and a known scope wins over an undefined one.
      */
+    @Suppress("MagicNumber") // Reason: the values encode the relative scope order.
     internal fun dependencyPriority(): Int {
         return when (scope) {
             compile -> 0
-            runtime -> 1
-            test -> 2
-            else -> 3
+            provided -> 1
+            runtime -> 2
+            test -> 3
+            system -> 4
+            undefined -> 5
         }
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/VersionComparator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/VersionComparator.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.report.pom
+
+/**
+ * Compares dependency version strings by their meaning rather than lexicographically.
+ *
+ * Numeric segments are ordered as numbers, so `10.0.0` is newer than `9.2.0`, and
+ * `2.0.0-SNAPSHOT.100` is newer than `2.0.0-SNAPSHOT.99`. A plain `String` comparison
+ * would order both pairs the other way around.
+ *
+ * The rules follow Semantic Versioning where it applies:
+ *
+ *  1. A version consists of a release part and an optional qualifier, separated by
+ *     the first `-`: for `2.0.0-SNAPSHOT.100` these are `2.0.0` and `SNAPSHOT.100`.
+ *  2. Both parts are compared segment by segment, as split by `.`, and also by `-`
+ *     within a qualifier. Two numeric segments are compared as numbers, two textual
+ *     ones as case-insensitive text, and a numeric segment is older than a textual one.
+ *  3. When one version runs out of segments, it is the older one: `1.0.1` is newer
+ *     than `1.0`, and `1.0.0-RC.1` is newer than `1.0.0-RC`.
+ *  4. When the release parts are equal, a version without a qualifier is newer than
+ *     a version with one: `2.0.0` is newer than `2.0.0-SNAPSHOT.100`.
+ *
+ * Unlike full Maven semantics, qualifiers carry no special meaning: `RC`, `SNAPSHOT`,
+ * and the like are ordered as plain text. This keeps the comparison simple and
+ * predictable for the report, where only the relative recency of the versions
+ * of the same artifact matters.
+ */
+internal object VersionComparator : Comparator<String> {
+
+    override fun compare(left: String, right: String): Int {
+        val (leftRelease, leftQualifier) = left.parse()
+        val (rightRelease, rightQualifier) = right.parse()
+        val byRelease = compareSegments(leftRelease, rightRelease)
+        if (byRelease != 0) {
+            return byRelease
+        }
+        return when {
+            leftQualifier == null && rightQualifier == null -> 0
+            leftQualifier == null -> 1
+            rightQualifier == null -> -1
+            else -> compareSegments(leftQualifier, rightQualifier)
+        }
+    }
+
+    /**
+     * Splits this version into the segments of its release part and the segments
+     * of its qualifier, the latter being `null` when the version has no qualifier.
+     */
+    private fun String.parse(): Pair<List<String>, List<String>?> {
+        val release = substringBefore('-')
+        val qualifier = if ('-' in this) substringAfter('-') else null
+        return release.split('.') to qualifier?.split('.', '-')
+    }
+
+    private fun compareSegments(left: List<String>, right: List<String>): Int {
+        for (index in 0 until maxOf(left.size, right.size)) {
+            val bySegment = compareSegment(
+                left.getOrElse(index) { "" },
+                right.getOrElse(index) { "" }
+            )
+            if (bySegment != 0) {
+                return bySegment
+            }
+        }
+        return 0
+    }
+
+    /**
+     * Compares single segments, ordering an absent (empty) segment below any present
+     * one, a numeric segment below a textual one, numbers by their value, and text
+     * case-insensitively.
+     *
+     * Keeping the empty, numeric, and textual segments in distinct buckets makes
+     * the order transitive: comparing a numeric pair as numbers, but a mixed pair
+     * as text, would order `2` < `10` < `1a` < `2`.
+     */
+    private fun compareSegment(left: String, right: String): Int {
+        if (left.isEmpty() || right.isEmpty()) {
+            return left.length.compareTo(right.length)
+        }
+        val leftNumber = left.toLongOrNull()
+        val rightNumber = right.toLongOrNull()
+        return when {
+            leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+            leftNumber != null -> -1
+            rightNumber != null -> 1
+            else -> left.compareTo(right, ignoreCase = true)
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/DependencyWriterSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/DependencyWriterSpec.kt
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.report.pom
+
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import java.io.StringWriter
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`DependencyWriter` should")
+internal class DependencyWriterSpec {
+
+    private val rootProject: Project = ProjectBuilder.builder().withName("root").build()
+
+    /**
+     * Creates a subproject of the [rootProject] with the given name.
+     *
+     * The names of the subprojects in the tests below are chosen so that
+     * a module using a dependency in a lower-ranked scope — as defined by
+     * [ScopedDependency.dependencyPriority] — sorts first, and is thus
+     * encountered first when the dependencies are collected. This way,
+     * the tests prove that the merged scope does not depend on the order
+     * in which project modules are traversed.
+     */
+    private fun subproject(name: String): Project =
+        ProjectBuilder.builder().withParent(rootProject).withName(name).build()
+
+    /**
+     * Declares a dependency with the given [notation] in the named [configuration],
+     * creating it if it does not exist.
+     */
+    private fun Project.declare(configuration: String, notation: String) {
+        configurations.maybeCreate(configuration)
+        dependencies.add(configuration, notation)
+    }
+
+    @Nested inner class
+    `merge an artifact duplicated across modules` {
+
+        @Test
+        fun `preferring the 'compile' scope over the 'test' one`() {
+            subproject("a-tests").declare("testImplementation", SPINE_BASE)
+            subproject("b-lib").declare("api", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.compile.name
+        }
+
+        @Test
+        fun `preferring the 'runtime' scope over the 'test' one`() {
+            subproject("a-tests").declare("testImplementation", SPINE_BASE)
+            subproject("b-lib").declare("runtimeOnly", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.runtime.name
+        }
+
+        @Test
+        fun `preferring the 'compile' scope over the 'runtime' one`() {
+            subproject("a-run").declare("runtimeOnly", SPINE_BASE)
+            subproject("b-lib").declare("implementation", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.compile.name
+        }
+
+        @Test
+        fun `preferring the 'provided' scope over the 'test' one`() {
+            subproject("a-tests").declare("testImplementation", SPINE_BASE)
+            subproject("b-lib").declare("compileOnly", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.provided.name
+        }
+
+        @Test
+        fun `reporting 'annotationProcessor' and 'testAnnotationProcessor' usages as 'provided'`() {
+            subproject("a-tests").declare("testAnnotationProcessor", SPINE_BASE)
+            subproject("b-codegen").declare("annotationProcessor", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.provided.name
+        }
+
+        @Test
+        fun `preferring the 'compile' scope over the 'provided' one`() {
+            subproject("a-tools").declare("compileOnly", SPINE_BASE)
+            subproject("b-lib").declare("implementation", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.compile.name
+        }
+
+        @Test
+        fun `preferring the 'provided' scope over the 'runtime' one`() {
+            subproject("a-run").declare("runtimeOnly", SPINE_BASE)
+            subproject("b-tools").declare("compileOnly", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.provided.name
+        }
+
+        @Test
+        fun `retaining the newest version with the widest of its scopes`() {
+            subproject("a-tests").declare("testImplementation", SPINE_BASE_NEWER)
+            subproject("b-lib").declare("api", SPINE_BASE_NEWER)
+            subproject("c-old").declare("api", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.dependency().version shouldBe "2.0.1"
+            dependency.scopeName() shouldBe DependencyScope.compile.name
+        }
+
+        @Test
+        fun `comparing versions semantically rather than as text`() {
+            subproject("a-lib").declare("api", "io.spine:spine-base:9.2.0")
+            subproject("b-lib").declare("api", "io.spine:spine-base:10.0.0")
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.dependency().version shouldBe "10.0.0"
+        }
+
+        @Test
+        fun `ordering pre-release increments numerically`() {
+            subproject("a-old").declare("api", "io.spine:spine-base:2.0.0-SNAPSHOT.99")
+            subproject("b-new").declare("api", "io.spine:spine-base:2.0.0-SNAPSHOT.100")
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.dependency().version shouldBe "2.0.0-SNAPSHOT.100"
+        }
+
+        @Test
+        fun `preferring a release over its pre-release`() {
+            subproject("a-snapshot").declare("api", "io.spine:spine-base:2.0.0-SNAPSHOT.100")
+            subproject("b-release").declare("api", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.dependency().version shouldBe "2.0.0"
+        }
+
+        /**
+         * The `api` usage of the older `9.2.0` must affect neither the version
+         * nor the scope: both come from the usages of the newest `10.0.0`,
+         * which would lose to `9.2.0` in a plain text comparison.
+         */
+        @Test
+        fun `taking the widest scope from the usages of the numerically newest version`() {
+            subproject("a-lib").declare("api", "io.spine:spine-base:9.2.0")
+            subproject("b-tests").declare("testImplementation", "io.spine:spine-base:10.0.0")
+            subproject("c-run").declare("runtimeOnly", "io.spine:spine-base:10.0.0")
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.dependency().version shouldBe "10.0.0"
+            dependency.scopeName() shouldBe DependencyScope.runtime.name
+        }
+
+        /**
+         * When the newest version of an artifact occurs only in test configurations,
+         * the `test` scope is reported even if an older version is a production
+         * dependency: the report describes the retained version as it is used.
+         */
+        @Test
+        fun `taking the scope only from the usages of the newest version`() {
+            subproject("a-tests").declare("testImplementation", SPINE_BASE_NEWER)
+            subproject("b-lib").declare("api", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.dependency().version shouldBe "2.0.1"
+            dependency.scopeName() shouldBe DependencyScope.test.name
+        }
+
+        @Test
+        fun `keeping the 'test' scope for an artifact used only in tests`() {
+            subproject("a-tests").declare("testImplementation", SPINE_BASE)
+            subproject("b-tests").declare("testRuntimeOnly", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.scopeName() shouldBe DependencyScope.test.name
+        }
+
+        @Test
+        fun `preferring a known scope over that of an unknown configuration`() {
+            subproject("a-tools").declare("protoData", SPINE_BASE)
+            subproject("b-tests").declare("testImplementation", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.hasDefinedScope() shouldBe true
+            dependency.scopeName() shouldBe DependencyScope.test.name
+        }
+
+        @Test
+        fun `preferring the 'provided' scope over that of an unknown configuration`() {
+            subproject("a-tools").declare("protoData", SPINE_BASE)
+            subproject("b-lib").declare("compileOnly", SPINE_BASE)
+
+            val dependency = rootProject.dependencies().single()
+
+            dependency.hasDefinedScope() shouldBe true
+            dependency.scopeName() shouldBe DependencyScope.provided.name
+        }
+    }
+
+    @Test
+    fun `omit the scope of a dependency coming only from an unknown configuration`() {
+        subproject("lib").declare("protoData", SPINE_BASE)
+
+        val dependency = rootProject.dependencies().single()
+
+        dependency.hasDefinedScope() shouldBe false
+    }
+
+    @Test
+    fun `write a production dependency as 'compile' even when it is also used in tests`() {
+        subproject("a-tests").declare("testImplementation", SPINE_BASE)
+        subproject("b-lib").declare("api", SPINE_BASE)
+
+        val out = StringWriter()
+        DependencyWriter.of(rootProject).writeXmlTo(out)
+        val xml = out.toString()
+
+        xml shouldContain "<artifactId>spine-base</artifactId>"
+        xml shouldContain "<scope>compile</scope>"
+        xml shouldNotContain "<scope>test</scope>"
+    }
+
+    @Test
+    fun `lay out dependencies in the conventional Maven scope order`() {
+        subproject("a-tests").declare("testImplementation", "io.spine:spine-testlib:2.0.0")
+        subproject("b-run").declare("runtimeOnly", "io.spine:spine-logging:2.0.0")
+        subproject("c-tools").declare("annotationProcessor", "io.spine:spine-validate:2.0.0")
+        subproject("d-lib").declare("api", SPINE_BASE)
+
+        val out = StringWriter()
+        DependencyWriter.of(rootProject).writeXmlTo(out)
+        val xml = out.toString()
+
+        val compileAt = xml.indexOf("<scope>compile</scope>")
+        val providedAt = xml.indexOf("<scope>provided</scope>")
+        val runtimeAt = xml.indexOf("<scope>runtime</scope>")
+        val testAt = xml.indexOf("<scope>test</scope>")
+
+        compileAt shouldBeGreaterThan -1
+        compileAt shouldBeLessThan providedAt
+        providedAt shouldBeLessThan runtimeAt
+        runtimeAt shouldBeLessThan testAt
+    }
+
+    private companion object {
+        const val SPINE_BASE = "io.spine:spine-base:2.0.0"
+        const val SPINE_BASE_NEWER = "io.spine:spine-base:2.0.1"
+    }
+}

--- a/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/VersionComparatorSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/VersionComparatorSpec.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.report.pom
+
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`VersionComparator` should")
+internal class VersionComparatorSpec {
+
+    /**
+     * Asserts that [newer] compares above [older], checking both directions.
+     */
+    private fun assertNewer(newer: String, older: String) {
+        VersionComparator.compare(newer, older) shouldBeGreaterThan 0
+        VersionComparator.compare(older, newer) shouldBeLessThan 0
+    }
+
+    @Test
+    fun `compare numeric segments as numbers`() {
+        assertNewer("10.0.0", "9.2.0")
+        assertNewer("2.10.0", "2.9.1")
+        assertNewer("1.0.10", "1.0.9")
+    }
+
+    @Test
+    fun `compare numeric qualifier segments as numbers`() {
+        assertNewer("2.0.0-SNAPSHOT.100", "2.0.0-SNAPSHOT.99")
+        assertNewer("2.0.0-SNAPSHOT.100", "2.0.0-SNAPSHOT.070")
+    }
+
+    @Test
+    fun `treat a release as newer than its pre-release`() {
+        assertNewer("2.0.0", "2.0.0-SNAPSHOT.100")
+        assertNewer("1.0.0", "1.0.0-RC.2")
+    }
+
+    @Test
+    fun `treat a longer version as newer when the common segments are equal`() {
+        assertNewer("1.0.1", "1.0")
+        assertNewer("1.0.0-RC.1", "1.0.0-RC")
+    }
+
+    @Test
+    fun `ignore the case of textual segments`() {
+        assertNewer("1.0.0-snapshot.10", "1.0.0-SNAPSHOT.2")
+        VersionComparator.compare("1.0.0-RC", "1.0.0-rc") shouldBe 0
+    }
+
+    @Test
+    fun `order a numeric segment before a textual one`() {
+        assertNewer("1.0.0-alpha", "1.0.0-1")
+    }
+
+    @Test
+    fun `treat equal versions as equal`() {
+        VersionComparator.compare("2.0.0-SNAPSHOT.070", "2.0.0-SNAPSHOT.070") shouldBe 0
+        VersionComparator.compare("31.1-jre", "31.1-jre") shouldBe 0
+    }
+}


### PR DESCRIPTION
## What & why

The aggregated dependency report (`docs/dependencies/pom.xml` in consumer repos)
could mislabel a **production** dependency as `<scope>test</scope>` whenever a
test-only module happened to depend on the same artifact. Observed in
[`SpineEventEngine/core-jvm-compiler` PR #94](https://github.com/SpineEventEngine/core-jvm-compiler/pull/94),
where `io.spine:spine-base` — an `api` dependency of production modules — flipped
to `test` scope.

Root cause: `deduplicate()` collapsed same-GAV entries with
`distinctBy { it.gav }`, keeping the *first-encountered* occurrence, whose
configuration then dictated the reported scope. Version selection was also a
plain lexicographic string compare, so `9.2.0` incorrectly outranked `10.0.0`.

## Changes

- **Scope merge** — `deduplicate()` now groups by `group:name`, retains the
  newest version, and among that version's usages reports the **widest** Maven
  scope. A dependency used via `api` in one module and `testImplementation` in
  another is reported as `compile`, not `test`.
- **`VersionComparator`** (new) — numeric-aware, SemVer-flavored version
  ordering: `10.0.0` > `9.2.0`, `2.0.0-SNAPSHOT.100` > `2.0.0-SNAPSHOT.99`,
  release > pre-release. Replaces the lexicographic compare. No new dependency.
- **`dependencyPriority()`** — re-ranked into the conventional Maven scope order
  (`compile < provided < runtime < test < system < undefined`) as an exhaustive
  `when` over the scope enum. The single ranking drives both scope selection and
  `pom.xml` layout, so `compileOnly`/`annotationProcessor` usages report as
  `provided` rather than `test`.

## Tests

- `VersionComparatorSpec` — 7 tests (numeric ordering, release-vs-pre-release,
  segment edge cases).
- `DependencyWriterSpec` — 19 tests (`ProjectBuilder`-based): scope precedence,
  numeric version selection, and the end-to-end `pom.xml` regression.

`./gradlew :buildSrc:test detekt` green; `spine-code-review`, `kotlin-engineer`,
and `review-docs` all APPROVE.

## Also on this branch

`group-of-fixes` bundles two small unrelated commits: an SSH log-message typo
fix (`SshKey.kt`) and agent-memory additions under `.agents/memory/`.

## One-time downstream effect

On the next regeneration, consumer `pom.xml` reports list `provided`
dependencies above `runtime` — a one-time layout shift toward the Maven
convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
