### PR TITLE
Handle `null` versions in dependency reports; fix "which/that" doc grammar

### DIFF
--- a/.agents/tasks/archive/pom-version-null.md
+++ b/.agents/tasks/archive/pom-version-null.md
@@ -1,0 +1,65 @@
+---
+slug: pom-version-null
+branch: which-that
+owner: claude
+status: in-review
+started: 2026-06-15
+---
+
+## Goal
+
+The aggregated dependency report (`docs/dependencies/pom.xml` in consumer repos)
+must never emit `<version>null</version>`. A BOM-managed coordinate that carries
+no explicit version must omit the `<version>` element entirely, producing valid
+Maven XML.
+
+## Context
+
+Surfaced by a Copilot review on `SpineEventEngine/compiler` PR #69
+(discussion `r3415608846`). Pre-existing on `master`; not introduced by that PR.
+Affected artifacts observed in the generated report: `junit-platform-launcher`,
+`io.grpc:grpc-protobuf`, `io.grpc:grpc-stub`, `jackson-dataformat-yaml`.
+
+Root cause: `buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt`
+wrote `"version" { xml.text(dependency.version) }` unconditionally. For a
+version-less dependency `dependency.version` is `null`, and the
+`MarkupBuilder.text` helper (`MarkupExtensions.kt`) does `value.toString()`,
+turning `null` into the literal string `"null"`. The data layer already knew a
+null version was possible — `deduplicate()` guards it with `it.version ?: ""` —
+only the emission site did not.
+
+Config-owned: the `report/pom/*.kt` files are byte-identical across all consumer
+repos and cannot be durably fixed there. Fixed here; floats via the `config`
+submodule + `pull`. Relates to the vendored-`buildSrc` audit follow-ups tracked
+in config#691 (a 6th, self-contained item — fixed directly rather than deferred).
+
+## Plan
+
+- [x] Guard the version element in `DependencyWriter.writeXmlTo`: emit
+      `<version>` only when `dependency.version != null`
+      (`dependency.version?.let { … }`), mirroring the existing conditional for
+      the optional `<scope>` element. Chose "omit the element" (option a) over
+      "resolve the effective BOM-managed version" (option b): the generator
+      walks declared deps across all configurations, including non-resolvable
+      ones, so the resolved version is not readily available; an omitted
+      `<version>` is also the correct Maven representation for a managed version.
+- [x] Add `DependencyWriterSpec` regression test
+      `omit the version of a dependency that declares none`: a version-less
+      `io.grpc:grpc-stub` (BOM-managed) plus a versioned `spine-base` prove the
+      literal `null` is gone while versioned entries still emit `<version>`.
+- [x] Verify: `./gradlew :buildSrc:test detekt` green; regression proof
+      (test fails without the fix); detekt clean.
+
+## Log
+
+- 2026-06-15 — drafted from the user's directive; plan approved.
+- 2026-06-15 — implemented Changes 1–2. No version bump or `docs/dependencies`
+      regeneration: `config` has no root `version.gradle.kts` and no such
+      directory; both happen consumer-side on the next `pull` + build. Both
+      source files already carry the 2026 copyright year.
+- 2026-06-15 — verified: `./gradlew :buildSrc:test detekt` BUILD SUCCESSFUL
+      (JDK 17). New `DependencyWriterSpec` test green (top-level suite 3 → 4
+      tests, 0 failures); detekt clean. Regression proof: reverting the guard
+      makes the new test fail at the `<version>null</version>` assertion
+      (`DependencyWriterSpec.kt:268`); fix restored. Change set staged for the
+      user to review and commit.

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -337,7 +337,7 @@ val buildToolConfigurations: Array<String> = arrayOf(
 )
 
 /**
- * Make the `sourcesJar` task accept duplicated input which seems to occur
+ * Make the `sourcesJar` task accept duplicated input, which seems to occur
  * somewhere inside Protobuf Gradle Plugin.
  */
 fun Project.allowDuplicationInSourcesJar() {

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -216,7 +216,7 @@ fun Project.htmlDocsJar(): TaskProvider<Jar> = tasks.getOrCreate("htmlDocsJar") 
 }
 
 /**
- * Tells if this task belongs to the execution graph which contains
+ * Tells if this task belongs to the execution graph that contains
  * the `publish` and `dokkaGenerate` tasks.
  *
  * This predicate could be useful for disabling publishing tasks

--- a/buildSrc/src/main/kotlin/LicenseSettings.kt
+++ b/buildSrc/src/main/kotlin/LicenseSettings.kt
@@ -1,31 +1,31 @@
 /*
-* Copyright 2025, TeamDev. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Redistribution and use in source and/or binary forms, with or without
-* modification, must retain the above copyright notice and the following
-* disclaimer.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
- * The settings of the software license which apply to the code of this project.
+ * The settings of the software license that apply to the code of this project.
  *
  * The constants defined in this object are used by the
  * [PublicationHandler][io.spine.gradle.publish.PublicationHandler] to set up

--- a/buildSrc/src/main/kotlin/Strings.kt
+++ b/buildSrc/src/main/kotlin/Strings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
  * This file provides extensions to `String` and `CharSequence` that wrap
  * analogues from standard Kotlin runtime.
  *
- * It helps in switching between versions of Gradle which have different versions of
+ * It helps in switching between versions of Gradle that have different versions of
  * the Kotlin runtime. Please see the bodies of the extension functions for details on
  * switching the implementations depending on the Kotlin version at hand.
  *

--- a/buildSrc/src/main/kotlin/io/spine/dependency/Dependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/Dependency.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ abstract class Dependency {
      *
      * @param project The project in which the artifacts are forced. Used for logging.
      * @param cfg The configuration for which the artifacts are forced.  Used for logging.
-     * @param rs The resolution strategy which forces the artifacts.
+     * @param rs The resolution strategy that forces the artifacts.
      */
     fun forceArtifacts(project: Project, cfg: Configuration, rs: ResolutionStrategy) {
         artifacts.values.forEach {
@@ -90,7 +90,7 @@ abstract class Dependency {
 }
 
 /**
- * A dependency which declares a Maven Bill of Materials (BOM).
+ * A dependency that declares a Maven Bill of Materials (BOM).
  *
  * @see <a href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Bill_of_Materials_.28BOM.29_POMs">
  * Maven Bill of Materials</a>
@@ -110,7 +110,6 @@ abstract class DependencyWithBom : Dependency() {
  */
 fun Configuration.diagSuffix(project: Project): String =
     "the configuration `$name` in the project: `${project.path}`."
-
 
 private fun ResolutionStrategy.forceWithLogging(
     project: Project,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 
 /**
- * The plugin which forces versions of platforms declared in the [Boms] object.
+ * The plugin that forces versions of platforms declared in the [Boms] object.
  *
  * Versions are enforced via the
  * [org.gradle.api.artifacts.dsl.DependencyHandler.enforcedPlatform] call

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsCli.kt
@@ -27,7 +27,7 @@
 package io.spine.dependency.lib
 
 /**
- * Commons CLI is a transitive dependency which we don't use directly.
+ * Commons CLI is a transitive dependency that we don't use directly.
  * We `force` it in [forceVersions].
  *
  * [Commons CLI](https://commons.apache.org/proper/commons-cli/)

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -35,7 +35,7 @@ import io.spine.dependency.DependencyWithBom
 object Kotlin : DependencyWithBom() {
 
     /**
-     * This is the version of Kotlin we use for writing code which does not
+     * This is the version of Kotlin we use for writing code that does not
      * depend on Gradle and the version of embedded Kotlin.
      */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from the outside.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/ConfigTester.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/ConfigTester.kt
@@ -250,7 +250,7 @@ class GitRepository(
 class ClonedRepo(
 
     /**
-     * Origin Git repository which is cloned.
+     * Origin Git repository that is cloned.
      */
     private val repo: GitRepository,
 
@@ -269,7 +269,7 @@ class ClonedRepo(
      * The original `buildSrc` folder, if it exists in this cloned repo, is renamed
      * to `buildSrc-original`.
      *
-     * Optionally, takes an [ignoredFolder] which will be excluded from the [source] paths
+     * Optionally, takes an [ignoredFolder] that will be excluded from the [source] paths
      * when copying.
      *
      *
@@ -289,7 +289,7 @@ class ClonedRepo(
      * The original `config` folder, if it exists in this cloned repo, is renamed
      * to `config-original`.
      *
-     * Optionally, takes an [ignoredFolder] which will be excluded from the [source] paths
+     * Optionally, takes an [ignoredFolder] that will be excluded from the [source] paths
      * when copying.
      *
      * Returns this instance of `ClonedRepo`, for call chaining.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 
 /**
- * A Gradle task which runs another Gradle build.
+ * A Gradle task that runs another Gradle build.
  *
  * Launches Gradle wrapper under a given [directory] with the specified [taskNames] names.
  * The `clean` task is also run if current build includes a `clean` task.
@@ -56,7 +56,7 @@ open class RunGradle : DefaultTask() {
     }
 
     /**
-     * Path to the directory which contains a Gradle wrapper script.
+     * Path to the directory that contains a Gradle wrapper script.
      */
     @Internal
     lateinit var directory: String

--- a/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartEnvironment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ interface DartEnvironment {
     val projectName: String
 
     /**
-     * A directory which all artifacts are generated into.
+     * A directory that all artifacts are generated into.
      *
      * Default value: "$projectDir/build".
      */
@@ -73,7 +73,7 @@ interface DartEnvironment {
             .resolve(projectName)
 
     /**
-     * A directory which contains integration test Dart sources.
+     * A directory that contains integration test Dart sources.
      *
      * Default value: "$projectDir/integration-test".
      */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ import org.gradle.kotlin.dsl.findByType
  * There are two ways to modify the environment:
  *
  *  1. Modify [DartEnvironment] interface directly. Go with this option when it is a global change
- *     that should affect all projects which use this extension.
+ *     that should affect all projects that use this extension.
  *  2. Use [DartExtension.environment] scope — for temporary and custom overridings.
  *
  * An example of a property overriding:
@@ -92,7 +92,7 @@ import org.gradle.kotlin.dsl.findByType
  * be named after a task it registers or a task group if several tasks are registered at once.
  * Then this extension is called in a project's `build.gradle.kts`.
  *
- * `DartTasks` and `DartPlugins` scopes extend [DartContext] which provides access
+ * `DartTasks` and `DartPlugins` scopes extend [DartContext] that provides access
  * to the current [DartEnvironment] and shortcuts for running `pub` tool.
  *
  * Below is the simplest example of how to create a primitive `printPubVersion` task.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/dart/task/IntegrationTest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/dart/task/IntegrationTest.kt
@@ -41,7 +41,7 @@ private val integrationTestName = TaskName.of("integrationTest", Exec::class)
  *
  * The task runs integration tests of the `spine-dart` library against a sample
  * Spine-based application. The tests are run in Chrome browser because they use `WebFirebaseClient`
- * which only works in web environment.
+ * that only works in web environment.
  *
  * A sample Spine-based application is run from the `test-app` module before integration
  * tests start and is stopped as the tests complete.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/TaskName.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/TaskName.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ package io.spine.gradle.github.pages
 object TaskName {
 
     /**
-     * The name of the task which updates the GitHub Pages.
+     * The name of the task that updates the GitHub Pages.
      */
     const val updateGitHubPages = "updateGitHubPages"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/UpdateGitHubPages.kt
@@ -42,7 +42,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 
 /**
- * Registers the `updateGitHubPages` task which performs the update of
+ * Registers the `updateGitHubPages` task that performs the update of
  * the GitHub Pages with the documentation generated in Javadoc and HTML format
  * for a particular Gradle project.
  *
@@ -67,7 +67,7 @@ import org.gradle.api.tasks.TaskProvider
  *      REPO_SLUG: SpineEventEngine/base
  * ```
  *
- * @see UpdateGitHubPagesExtension for the extension which is used to configure
+ * @see UpdateGitHubPagesExtension for the extension that is used to configure
  *      this plugin
  */
 class UpdateGitHubPages : Plugin<Project> {
@@ -113,7 +113,7 @@ class UpdateGitHubPages : Plugin<Project> {
     }
 
     /**
-     * Registers `updateGitHubPages` task which performs no actual update, but prints
+     * Registers `updateGitHubPages` task that performs no actual update, but prints
      * the message telling the update is skipped, since the project is in
      * its `SNAPSHOT` version.
      */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/java/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/java/Tasks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.gradle.kotlin.dsl.named
  *
  * Runs the unit tests using JUnit or TestNG.
  *
- * Depends on `testClasses`, and all tasks which produce the test runtime classpath.
+ * Depends on `testClasses`, and all tasks that produce the test runtime classpath.
  *
  * @see <a href="https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_tasks">
  *     Tasks | The Java Plugin</a>

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javadoc/ExcludeInternalDoclet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javadoc/ExcludeInternalDoclet.kt
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 
 /**
- * The doclet which removes Javadoc for `@Internal` things in the Java code.
+ * The doclet that removes Javadoc for `@Internal` things in the Java code.
  */
 @Suppress("ConstPropertyName")
 class ExcludeInternalDoclet {
@@ -57,7 +57,7 @@ class ExcludeInternalDoclet {
         const val className = "io.spine.tools.javadoc.ExcludeInternalDoclet"
 
         /**
-         * The name of the helper task which configures the Javadoc processing
+         * The name of the helper task that configures the Javadoc processing
          * to exclude `@Internal` types.
          */
         const val taskName = "noInternalJavadoc"
@@ -68,7 +68,7 @@ class ExcludeInternalDoclet {
     }
 
     /**
-     * Creates a custom Javadoc task for the [project] which excludes the types
+     * Creates a custom Javadoc task for the [project] that excludes the types
      * annotated as `@Internal`.
      *
      * The task is registered under [taskName].

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsEnvironment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ interface JsEnvironment {
         get() = projectDir.resolve("test")
 
     /**
-     * A directory which all artifacts are generated into.
+     * A directory that all artifacts are generated into.
      *
      * Default value: "$projectDir/build".
      */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ import org.gradle.kotlin.dsl.findByType
  * There are two ways to modify the environment:
  *
  *  1. Update [JsEnvironment] directly. Go with this option when it is a global change
- *     that should affect all projects which use this extension.
+ *     that should affect all projects that use this extension.
  *  2. Use [JsExtension.environment] scope — for temporary and custom overridings.
  *
  * An example of a property overriding:
@@ -93,7 +93,7 @@ import org.gradle.kotlin.dsl.findByType
  * named after a task it registers or a task group if several tasks are registered at once.
  * Then this extension is called in a project's `build.gradle.kts`.
  *
- * `JsTasks` and `JsPlugins` scopes extend [JsContext] which provides access
+ * `JsTasks` and `JsPlugins` scopes extend [JsContext] that provides access
  * to the current [JsEnvironment] and shortcuts for running `npm` tool.
  *
  * Below is the simplest example of how to create a primitive `printNpmVersion` task.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/task/Assemble.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/task/Assemble.kt
@@ -142,7 +142,7 @@ private val installNodePackagesName = TaskName.of("installNodePackages")
 /**
  * Locates `installNodePackages` task in this [TaskContainer].
  *
- * The task installs Node packages which this module depends on using `npm install` command.
+ * The task installs Node packages that this module depends on using `npm install` command.
  *
  * The `npm install` command is executed with the vulnerability check disabled since
  * it cannot fail the task execution despite on vulnerabilities found.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 /**
- * A task which verifies that the current version of the library has not been published to the given
+ * A task that verifies that the current version of the library has not been published to the given
  * Maven repository yet.
  */
 open class CheckVersionIncrement : DefaultTask() {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CustomPublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CustomPublicationHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.gradle.api.publish.maven.MavenPublication
  * which is <em>created</em> for a module. Instead, since the publications are already declared,
  * this class only [assigns Maven coordinates][copyProjectAttributes].
  *
- * A module which declares custom publications must be specified in
+ * A module that declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.
  *
  * If a module with [publications] declared locally is not specified as one with custom publishing,

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
@@ -82,8 +82,8 @@ private fun Project.readGitHubToken(): String {
 }
 
 /**
- * Read the personal access token for the `developers@spine.io` account that
- * has only the permission to read public GitHub packages.
+ * Reads the personal access token for the `developers@spine.io` account.
+ * The token grants only read access to public GitHub packages.
  *
  * The token is extracted from the archive called `aus.weis` stored under `buildSrc`.
  * The archive has such an unusual name to avoid scanning for tokens placed in repositories

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,12 +82,12 @@ private fun Project.readGitHubToken(): String {
 }
 
 /**
- * Read the personal access token for the `developers@spine.io` account which
+ * Read the personal access token for the `developers@spine.io` account that
  * has only the permission to read public GitHub packages.
  *
  * The token is extracted from the archive called `aus.weis` stored under `buildSrc`.
  * The archive has such an unusual name to avoid scanning for tokens placed in repositories
- * which is performed by GitHub. Since we do not violate any security, it is OK to
+ * that is performed by GitHub. Since we do not violate any security, it is OK to
  * use such a workaround.
  */
 private fun Project.readTokenFromArchive(): String {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -33,7 +33,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 /**
- * Gradle plugin which adds a [CheckVersionIncrement] task.
+ * Gradle plugin that adds a [CheckVersionIncrement] task.
  *
  * The task is called `checkVersionIncrement` inserted before the `check` task.
  */
@@ -67,7 +67,7 @@ class IncrementGuard : Plugin<Project> {
      *  2. The job is a pull request targeting a default (`master` or `main`) or
      *     a release-line (e.g. `2.x-jdk8-master`) branch.
      *
-     * It is the responsibility of a branch which aims to merge into a default
+     * It is the responsibility of a branch that aims to merge into a default
      * (or otherwise protected) branch to bump the version. Auxiliary branches do not
      * deal with the versions in the release cycle, so pull requests targeting them,
      * direct pushes, and tag builds do not run the check. This also prevents unexpected

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/JarDsl.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/JarDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 package io.spine.gradle.publish
 
 /**
- * A DSL element of [SpinePublishing] extension which allows enabling publishing
+ * A DSL element of [SpinePublishing] extension that allows enabling publishing
  * of [testJar] artifact.
  *
  * This artifact contains compilation output of `test` source set. By default, it is not published.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
@@ -236,7 +236,7 @@ sealed class PublicationHandler(
          * If the handler for the given [project] was already created, the handler
          * gets new [destinations], [overwriting][publishTo] previously specified.
          *
-         * @return the handler for the given project which would handle publishing to
+         * @return the handler for the given project that would handle publishing to
          *  the specified [destinations].
          */
         fun serving(project: Project, destinations: Set<Repository>, vararg params: Any): H {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -318,7 +318,7 @@ internal fun TaskContainer.getOrCreate(name: String, init: Jar.() -> Unit): Task
  * Obtains as a set of [Jar] tasks, output of which is used as Maven artifacts.
  *
  * By default, only a jar with Java compilation output is included into publication. This method
- * registers tasks which produce additional artifacts according to the values of [jarFlags].
+ * registers tasks that produce additional artifacts according to the values of [jarFlags].
  *
  * @return the list of the registered tasks.
  */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
@@ -65,7 +65,7 @@ import org.gradle.kotlin.dsl.findByType
  * ### Filtering out test-only modules
  *
  * Sometimes a functional or an integration test requires a significant amount of
- * configuration code which is better understood when isolated into a separate module.
+ * configuration code that is better understood when isolated into a separate module.
  * Conventionally, we use the `-tests` suffix for naming such modules.
  *
  * In order to avoid publishing of such a test-only module, we use the following extensions

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ import org.gradle.api.Project
 /**
  * A Maven repository.
  *
- * @param name The human-readable name which is also used in the publishing task names
+ * @param name The human-readable name that is also used in the publishing task names
  *   for identifying the target repository.
  *   The name must match the [regex].
  * @param releases The URL for publishing release versions of artifacts.
  * @param snapshots The URL for publishing [snapshot][io.spine.gradle.isSnapshot] versions.
- * @param credentialsFile The path to the file which contains the credentials for the registry.
+ * @param credentialsFile The path to the file that contains the credentials for the registry.
  * @param credentialValues The function to obtain an instance of [Credentials] from
  *   a Gradle [Project], if [credentialsFile] is not specified.
  */
@@ -116,7 +116,7 @@ data class Repository(
         val password = properties.getProperty("user.password")
         return Credentials(username, password)
     }
-    
+
     override fun equals(other: Any?): Boolean = when {
         this === other -> true
         other !is Repository -> false

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
@@ -64,7 +64,7 @@ import org.gradle.kotlin.dsl.the
 object LicenseReporter {
 
     /**
-     * The name of the Gradle task which generates the reports for a specific Gradle project.
+     * The name of the Gradle task that generates the reports for a specific Gradle project.
      */
     private const val projectTaskName = "generateLicenseReport"
 
@@ -104,7 +104,7 @@ object LicenseReporter {
      *
      * The merge result is placed according to [Paths].
      *
-     * Registers a `mergeAllLicenseReports` which is specified to be executed after `build`.
+     * Registers a `mergeAllLicenseReports` that is specified to be executed after `build`.
      */
     fun mergeAllReports(project: Project) {
         val rootProject = project.rootProject

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/ModuleDataExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/ModuleDataExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ private fun MarkdownDocument.print(
 }
 
 /**
- * Prints the URL to the project which provides the dependency.
+ * Prints the URL to the project that provides the dependency.
  *
  * If the passed project URL is `null` or empty, it is not printed.
  */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/Paths.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/Paths.kt
@@ -46,7 +46,7 @@ internal object Paths {
      * as the result of the [LicenseReporter] work.
      *
      * Its contents describe the licensing information for each of the Java dependencies
-     * which are referenced by Gradle projects in the repository.
+     * that are referenced by Gradle projects in the repository.
      */
     internal const val outputFilename = "dependencies.md"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -88,7 +88,12 @@ private constructor(
                     "dependency" {
                         "groupId" { xml.text(dependency.group) }
                         "artifactId" { xml.text(dependency.name) }
-                        "version" { xml.text(dependency.version) }
+                        // A BOM-managed dependency carries no explicit version.
+                        // Omit the element rather than emit `<version>null</version>`,
+                        // which is not a valid Maven version.
+                        dependency.version?.let { version ->
+                            "version" { xml.text(version) }
+                        }
                         if (scopedDep.hasDefinedScope()) {
                             "scope" { xml.text(scopedDep.scopeName()) }
                         }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -90,7 +90,7 @@ private constructor(
                         "artifactId" { xml.text(dependency.name) }
                         // A BOM-managed dependency carries no explicit version.
                         // Omit the element rather than emit `<version>null</version>`,
-                        // which is not a valid Maven version.
+                        // since `null` is not a valid Maven version.
                         dependency.version?.let { version ->
                             "version" { xml.text(version) }
                         }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
@@ -127,7 +127,7 @@ internal const val TESTKIT_COVERAGE_DIR: String = "jacoco-testkit"
 
 /**
  * The name of the system property carrying the absolute path to the JaCoCo
- * agent JAR which the test harness attaches to TestKit worker JVMs.
+ * agent JAR that the test harness attaches to TestKit worker JVMs.
  *
  * The value is read by `plugin-testlib` at test runtime.
  *

--- a/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/DependencyWriterSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/DependencyWriterSpec.kt
@@ -256,6 +256,20 @@ internal class DependencyWriterSpec {
     }
 
     @Test
+    fun `omit the version of a dependency that declares none`() {
+        subproject("a-bom").declare("api", "io.grpc:grpc-stub")
+        subproject("b-lib").declare("api", SPINE_BASE)
+
+        val out = StringWriter()
+        DependencyWriter.of(rootProject).writeXmlTo(out)
+        val xml = out.toString()
+
+        xml shouldContain "<artifactId>grpc-stub</artifactId>"
+        xml shouldNotContain "<version>null</version>"
+        xml shouldContain "<version>2.0.0</version>"
+    }
+
+    @Test
     fun `write a production dependency as 'compile' even when it is also used in tests`() {
         subproject("a-tests").declare("testImplementation", SPINE_BASE)
         subproject("b-lib").declare("api", SPINE_BASE)


### PR DESCRIPTION
## Summary

Two related build-logic changes to `config`'s `buildSrc` (both float to all
consumer repos via the submodule + `pull`):

1. **Handle `null` versions gracefully in the POM dependency report** — a
   functional bug fix.
2. **Fix "which/that" grammar in build-logic KDoc/comments** — a documentation
   pass.

## 1. Handle `null` versions in the POM dependency report

The POM dependency-report generator emitted BOM-managed coordinates (declared
without an explicit version) as the literal `<version>null</version>` in every
consumer repo's generated `docs/dependencies/pom.xml`. `null` is not a valid
Maven version, making the report hard to consume by tooling.

**Root cause.** `DependencyWriter.writeXmlTo` wrote
`"version" { xml.text(dependency.version) }` unconditionally; for a version-less
dependency `dependency.version` is `null`, and the `MarkupBuilder.text` helper
does `value.toString()`, turning `null` into the string `"null"`. The data layer
already knew a null version was possible (`deduplicate()` guards it with
`it.version ?: ""`) — only this emission site did not.

**Fix.** Emit `<version>` only when present, mirroring the existing conditional
for the optional `<scope>` element:

```kotlin
dependency.version?.let { version ->
    "version" { xml.text(version) }
}
```

A version-less dependency now omits `<version>` entirely — the correct Maven
representation for a dependency-managed version — instead of emitting invalid
XML. Covered by a new `DependencyWriterSpec` regression test
(`omit the version of a dependency that declares none`).

Surfaced by a Copilot review on
[SpineEventEngine/compiler#69](https://github.com/SpineEventEngine/compiler/pull/69#discussion_r3415608846).
Pre-existing on `master`; not introduced by that PR. Same family as the vendored
`buildSrc` audit follow-ups tracked in
[config#691](https://github.com/SpineEventEngine/config/issues/691) (fixed
directly here, since it is self-contained).

## 2. Fix "which/that" grammar in build-logic docs

An English wording pass across ~32 `buildSrc/**/*.kt` files, correcting
restrictive relative clauses ("which" → "that") in KDoc and inline comments,
plus an incidental copyright-year bump (2025 → 2026) on the touched files and
two trivial whitespace cleanups. Doc-only: no executable code changed in these
files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
🙌🏻 Updated by @alexander-yevsyukov 