### PR TITLE
Create the `gh-pages` branch on the fly; improve working with Git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = .agents/shared
 	url = https://github.com/SpineEventEngine/agents.git
 	branch = master
-	update = checkout
+	update = merge
 	ignore = all

--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ Run the following command from the root of your project:
 ./config/pull
 ```
 
-`pull` floats **every** Git submodule — `config` itself, the shared
-[`agents`][agents-repo] submodule, and any added later — to the tip of its
-tracked branch (`master` by default), leaving each *on* the branch rather than
-in a detached `HEAD`. It then copies the shared files into your project.
+`pull` updates `config` to the tip of `origin/master`, then floats the
+**config-managed** submodules — the shared [`agents`][agents-repo] submodule and
+any shared submodule added later (those declaring a tracked `branch` in
+`.gitmodules`) — to their branch tip, leaving each *on* the branch rather than in
+a detached `HEAD`. Submodules your repository owns (a Hugo theme, a vendored
+library) declare no tracked branch and are left untouched. It then copies the
+shared files into your project.
 
 > **Use `./config/pull`, not `git submodule update --recursive`.** A bare
 > `git submodule update` restores the commit each submodule is *pinned* to in

--- a/README.md
+++ b/README.md
@@ -22,7 +22,17 @@ Run the following command from the root of your project:
 ./config/pull
 ```
 
-It will get the latest code from the remote repo and then copy the shared files into your project.
+`pull` floats **every** Git submodule — `config` itself, the shared
+[`agents`][agents-repo] submodule, and any added later — to the tip of its
+tracked branch (`master` by default), leaving each *on* the branch rather than
+in a detached `HEAD`. It then copies the shared files into your project.
+
+> **Use `./config/pull`, not `git submodule update --recursive`.** A bare
+> `git submodule update` restores the commit each submodule is *pinned* to in
+> your superproject and will roll the shared submodules **backward**; only
+> `pull` (or `git submodule update --remote`) advances them to the latest
+> `master`.
+
 The following files will be copied:
 
  * `.idea` — shared IntelliJ IDEA settings.
@@ -46,9 +56,9 @@ The `pull` script also wires up AI-agent configuration:
    `.agents/scripts`, `.agents/guidelines`, `.claude/commands`, and `.claude/agents` — plus
    `.claude/skills` and `.junie/skills`, which alias `.agents/skills`. `pull`
    runs the idempotent [`adopt-shared-agents`](./adopt-shared-agents) script, which sets up
-   the submodule on the first run and floats it to the latest `agents@master` on every
-   subsequent run — so shared skills update everywhere with **no file churn** in consumer
-   pull requests.
+   the submodule on the first run and floats it to the latest `agents@master` (checked out
+   *on* `master`, not a detached `HEAD`) on every subsequent run — so shared skills update
+   everywhere with **no file churn** in consumer pull requests.
  * `.claude/settings.json` — the permission allowlist distributed by `config` (Hugo-only
    repos receive a Hugo-tuned variant). JVM and mixed repos also get `settings.local.json`;
    Hugo-only repos do not.

--- a/adopt-shared-agents
+++ b/adopt-shared-agents
@@ -127,6 +127,14 @@ git config -f .gitmodules "submodule.$SHARED_PATH.ignore" all
 git submodule sync -- "$SHARED_PATH"
 git submodule update --init --remote "$SHARED_PATH"
 
+# `.gitmodules` is only the template: the *active* update strategy lives in
+# `.git/config` (where it takes precedence), and `git submodule init`/`sync` copy
+# it there only when absent — an existing entry is left untouched. A repo first
+# initialized under the old `update = checkout` would otherwise keep that value
+# locally, so a bare `git submodule update` would still detach/rewind the
+# submodule despite the `.gitmodules` change above. Force the active strategy.
+git config "submodule.$SHARED_PATH.update" merge
+
 # Leave the submodule checked out ON `master`, not in a detached `HEAD`. The
 # `--remote` update above checks out the branch *tip* detached; pointing the local
 # `master` at that tip keeps the working tree on a branch — less confusing, and the

--- a/adopt-shared-agents
+++ b/adopt-shared-agents
@@ -114,12 +114,25 @@ fi
 # Set url and branch unconditionally so an already-registered submodule pointing at a
 # different URL/branch (or lacking one) is corrected before `--remote` runs;
 # `git submodule sync` propagates the .gitmodules url into the active .git/config.
+#
+# `update = merge` (not `checkout`) keeps the float robust: a later *bare*
+# `git submodule update` then merges the pinned (older) commit into the checked-out
+# `master` — an already-up-to-date no-op — instead of rewinding `master` to the
+# stale pin. It does mean `update` integrates onto a branch, which is exactly the
+# on-`master` state established just below.
 git config -f .gitmodules "submodule.$SHARED_PATH.url" "$AGENTS_URL"
 git config -f .gitmodules "submodule.$SHARED_PATH.branch" master
-git config -f .gitmodules "submodule.$SHARED_PATH.update" checkout
+git config -f .gitmodules "submodule.$SHARED_PATH.update" merge
 git config -f .gitmodules "submodule.$SHARED_PATH.ignore" all
 git submodule sync -- "$SHARED_PATH"
 git submodule update --init --remote "$SHARED_PATH"
+
+# Leave the submodule checked out ON `master`, not in a detached `HEAD`. The
+# `--remote` update above checks out the branch *tip* detached; pointing the local
+# `master` at that tip keeps the working tree on a branch — less confusing, and the
+# precondition for the `update = merge` resilience noted above. `ignore = all`
+# already hides the advanced commit from status/diff, so this never churns PRs.
+git -C "$SHARED_PATH" checkout -q -B master origin/master
 
 # --- 3. (re)create the symlinks ------------------------------------------------
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
@@ -38,7 +38,7 @@ package io.spine.dependency.local
 )
 object ProtoTap {
     const val group = Spine.toolsGroup
-    const val version = "0.15.0"
+    const val version = "0.16.0"
     const val gradlePluginId = "io.spine.prototap"
     const val api = "$group:prototap-api:$version"
     const val gradlePlugin = "$group:prototap-gradle-plugin:$version"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/Cli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/Cli.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,11 +63,14 @@ class Cli(private val workingFolder: File) {
             redirectError(PIPE)
         }.start()
 
-        val exitCode = process.run {
-            inputStream!!.pourTo(outWriter)
-            errorStream!!.pourTo(errWriter)
-            waitFor()
-        }
+        val outReader = process.inputStream!!.pourTo(outWriter)
+        val errReader = process.errorStream!!.pourTo(errWriter)
+        val exitCode = process.waitFor()
+        // `waitFor()` returns on process exit but does not wait for the reader
+        // threads to finish draining the pipes; join them so the buffers hold
+        // the complete output before it is read below.
+        outReader.join()
+        errReader.join()
 
         if (exitCode == 0) {
             return outWriter.toString()
@@ -83,14 +86,14 @@ class Cli(private val workingFolder: File) {
 }
 
 /**
- * Asynchronously reads all lines from this [InputStream] and appends them
- * to the passed [StringWriter].
+ * Starts a background thread that reads all lines from this [InputStream] and
+ * appends them to [dest], returning the thread so the caller can [join][Thread.join]
+ * it once the process has exited, ensuring the buffer holds the complete output.
  */
-private fun InputStream.pourTo(dest: StringWriter) {
+private fun InputStream.pourTo(dest: StringWriter): Thread =
     Thread {
         val sc = Scanner(this)
         while (sc.hasNextLine()) {
             dest.append(sc.nextLine())
         }
-    }.start()
-}
+    }.also { it.start() }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
@@ -101,15 +101,20 @@ class Repository private constructor(
      * not exist yet.
      *
      * If the branch is already present on the remote, it is [checked out][checkout]
-     * as usual. Otherwise, it is created as an orphan branch with an empty initial
-     * commit and pushed to the remote, so that subsequent commits with the
+     * as usual. Otherwise, it is created as an orphan branch seeded with
+     * [initialFiles] and pushed to the remote, so that subsequent commits with the
      * documentation have a branch to append to.
      *
      * Creating the branch on the fly makes the very first documentation publication
      * of a repository self-sufficient: the [documentation branch][Branch.documentation]
      * no longer needs to be created manually beforehand.
+     *
+     * @param branch the name of the branch to check out or create.
+     * @param initialFiles the files — paths relative to the repository root mapped
+     *   to their content — to add to the initial commit when the branch is created.
+     *   Ignored when the branch already exists.
      */
-    fun checkoutOrCreate(branch: String) {
+    fun checkoutOrCreate(branch: String, initialFiles: Map<String, String> = emptyMap()) {
         if (remoteHasBranch(branch)) {
             // `remoteHasBranch` queries the remote directly via `git ls-remote`,
             // which does not populate `refs/remotes/origin/*`. In a parallel
@@ -120,7 +125,7 @@ class Repository private constructor(
             repoExecute("git", "fetch", "origin")
             checkout(branch)
         } else {
-            createOrphanBranch(branch)
+            createOrphanBranch(branch, initialFiles)
         }
     }
 
@@ -136,14 +141,20 @@ class Repository private constructor(
     }
 
     /**
-     * Creates the [branch] as an orphan branch with an empty initial commit and
+     * Creates the [branch] as an orphan branch seeded with [initialFiles] and
      * pushes it to the remote.
      *
      * `git switch --orphan` starts a new history with an empty working tree, so
      * the source code of the default branch does not leak into the created branch.
+     * The [initialFiles] are written into this clean tree and staged before the
+     * initial commit, which stays `--allow-empty` to support seeding no files.
      */
-    private fun createOrphanBranch(branch: String) {
+    private fun createOrphanBranch(branch: String, initialFiles: Map<String, String>) {
         repoExecute("git", "switch", "--orphan", branch)
+        initialFiles.forEach { (path, content) ->
+            location.toFile().resolve(path).writeText(content)
+            repoExecute("git", "add", path)
+        }
         repoExecute(
             "git",
             "commit",
@@ -248,7 +259,8 @@ class Repository private constructor(
          * See [configureUser] documentation for more information.
          *
          * Performs checkout of the branch in case it was passed.
-         * By default, [master][Branch.master] is checked out.
+         * By default, [master][Branch.master] is checked out. A non-default branch
+         * that does not exist yet is created and seeded with [initialFiles].
          *
          * @throws IllegalArgumentException if SSH URL is an empty string.
          */
@@ -257,6 +269,7 @@ class Repository private constructor(
             sshUrl: String,
             user: UserInfo,
             branch: String = Branch.master,
+            initialFiles: Map<String, String> = emptyMap(),
         ): Repository {
             require(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }
 
@@ -265,7 +278,7 @@ class Repository private constructor(
             repo.configureUser(user)
 
             if (branch != Branch.master) {
-                repo.checkoutOrCreate(branch)
+                repo.checkoutOrCreate(branch, initialFiles)
             }
 
             return repo

--- a/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.gradle.api.Project
  *   This configuration determines what ends up in the `author` and `committer` fields of a commit.
  * @property currentBranch The currently checked-out branch.
  */
+@Suppress("TooManyFunctions") // A cohesive wrapper over many small `git` commands.
 class Repository private constructor(
     private val project: Project,
     private val sshUrl: String,
@@ -86,12 +87,98 @@ class Repository private constructor(
      * Checks out the branch by its name.
      *
      * IMPORTANT. The branch must exist in the upstream repository.
+     * Use [checkoutOrCreate] to check out a branch that may not exist yet.
      */
     fun checkout(branch: String) {
         repoExecute("git", "checkout", branch)
         repoExecute("git", "pull")
 
         currentBranch = branch
+    }
+
+    /**
+     * Checks out the [branch], creating it in the remote repository if it does
+     * not exist yet.
+     *
+     * If the branch is already present on the remote, it is [checked out][checkout]
+     * as usual. Otherwise, it is created as an orphan branch with an empty initial
+     * commit and pushed to the remote, so that subsequent commits with the
+     * documentation have a branch to append to.
+     *
+     * Creating the branch on the fly makes the very first documentation publication
+     * of a repository self-sufficient: the [documentation branch][Branch.documentation]
+     * no longer needs to be created manually beforehand.
+     */
+    fun checkoutOrCreate(branch: String) {
+        if (remoteHasBranch(branch)) {
+            checkout(branch)
+        } else {
+            createOrphanBranch(branch)
+        }
+    }
+
+    /**
+     * Tells whether the remote repository has a branch with the given [name].
+     *
+     * Relies on `git ls-remote` returning an empty output with a zero exit code
+     * when the branch is absent, so the check does not raise an exception.
+     */
+    private fun remoteHasBranch(name: String): Boolean {
+        val output = repoExecute("git", "ls-remote", "--heads", "origin", name)
+        return output.isNotBlank()
+    }
+
+    /**
+     * Creates the [branch] as an orphan branch with an empty initial commit and
+     * pushes it to the remote.
+     *
+     * `git switch --orphan` starts a new history with an empty working tree, so
+     * the source code of the default branch does not leak into the created branch.
+     */
+    private fun createOrphanBranch(branch: String) {
+        repoExecute("git", "switch", "--orphan", branch)
+        repoExecute(
+            "git",
+            "commit",
+            "--allow-empty",
+            "--message=Initialize the `$branch` branch."
+        )
+        currentBranch = branch
+        pushNewBranch(branch)
+    }
+
+    /**
+     * Pushes the just-created [branch] to the remote, setting up the upstream tracking.
+     *
+     * If the push is rejected because a concurrently running publication created
+     * the branch first (e.g., another module publishing documentation in the same
+     * parallel build), the remote branch is [adopted][adoptRemoteBranch] instead.
+     * Otherwise, the failure is genuine, and the original exception is rethrown.
+     */
+    private fun pushNewBranch(branch: String) {
+        try {
+            repoExecute("git", "push", "--set-upstream", "origin", branch)
+        } catch (e: IllegalStateException) {
+            // `Cli.execute` surfaces every non-zero `git` exit as an
+            // `IllegalStateException`, so this branch handles a rejected push.
+            // If the branch now exists on the remote, another module won the
+            // creation race and we adopt its branch; otherwise the failure is
+            // genuine and is rethrown.
+            repoExecute("git", "fetch", "origin")
+            if (!remoteHasBranch(branch)) {
+                throw e
+            }
+            adoptRemoteBranch(branch)
+        }
+    }
+
+    /**
+     * Discards the local orphan branch in favour of the same-named branch that
+     * already exists on the remote, keeping the local branch in sync with it.
+     */
+    private fun adoptRemoteBranch(branch: String) {
+        repoExecute("git", "reset", "--hard", "origin/$branch")
+        repoExecute("git", "branch", "--set-upstream-to=origin/$branch", branch)
     }
 
     /**
@@ -171,7 +258,7 @@ class Repository private constructor(
             repo.configureUser(user)
 
             if (branch != Branch.master) {
-                repo.checkout(branch)
+                repo.checkoutOrCreate(branch)
             }
 
             return repo

--- a/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
@@ -132,11 +132,14 @@ class Repository private constructor(
     /**
      * Tells whether the remote repository has a branch with the given [name].
      *
-     * Relies on `git ls-remote` returning an empty output with a zero exit code
-     * when the branch is absent, so the check does not raise an exception.
+     * Queries the fully-qualified ref `refs/heads/$name` rather than the bare
+     * [name]: `git ls-remote` treats a bare name as a tail glob and would also
+     * match a namespaced branch such as `feature/$name`. Relies on `git ls-remote`
+     * returning an empty output with a zero exit code when the branch is absent,
+     * so the check does not raise an exception.
      */
     private fun remoteHasBranch(name: String): Boolean {
-        val output = repoExecute("git", "ls-remote", "--heads", "origin", name)
+        val output = repoExecute("git", "ls-remote", "--heads", "origin", "refs/heads/$name")
         return output.isNotBlank()
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
@@ -111,6 +111,13 @@ class Repository private constructor(
      */
     fun checkoutOrCreate(branch: String) {
         if (remoteHasBranch(branch)) {
+            // `remoteHasBranch` queries the remote directly via `git ls-remote`,
+            // which does not populate `refs/remotes/origin/*`. In a parallel
+            // build another module may have created the branch after this clone,
+            // so fetch first to make the `origin/$branch` ref available;
+            // otherwise `git checkout` cannot guess it and fails with a
+            // pathspec error.
+            repoExecute("git", "fetch", "origin")
             checkout(branch)
         } else {
             createOrphanBranch(branch)

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/RepositoryExtensions.kt
@@ -39,7 +39,9 @@ import org.gradle.api.Project
  * The repository's GitHub SSH URL is derived from the `REPO_SLUG` environment
  * variable. The [branch][Branch.documentation] dedicated to publishing documentation
  * is automatically checked out in this repository, and created if it does not exist
- * yet. Also, the username and the email of the git user are automatically configured.
+ * yet. A freshly created branch is seeded with a `CNAME` file so that GitHub Pages
+ * serves the documentation under the `spine.io` custom domain. Also, the username
+ * and the email of the git user are automatically configured.
  *
  * The username is set to `"UpdateGitHubPages Plugin"`, and the email is derived from
  * the `FORMAL_GIT_HUB_PAGES_AUTHOR` environment variable.
@@ -56,5 +58,10 @@ internal fun Repository.Factory.forPublishingDocumentation(project: Project): Re
 
     val branch = Branch.documentation
 
-    return clone(project, host, user, branch)
+    // When the `gh-pages` branch is created from scratch, seed it with a `CNAME`
+    // file so that GitHub Pages serves the documentation under the `spine.io`
+    // custom domain.
+    val initialFiles = mapOf("CNAME" to "spine.io\n")
+
+    return clone(project, host, user, branch, initialFiles)
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/RepositoryExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@ import org.gradle.api.Project
  *
  * The repository's GitHub SSH URL is derived from the `REPO_SLUG` environment
  * variable. The [branch][Branch.documentation] dedicated to publishing documentation
- * is automatically checked out in this repository. Also, the username and the email
- * of the git user are automatically configured.
+ * is automatically checked out in this repository, and created if it does not exist
+ * yet. Also, the username and the email of the git user are automatically configured.
  *
  * The username is set to `"UpdateGitHubPages Plugin"`, and the email is derived from
  * the `FORMAL_GIT_HUB_PAGES_AUTHOR` environment variable.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/UpdateGitHubPages.kt
@@ -53,7 +53,7 @@ import org.gradle.api.tasks.TaskProvider
  * repository root. It is recommended to encrypt it in the repository and then decrypt
  * it on CI upon publication. Also, the script uses the `FORMAL_GIT_HUB_PAGES_AUTHOR`
  * environment variable to set the author email for the commits. The `gh-pages`
- * branch itself should exist before the plugin is run.
+ * branch is created automatically if it does not exist yet.
  *
  * NOTE: when changing the value of "FORMAL_GIT_HUB_PAGES_AUTHOR", one also must change
  * the SSH private (encrypted `deploy_key_rsa`) and the public

--- a/pull
+++ b/pull
@@ -2,10 +2,19 @@
 
 ################################################################################
 #
-# Pulls the shared project configuration from the `config` repository and floats
-# every Git submodule — `config` itself, the shared `agents` submodule, and any
-# added in the future — to the tip of its tracked branch, leaving each ON the
+# Pulls the shared project configuration from the `config` repository and brings
+# the config-managed submodules up to date.
+#
+# It updates `config` itself to the tip of `origin/master`, then floats every
+# *config-managed* submodule — those declared with a tracked `branch` in
+# `.gitmodules` (the shared `agents` submodule at `.agents/shared`, and any shared
+# submodule added in the future) — to the tip of that branch, leaving each on the
 # branch rather than in a detached `HEAD`.
+#
+# Submodules the consumer owns (a Hugo theme, a vendored library, ...) declare no
+# tracked branch and are deliberately left untouched: this script never advances
+# or resets them, and a failure floating one shared submodule is warned about, not
+# fatal, so it can never take down the whole pull.
 #
 # The code of the script assumes that:
 #
@@ -17,37 +26,41 @@
 ################################################################################
 
 # ---------------------------------------------------------------------------
-# Float every submodule to the latest commit of its tracked branch.
-#
-# `git submodule update` alone only restores the commit each submodule is
-# *pinned* to in the superproject; it never advances to a branch tip, and it
-# leaves the submodule in a detached `HEAD`. To get the latest of every module
-# we check out its tracked branch (read from `.gitmodules`, defaulting to
-# `master`) and fast-forward it to `origin/<branch>`.
-#
-# `--recursive` descends into nested submodules (e.g. `config`'s own `agents`),
-# so any submodule added later is floated automatically — no edit needed here.
-# A fast-forward-only merge keeps each module a clean descendant of its remote
-# and fails loudly if a local commit ever diverged, rather than silently
-# creating a merge commit.
+# 1. Bring `config` itself to the tip of `origin/master`, on the `master`
+#    branch (not a detached `HEAD`). Pulling here also refreshes `migrate`,
+#    which is sourced from the updated `config` below.
 # ---------------------------------------------------------------------------
 
-echo "Floating submodules to the latest of their tracked branches"
-git submodule sync --recursive \
-    || { echo "Error: 'git submodule sync' failed."; exit 1; }
-git submodule update --init --recursive \
-    || { echo "Error: 'git submodule update --init' failed."; exit 1; }
-git submodule --quiet foreach --recursive '
-    branch=$(git config -f "$toplevel/.gitmodules" --get "submodule.$name.branch" 2>/dev/null || echo master)
-    echo "  $displaypath -> origin/$branch"
-    git fetch --quiet origin "$branch" \
-        && git checkout --quiet "$branch" \
-        && git merge --quiet --ff-only "origin/$branch"
-' || { echo "Error: failed to float a submodule to its branch tip."; exit 1; }
+echo "Updating 'config' to the latest 'master'"
+( cd ./config && git checkout master && git pull --ff-only ) \
+    || { echo "Error: failed to update the 'config' submodule."; exit 1; }
 
 # ---------------------------------------------------------------------------
-# Apply the shared files from the now-current `config`.
-# `migrate` must run with the `config` directory as the working directory.
+# 2. Float the config-managed submodules to the tip of their tracked branch.
+#    A submodule is "config-managed" when its `.gitmodules` entry declares a
+#    `branch` (set up by `adopt-shared-agents`); consumer-owned submodules have
+#    none and are skipped. `--ff-only` keeps each a clean descendant of its
+#    remote; any failure is warned about, never fatal.
+# ---------------------------------------------------------------------------
+
+if [ -f .gitmodules ]; then
+    git config -f .gitmodules --get-regexp '^submodule\..*\.branch$' 2>/dev/null \
+    | while read -r key branch; do
+        name=${key#submodule.}; name=${name%.branch}
+        path=$(git config -f .gitmodules --get "submodule.$name.path") || continue
+        echo "Floating '$path' -> origin/$branch"
+        git submodule sync -- "$path" >/dev/null 2>&1 || true
+        git submodule update --init -- "$path" >/dev/null 2>&1 || true
+        ( cd "$path" \
+            && git fetch --quiet origin "$branch" \
+            && git checkout --quiet "$branch" \
+            && git merge --quiet --ff-only "origin/$branch" ) \
+        || echo "  WARNING: could not float '$path' to origin/$branch; left as-is." >&2
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Apply the shared files. `migrate` runs with `config` as the working dir.
 # ---------------------------------------------------------------------------
 
 cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }

--- a/pull
+++ b/pull
@@ -2,29 +2,55 @@
 
 ################################################################################
 #
-# This script pulls the project configuration files from a remote Git repository.
+# Pulls the shared project configuration from the `config` repository and floats
+# every Git submodule — `config` itself, the shared `agents` submodule, and any
+# added in the future — to the tip of its tracked branch, leaving each ON the
+# branch rather than in a detached `HEAD`.
 #
 # The code of the script assumes that:
 #
 #   1. The project uses this code as a Git sub-module installed in the `config`
 #      directory under the project root.
 #
-#   2. The script is called from the root of the project.
+#   2. The script is called from the root of the project, i.e. `./config/pull`.
 #
 ################################################################################
 
-# Update the module with reference to the latest version.
-# In this state there is no current branch.
-git submodule update
+# ---------------------------------------------------------------------------
+# Float every submodule to the latest commit of its tracked branch.
+#
+# `git submodule update` alone only restores the commit each submodule is
+# *pinned* to in the superproject; it never advances to a branch tip, and it
+# leaves the submodule in a detached `HEAD`. To get the latest of every module
+# we check out its tracked branch (read from `.gitmodules`, defaulting to
+# `master`) and fast-forward it to `origin/<branch>`.
+#
+# `--recursive` descends into nested submodules (e.g. `config`'s own `agents`),
+# so any submodule added later is floated automatically — no edit needed here.
+# A fast-forward-only merge keeps each module a clean descendant of its remote
+# and fails loudly if a local commit ever diverged, rather than silently
+# creating a merge commit.
+# ---------------------------------------------------------------------------
 
-# Make the `config` dir current.
+echo "Floating submodules to the latest of their tracked branches"
+git submodule sync --recursive \
+    || { echo "Error: 'git submodule sync' failed."; exit 1; }
+git submodule update --init --recursive \
+    || { echo "Error: 'git submodule update --init' failed."; exit 1; }
+git submodule --quiet foreach --recursive '
+    branch=$(git config -f "$toplevel/.gitmodules" --get "submodule.$name.branch" 2>/dev/null || echo master)
+    echo "  $displaypath -> origin/$branch"
+    git fetch --quiet origin "$branch" \
+        && git checkout --quiet "$branch" \
+        && git merge --quiet --ff-only "origin/$branch"
+' || { echo "Error: failed to float a submodule to its branch tip."; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Apply the shared files from the now-current `config`.
+# `migrate` must run with the `config` directory as the working directory.
+# ---------------------------------------------------------------------------
+
 cd ./config || { echo "Error: 'config' directory is missing."; exit 1; }
-
-# Set the current branch to `master`.
-git checkout master
-
-echo "Pulling changes from remote repo"
-git pull
 
 # Handle file operations related to the migration from the previous version(s).
 source migrate


### PR DESCRIPTION
## Problem

ProtoTap's `Publish` workflow fails on its first-ever documentation publish at
`:api:updateGitHubPages`
([run 27410611416](https://github.com/SpineEventEngine/ProtoTap/actions/runs/27410611416)):

```
[Repo (:api)] Executing command: `git checkout gh-pages`.
error: pathspec 'gh-pages' did not match any file(s) known to git
```

The `UpdateGitHubPages` plugin (distributed from this repo) assumed the
`gh-pages` branch already existed and ran a bare `git checkout gh-pages` with no
fallback. Any Spine repository publishing documentation for the first time hits
this.

## Fix

`Repository.checkoutOrCreate()` now checks out the branch when it exists, or
**creates it as an orphan branch** and pushes it otherwise — mirroring the
existing `scripts/publish-documentation/publish.sh`.

**Branch initialization.** The initial commit on a freshly created `gh-pages`
branch seeds a root `CNAME` file containing `spine.io`, so GitHub Pages serves
the documentation under the custom domain — matching the previous manual
initialization procedure. `Repository` stays a generic git wrapper via an
`initialFiles` (path -> content) parameter; the GitHub Pages layer supplies the
`CNAME`. The only seeded file is the functional `CNAME` — no throwaway
placeholder.

**Parallel-build safety.** Publishing runs with `org.gradle.parallel=true` and
every module registers an `updateGitHubPages` task, so the first publish can
have several modules racing to create the branch. The winner pushes the orphan
branch; the losers detect the rejected push, fetch, and adopt the branch the
winner created.

- `buildSrc/.../git/Repository.kt` — `checkoutOrCreate`, `remoteHasBranch`,
  `createOrphanBranch` (seeds `initialFiles`), `pushNewBranch`,
  `adoptRemoteBranch`; the clone factory now calls `checkoutOrCreate`.
- `buildSrc/.../github/pages/{UpdateGitHubPages,RepositoryExtensions}.kt` — KDoc
  updated (the branch is created automatically); `RepositoryExtensions` supplies
  the `CNAME` seed; copyright year bumped.

## Improve working with Git submodules

**Problem.** Consumer repos pull `config` (and, nested under it, the shared
`agents` repo) as submodules. A submodule reference is a *pinned commit*, so a
bare `git submodule update --recursive` only restores those pins — it never
advances to a branch tip. `config` and `agents` drifted behind `origin/master`,
`agents` sat in a detached `HEAD`, and there was no generic way to float
submodules that may be added in the future.

**Fix.** `./config/pull` now updates `config` to the tip of `origin/master`,
then floats the **config-managed** submodules — those declaring a tracked
`branch` in `.gitmodules` (the shared `agents` submodule, and any shared
submodule added later) — to that branch tip, leaving each *on* the branch.
Submodules the consumer owns (a Hugo theme, a vendored library) declare no
tracked branch and are left untouched; a failure floating one shared submodule
is warned about, not fatal, so it can never take down the whole pull:

- **`pull`** — updates `config` explicitly (`git checkout master && git pull
  --ff-only`), then iterates the `.gitmodules` entries that declare a `branch`
  and fast-forwards each to `origin/<branch>` on its branch. Entries without a
  tracked branch (consumer-owned submodules) are skipped, and a per-submodule
  failure is a warning rather than a fatal error. This deliberately replaces the
  earlier "float every submodule" approach, which could abort `./config/pull`
  for a consumer whose own submodule is pinned to a commit or hosted on `main`.
- **`adopt-shared-agents`** — the `agents` submodule is registered with
  `update = merge` (so a stray bare `git submodule update` fast-forwards instead
  of rewinding the float) and is checked out **on `master`** after the
  `--remote` float instead of in a detached `HEAD`. `ignore = all` still keeps
  the advanced commit out of consumer diffs — no pin churn in their PRs.
- **`README.md`** — documents the floating behaviour and warns that a bare
  `git submodule update --recursive` rolls shared submodules *backward*; use
  `./config/pull` (or `git submodule update --remote`).
- **`Repository.kt`** — `checkoutOrCreate` additionally runs `git fetch origin`
  before checking out an existing remote branch, so a `gh-pages` branch created
  by another module earlier in the same parallel publish is visible locally
  (`remoteHasBranch` uses `git ls-remote`, which does not populate
  `refs/remotes/origin/*`).

This branch also carries an unrelated `Bump ProtoTap -> 0.16.0` commit (the
`config` dependency catalog).

## Verification

- `./gradlew :buildSrc:build detekt` — green (`detekt` initially flagged
  `TooManyFunctions` on `Repository`; resolved with a class-level suppression,
  consistent with other cohesive wrapper classes in `buildSrc`).
- A fresh clone of a newly created `gh-pages` contains only the `CNAME` file
  (content `spine.io`) — verified the orphan tree carries no source leak.
- `bash -n pull adopt-shared-agents` — green (the submodule-float scripts parse).
- Reviewers (`spine-code-review`, `kotlin-engineer`, `review-docs`,
  `dependency-audit`) — APPROVE.
- **Field test pending:** the fix will be exercised by bumping ProtoTap's
  `config` submodule to this commit and re-running `Publish` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

