### PR TITLE
Configure Error Prone for JDK 17 (#543); bump local Spine snapshots

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.411"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.411"
+    const val version = "2.0.0-SNAPSHOT.413"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.413"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.052"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.053"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.052"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.053"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.375"
+    const val version = "2.0.0-SNAPSHOT.376"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.074"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.077"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.074"
+    const val version = "2.0.0-SNAPSHOT.077"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.073"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.074"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.073"
+    const val version = "2.0.0-SNAPSHOT.074"
 
     /**
      * The ID of the Gradle plugin.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,24 @@ org.gradle.parallel=true
 # so cold builds skip work whose inputs are unchanged.
 org.gradle.caching=true
 
-# Dokka plugin eats more memory than usual. Therefore, all builds should have enough.
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC -Dfile.encoding=UTF-8
+# Extra JVM args for the Gradle daemon, for two unrelated reasons:
+#
+# 1. The Dokka plugin eats more memory than usual, so all builds get a generous heap.
+# 2. The `--add-exports` / `--add-opens` flags expose the `jdk.compiler` internals that
+#    Error Prone needs on JDK 16+ (JEP 396). Passing them to the daemon here lets the
+#    `net.ltgt.errorprone` plugin run Error Prone in-process instead of forking a separate
+#    compiler JVM per task. See https://github.com/SpineEventEngine/config/issues/543
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC -Dfile.encoding=UTF-8 \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 
 # suppress inspection "UnusedProperty"
 # The below property enables generation of XML reports for tests.


### PR DESCRIPTION
## Configure Error Prone for JDK 17 — Fixes #543

On JDK 16+ (JEP 396), Error Prone's compiler needs `--add-exports` / `--add-opens`
access to `jdk.compiler/com.sun.tools.javac.*`. This adds the canonical 10-flag set
(8 `--add-exports` + 2 `--add-opens` — exactly what `net.ltgt.errorprone` 5.1.0 adds
when it forks) to the Gradle daemon's `org.gradle.jvmargs` in the distributed
`gradle.properties`.

With the flags on the daemon JVM, the plugin's `CURRENT_JVM_NEEDS_FORKING` check is
satisfied, so Error Prone runs **in-process** instead of forking a separate compiler
JVM per `JavaCompile` task. Because `config` distributes `gradle.properties`, every
consumer repo inherits this.

**Verified:** all 10 flags confirmed present in a freshly-started daemon JVM (so the
properties line-continuation parses correctly and the daemon starts cleanly);
`./gradlew :buildSrc:build detekt` on JDK 17 → BUILD SUCCESSFUL. The in-process
(no-fork) behavior is exercised in consumer repos, since `config` itself has no Java
production code.

## Bump local Spine SDK snapshots

Refreshes the `local/`-scope Spine SDK dependency declarations under
`buildSrc/src/main/kotlin/io/spine/dependency/local/` to their latest snapshot builds
from the Spine Artifact Registry.

## Reviewers

`spine-code-review`, `kotlin-engineer`, and `dependency-audit` all APPROVE the branch
diff with no findings (one readability nit on the `gradle.properties` comment was
applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
