### PR TITLE
Regenerate `dependencies.md` on a version-only change

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
@@ -96,6 +96,20 @@ object LicenseReporter {
 
             renderers = arrayOf(MarkdownReportRenderer(Paths.outputFilename))
         }
+
+        // The rendered report embeds the project's Maven coordinates — including its
+        // version — in the report header (see `Template.writeHeader`). The
+        // `generateLicenseReport` task is a `@CacheableTask` that keys its up-to-date check
+        // and build-cache entry on the resolved dependencies only, not on the project version.
+        // Without the version as an explicit input, a version-only change leaves the task
+        // `UP-TO-DATE` (or restorable from the build cache), so the report keeps the previous
+        // version while `pom.xml`, produced by an always-running task, is updated. Declaring
+        // the version as an input invalidates the cached output when it changes, so the report
+        // is regenerated. The value is read lazily so it reflects the version resolved at
+        // execution time, regardless of when `project.version` is assigned during configuration.
+        project.tasks.generateLicenseReport.configure {
+            inputs.property("projectVersion", project.provider { project.version.toString() })
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Running `./gradlew clean build` after a change that **only bumps the project version**
updates `docs/dependencies/pom.xml` but leaves `docs/dependencies/dependencies.md`
stuck on the previous version. The two dependency reports drift out of sync.

## Root cause

The two reports are produced by tasks with very different up-to-date semantics:

- `pom.xml` is written by `generatePom`, a plain task with **no declared outputs**, so
  it never goes up-to-date and re-runs on every build — always reflecting the current version.
- `dependencies.md` is built from per-project `generateLicenseReport` tasks (from
  `com.github.jk1:gradle-license-report`). `ReportTask` is a **`@CacheableTask`** whose
  cache key is derived from the *resolved dependencies* and the extension config — **not**
  the project version. Yet the rendered report embeds the project version in its header
  (`# Dependencies of \`group:artifact:version\``, see `Template.writeHeader`).

With the Gradle build cache enabled (`org.gradle.caching=true`), a version-only change
leaves that cache key unchanged. After `clean`, Gradle restores the **stale** per-project
report from the build cache, and the merge step writes a `dependencies.md` carrying the
old version.

## Fix

Declare the project version as an explicit input of `generateLicenseReport`, via the
existing `TaskContainer.generateLicenseReport` accessor:

```kotlin
project.tasks.generateLicenseReport.configure {
    inputs.property("projectVersion", project.provider { project.version.toString() })
}
```

This folds the version into both the up-to-date check and the build-cache key, so a
version change invalidates the cached report and forces regeneration. The value is read
lazily because the version is resolved at execution time.

## Verification (in `base-libraries`)

- `./gradlew :buildSrc:build detekt` — passes (compile, `validatePlugins`, tests, detekt).
- Version bump → `generateLicenseReport` **re-executes**; `dependencies.md` updates in
  step with `pom.xml`.
- Version **unchanged** → task restores **FROM-CACHE**; report unchanged — caching
  efficiency preserved, no build-time regression.

Reviewed by `spine-code-review` and `kotlin-engineer` (both APPROVE); pre-PR checklist PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)