### PR TITLE
Restrict JetBrains Maven repositories to IntelliJ coordinates

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,24 +94,34 @@ fun RepositoryHandler.spineArtifacts(): MavenArtifactRepository = maven {
 }
 
 val RepositoryHandler.intellijReleases: MavenArtifactRepository
-    get() = maven("https://www.jetbrains.com/intellij-repository/releases")
+    get() = maven("https://www.jetbrains.com/intellij-repository/releases") {
+        includeIntelliJPlatformOnly()
+    }
 
 val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
-    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
+        includeIntelliJPlatformOnly()
+    }
 
 val RepositoryHandler.intellijDependencies: MavenArtifactRepository
     get() = maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") {
-        content {
-            includeGroupByRegex("com\\.jetbrains.*")
-            includeGroupByRegex("org\\.jetbrains.*")
-            includeGroupByRegex("com\\.intellij.*")
-        }
+        includeIntelliJPlatformOnly()
     }
 
 /**
  * Applies repositories commonly used by Spine Event Engine projects.
  */
 fun RepositoryHandler.standardToSpineSdk() {
+    //
+    // General-purpose, highly available repositories come first. Gradle stops at
+    // the first repository that can serve an artifact, so keeping these ahead of
+    // the special-purpose ones means coordinates shared with them (such as
+    // `org.jetbrains:annotations`) resolve here and never reach a less reliable
+    // mirror like `cache-redirector.jetbrains.com`.
+    //
+    mavenCentral()
+    gradlePluginPortal()
+
     spineArtifacts()
 
     @Suppress("DEPRECATION") // Still use `CloudRepo` for earlier versions.
@@ -131,16 +141,20 @@ fun RepositoryHandler.standardToSpineSdk() {
             }
         }
 
+    // IntelliJ Platform repositories. Each is restricted to the IntelliJ
+    // coordinates it serves (see `includeIntelliJPlatformOnly`), so a transient
+    // 5xx from one of them cannot break the resolution of unrelated artifacts.
     intellijReleases
     jetBrainsCacheRedirector
     intellijDependencies
 
     maven {
         url = URI(Repos.sonatypeSnapshots)
+        // This repository only ever serves snapshots; restrict it so it is not
+        // queried (and cannot fail the build) for release artifacts.
+        mavenContent { snapshotsOnly() }
     }
 
-    mavenCentral()
-    gradlePluginPortal()
     mavenLocal().includeSpineOnly()
 }
 
@@ -178,5 +192,24 @@ private object Repos {
 private fun MavenArtifactRepository.includeSpineOnly() {
     content {
         includeGroupByRegex("io\\.spine.*")
+    }
+}
+
+/**
+ * Restricts a JetBrains/IntelliJ Platform repository to the coordinates it
+ * actually serves.
+ *
+ * These hosts — `cache-redirector.jetbrains.com` in particular — periodically
+ * answer with HTTP 5xx. Once Gradle sees such an error, it disables the
+ * repository for the rest of the build and fails the resolution instead of
+ * falling back to another repository. Without this filter the redirector is
+ * queried for every artifact, so a single 502 on an unrelated POM (such as
+ * `com.fasterxml.jackson:jackson-parent`) breaks the whole build.
+ */
+private fun MavenArtifactRepository.includeIntelliJPlatformOnly() {
+    content {
+        includeGroupByRegex("com\\.jetbrains.*")
+        includeGroupByRegex("org\\.jetbrains.*")
+        includeGroupByRegex("com\\.intellij.*")
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
@@ -31,6 +31,7 @@ package io.spine.gradle.repo
 import io.spine.gradle.publish.PublishingRepos
 import java.net.URI
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.kotlin.dsl.maven
 
@@ -119,8 +120,13 @@ fun RepositoryHandler.standardToSpineSdk() {
     // `org.jetbrains:annotations`) resolve here and never reach a less reliable
     // mirror like `cache-redirector.jetbrains.com`.
     //
-    mavenCentral()
-    gradlePluginPortal()
+    // `io.spine.*` modules are served only by the Spine repositories below, so
+    // they are excluded here. Otherwise Gradle would query Central / the Plugin
+    // Portal for every Spine module first, adding pointless lookups and making
+    // Spine resolution depend on the health of repositories that never host it.
+    //
+    mavenCentral { excludeSpine() }
+    gradlePluginPortal { excludeSpine() }
 
     spineArtifacts()
 
@@ -192,6 +198,20 @@ private object Repos {
 private fun MavenArtifactRepository.includeSpineOnly() {
     content {
         includeGroupByRegex("io\\.spine.*")
+    }
+}
+
+/**
+ * Excludes Spine artifact groups from this repository.
+ *
+ * `io.spine.*` modules are published only to the Spine repositories (each scoped
+ * via [includeSpineOnly]). Excluding them from a general-purpose repository keeps
+ * Gradle from querying it — and depending on its health — for coordinates it
+ * never hosts.
+ */
+private fun ArtifactRepository.excludeSpine() {
+    content {
+        excludeGroupByRegex("io\\.spine.*")
     }
 }
 


### PR DESCRIPTION
## Problem

CI builds intermittently fail while resolving dependencies through the JetBrains
mirrors, e.g.:

```
> Could not resolve org.jetbrains:annotations:13.0.
   > Repository maven7 is disabled due to earlier error below:
      > Could not resolve com.fasterxml.jackson:jackson-parent:2.22.
         > Received status code 502 from server: Bad Gateway
            (https://cache-redirector.jetbrains.com/intellij-dependencies/...)
```

`cache-redirector.jetbrains.com` periodically returns HTTP 5xx. The root cause is
that `intellijReleases` and `jetBrainsCacheRedirector` were declared **without a
content filter**, so Gradle treated them as candidate sources for *every* artifact —
including general libraries like `com.fasterxml.jackson:*`. When the redirector 502s
while resolving such an unrelated POM, Gradle disables the repository for the rest of
the build and fails the resolution (it does not retry a 5xx or fall through to another
repo), taking down everything that was mid-resolution.

## Changes

All in `buildSrc/.../io/spine/gradle/repo/Repositories.kt`:

- **Content-filter every JetBrains repository.** Extracted `includeIntelliJPlatformOnly()`
  and applied it to `intellijReleases`, `jetBrainsCacheRedirector`, and
  `intellijDependencies` (the last already had the filter inline; now centralized).
  These mirrors are only consulted for the IntelliJ Platform coordinates they actually
  serve, so a transient 5xx from them can no longer break resolution of unrelated artifacts.
- **Reliable repositories first.** `mavenCentral()` and `gradlePluginPortal()` now lead
  `standardToSpineSdk()`. Coordinates shared with the JetBrains mirror (e.g.
  `org.jetbrains:annotations`) resolve from Central and never reach the redirector.
- **Scope the Sonatype snapshots repo** with `mavenContent { snapshotsOnly() }`, removing
  it from the lookup path (and as a failure point) for release artifacts.

## Verification

`./gradlew :buildSrc:build detekt` (JDK 17) — BUILD SUCCESSFUL, detekt clean, tests pass.
Reviewed by `spine-code-review` and `kotlin-engineer` (both APPROVE).

## Notes for reviewers

- This file is distributed by `config` into every consumer repo, so the fix propagates
  org-wide on the next `config` -> master merge and float.
- Residual risk: if the redirector 502s while resolving a genuine `com.jetbrains.intellij.*`
  artifact, that specific build still fails (Gradle won't retry a 5xx). The filter
  guarantees that is now the *only* thing that can break it. A possible follow-up is
  dropping the redirector in favor of `packages.jetbrains.team` alone, pending confirmation
  it carries every needed coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)