### PR TITLE
Stop wiring the `version.gradle.kts` Edit-block hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,15 +65,6 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.agents/scripts/protect-version-file.sh"
-          }
-        ]
-      },
-      {
         "matcher": "Bash",
         "hooks": [
           {


### PR DESCRIPTION
## What

Removes the `Edit|Write|MultiEdit → protect-version-file.sh` `PreToolUse` entry from the `.claude/settings.json` template. Because `migrate` clobber-copies this template into every consumer's `.claude/settings.json` on each `./config/pull`, dropping the entry here removes the block from **all consumers** on their next pull — no per-repo edits needed.

The `Bash` publish gate (`pre-pr-gate.sh`, `publish-version-gate.sh`), the `PostToolUse` hooks (`sanitize-source-code.sh`, `update-copyright.sh`), and the `SessionStart` `init-submodules` hook are all left intact.

## Why

The hook blocked agents from editing `version.gradle.kts`, forcing all version changes through the `bump-version` skill. It was **friction without protection**: it blocked the `Edit` tool but left a Bash `sed` write open, so it never actually prevented editing — it just diverted agents onto a path that then needed a permission prompt, defeating the autonomy the skill exists to provide.

The protections that matter are outcome-based and stay in place:

- `publish-version-gate.sh` still blocks a build/publish unless the branch is bumped above base.
- CI's `checkVersionIncrement` still rejects an already-published version.

## Companion change

The shared `agents` repo deletes the now-unreferenced script: SpineEventEngine/agents#21.

## Rollout

Merge **this PR first**: it removes the wiring everywhere on the next `./config/pull`, and the script lingering unused in `.agents/shared` is harmless. Then merge the `agents` PR (deletes the script). Merging in the other order leaves a brief window where a consumer's settings reference a deleted script — a non-blocking stderr note on edits, not a real break.