### PR TITLE
Harden the org-wide Maven repository set and drop the redundant JetBrains cache redirector

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/IntelliJ.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ package io.spine.dependency.lib
 /**
  * The components of the IntelliJ Platform.
  *
- * Make sure to add the `intellijReleases` and `jetBrainsCacheRedirector`
- * repositories to your project. See `kotlin/Repositories.kt` for details.
+ * Make sure to add the `intellijReleases` and `intellijDependencies`
+ * repositories to your project. See `io/spine/gradle/repo/Repositories.kt` for details.
  */
 @Suppress("unused")
 object IntelliJ {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repositories.kt
@@ -99,11 +99,6 @@ val RepositoryHandler.intellijReleases: MavenArtifactRepository
         includeIntelliJPlatformOnly()
     }
 
-val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
-    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
-        includeIntelliJPlatformOnly()
-    }
-
 val RepositoryHandler.intellijDependencies: MavenArtifactRepository
     get() = maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") {
         includeIntelliJPlatformOnly()
@@ -118,7 +113,7 @@ fun RepositoryHandler.standardToSpineSdk() {
     // the first repository that can serve an artifact, so keeping these ahead of
     // the special-purpose ones means coordinates shared with them (such as
     // `org.jetbrains:annotations`) resolve here and never reach a less reliable
-    // mirror like `cache-redirector.jetbrains.com`.
+    // JetBrains mirror.
     //
     // `io.spine.*` modules are served only by the Spine repositories below, so
     // they are excluded here. Otherwise Gradle would query Central / the Plugin
@@ -147,11 +142,13 @@ fun RepositoryHandler.standardToSpineSdk() {
             }
         }
 
-    // IntelliJ Platform repositories. Each is restricted to the IntelliJ
-    // coordinates it serves (see `includeIntelliJPlatformOnly`), so a transient
-    // 5xx from one of them cannot break the resolution of unrelated artifacts.
+    // IntelliJ Platform repositories. `intellijReleases` serves the platform
+    // artifacts (`com.jetbrains.intellij.*`); `intellijDependencies` serves the
+    // repackaged third-party dependencies (`org.jetbrains.intellij.deps.*` and
+    // JetBrains-internal builds). Each is restricted to the coordinates it serves
+    // (see `includeIntelliJPlatformOnly`), so a transient 5xx from one of them
+    // cannot break the resolution of unrelated artifacts.
     intellijReleases
-    jetBrainsCacheRedirector
     intellijDependencies
 
     maven {
@@ -219,12 +216,11 @@ private fun ArtifactRepository.excludeSpine() {
  * Restricts a JetBrains/IntelliJ Platform repository to the coordinates it
  * actually serves.
  *
- * These hosts — `cache-redirector.jetbrains.com` in particular — periodically
- * answer with HTTP 5xx. Once Gradle sees such an error, it disables the
- * repository for the rest of the build and fails the resolution instead of
- * falling back to another repository. Without this filter the redirector is
- * queried for every artifact, so a single 502 on an unrelated POM (such as
- * `com.fasterxml.jackson:jackson-parent`) breaks the whole build.
+ * These hosts periodically answer with HTTP 5xx. Once Gradle sees such an error,
+ * it disables the repository for the rest of the build and fails the resolution
+ * instead of falling back to another repository. Without this filter such a
+ * repository is queried for every artifact, so a single 502 on an unrelated POM
+ * (such as `com.fasterxml.jackson:jackson-parent`) would break the whole build.
  */
 private fun MavenArtifactRepository.includeIntelliJPlatformOnly() {
     content {


### PR DESCRIPTION
## What

Hardens `standardToSpineSdk()` against the periodically-flaky JetBrains mirrors, culminating in the removal of the `jetBrainsCacheRedirector` repository. Three commits:

1. **Restrict JetBrains repos to IntelliJ coordinates** — add `includeIntelliJPlatformOnly()` (`com.jetbrains.*`, `org.jetbrains.*`, `com.intellij.*`) to all JetBrains repos and put `mavenCentral()` / `gradlePluginPortal()` first, so an unrelated POM (e.g. `com.fasterxml.jackson:*`) never touches a JetBrains mirror.
2. **Exclude `io.spine.*` from Central and the Plugin Portal** — Spine modules are served only by the Spine repositories, so excluding them from the general-purpose repos removes pointless lookups and stops Spine resolution depending on the health of repos that never host it.
3. **Drop the redundant `jetBrainsCacheRedirector`** — remove the repo and its public `val`, leaving `intellijReleases` + `intellijDependencies`.

## Why drop the redirector

`cache-redirector.jetbrains.com` periodically returns HTTP 502. Gradle does **not** retry a 5xx — it disables the repository for the rest of the build and fails resolution rather than falling through to another repo. Content filtering (commit 1) stops *unrelated* artifacts from hitting it, but a 502 on a genuine `com.jetbrains.intellij.*` / `org.jetbrains.intellij.deps.*` artifact would still break the build.

The redirector turns out to be **redundant**, proven two ways:

**Repo roles** (curl, redirects followed):

| Coordinate | `intellijReleases` | `intellijDependencies` | `jetBrainsCacheRedirector` |
|---|---|---|---|
| `com.jetbrains.intellij.platform:core` (platform) | **200** | 404 | 404 |
| `org.jetbrains.intellij.deps:jdom:2.0.6` (dep) | 404 | **200** | **200** |
| `org.jetbrains.kotlin:kotlin-stdlib:1.5.10-release-949` (JB-internal) | 404 | **200** | **200** |

The redirector resolves to `artifacts-caching-proxy.aws.intellij.net/intellij-dependencies` — a CDN front-end for the *same* `intellij-dependencies` repo that `intellijDependencies` (`packages.jetbrains.team`) exposes directly. It hosts no unique coordinates.

**Empirical resolution** — a throwaway Gradle 9.5.1 project declaring all 19 IntelliJ Platform coordinates at `213.7172.53`, resolving the full `compileClasspath` transitive closure with `--refresh-dependencies --no-daemon` and production content filters:

| Repository set | Unresolved | Artifact failures | Artifacts resolved |
|---|---|---|---|
| **Without** redirector | 0 | 0 | **68** |
| With redirector (baseline) | 0 | 0 | 68 |

The diff is empty. The entire 68-artifact closure — including the deps-only `jdom` and the not-on-Maven-Central `kotlin-stdlib:1.5.10-release-949` — resolves from `intellijReleases` + `intellijDependencies` alone. Removing the 502-prone host is a **net reliability gain**: since Gradle disables a repo on 5xx instead of falling through, keeping the flaky redirector ahead of the reliable mirror was a pure failure point, never a fallback.

## Reviewer notes

- `jetBrainsCacheRedirector` was a public extension `val`. No references remain inside `config`; a consumer that referenced it directly (the old `IntelliJ` KDoc invited that) must drop the reference — a deliberate minor breaking change. The KDoc now points to `intellijReleases` + `intellijDependencies`.
- Verified with `./gradlew :buildSrc:build detekt` (JDK 17) — config has no aggregate `build` task. Reviewers `spine-code-review`, `kotlin-engineer`, `dependency-audit`, `review-docs` all approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)