### PR TITLE
Limit init-submodules bootstrap to config-managed submodules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,15 @@ Shared skills, scripts, and guidelines come from the `.agents/shared` submodule 
 `./config/pull` initializes and floats them automatically. But a fresh `git worktree`
 (and some shallow clones / cloud checkouts) start with NO submodules checked out, so
 those symlinks dangle and no skills are found. Bootstrap such a tree with
-**`./init-submodules`** — a root script that materializes the missing submodules
-(`config`, `.agents/shared`, …) at their pinned commits. It depends on no pre-existing
-`config` submodule, so it works before `./config/pull` (which lives inside the `config`
+**`./init-submodules`** — a root script that materializes the missing
+*config-managed* submodules at their pinned commits: `config` itself, plus every
+submodule that declares a tracked `branch` in `.gitmodules` (`.agents/shared`, and
+any shared submodule added later) — the same rule `./config/pull` uses to decide
+what it floats. Submodules the consumer owns (a Hugo theme, a vendored library,
+doc-example submodules, …) declare no tracked branch and are left untouched, so the
+automatic `SessionStart` run never tries to clone — or fail on credentials for — a
+submodule this project does not manage. It depends on no pre-existing `config`
+submodule, so it works before `./config/pull` (which lives inside the `config`
 submodule) can. Claude Code runs it automatically via a `SessionStart` hook; other
 agents and humans run it by hand, then `./config/pull` to float the shared submodules
 to their branch tips.

--- a/init-submodules
+++ b/init-submodules
@@ -2,8 +2,8 @@
 
 ################################################################################
 #
-# Materialize the submodules a fresh working tree is missing, so agent assets
-# resolve.
+# Materialize the *config-managed* submodules a fresh working tree is missing, so
+# agent assets resolve.
 #
 # `git worktree add` — and some shallow CI / cloud checkouts — populate only the
 # superproject's own tracked files; registered submodules are left UNinitialized.
@@ -17,12 +17,28 @@
 # (distributed by `config`), so `git worktree add` always checks it out — it can
 # therefore bring `config` itself into existence.
 #
-# It initializes ONLY submodules that are not yet checked out (those
-# `git submodule status` marks with a leading `-`), at the commit the branch
-# pins. Submodules already present are left exactly as they are, so a tree that
-# floated `config` / `.agents/shared` to a branch tip via `./config/pull` is
-# never silently rewound to the pin. That makes the script idempotent and safe to
-# run on every session start.
+# It initializes ONLY submodules that are BOTH:
+#
+#   * not yet checked out — those `git submodule status` marks with a leading `-`,
+#     at the commit the branch pins; and
+#
+#   * config-managed — `config` itself (the bootstrap target `pull` lives inside,
+#     which carries no tracked `branch` in a consumer's `.gitmodules`), plus every
+#     submodule that declares a tracked `branch` in `.gitmodules`. This is exactly
+#     the rule `./config/pull` uses to decide what it floats, so the two scripts
+#     can never disagree about what is shared.
+#
+# Consumer-owned submodules (a Hugo theme, a vendored library, documentation
+# examples, ...) declare no tracked branch and are deliberately left untouched.
+# Because a `SessionStart` hook runs this script automatically on every session,
+# initializing them would mean trying to clone — or failing on credentials for —
+# a submodule this project does not manage, on every single start. They are
+# skipped (noted on stderr).
+#
+# Submodules already present are left exactly as they are, so a tree that floated
+# `config` / `.agents/shared` to a branch tip via `./config/pull` is never
+# silently rewound to the pin. That makes the script idempotent and safe to run on
+# every session start.
 #
 # It does NOT float submodules to their branch tips — run `./config/pull`
 # afterwards for that. Unlike `pull`, it depends on no pre-existing `config`
@@ -39,14 +55,33 @@ cd "$root" || exit 0
 # Nothing to do in a repo without submodules.
 [ -f .gitmodules ] || exit 0
 
+# The set of config-managed submodule paths: `config` itself (handled specially —
+# it carries no tracked branch, exactly as in `./config/pull`), plus every
+# submodule declaring a tracked `branch` in `.gitmodules`. Mirrors `pull`'s rule.
+config_managed_paths() {
+    printf '%s\n' 'config'
+    git config -f .gitmodules --get-regexp '^submodule\..*\.branch$' 2>/dev/null \
+    | while read -r key _branch; do
+        name=${key#submodule.}; name=${name%.branch}
+        git config -f .gitmodules --get "submodule.$name.path" 2>/dev/null
+    done
+}
+
+managed=$(config_managed_paths | sort -u)
+
 # `git submodule status` prefixes each uninitialized submodule with `-`; an
-# initialized one starts with a space (at the pinned commit) or `+` (ahead of
-# it). Act only on the `-` lines, taking the path from the second field.
+# initialized one starts with a space (at the pinned commit) or `+` (ahead of it).
+# Act only on the `-` lines, taking the path from the second field, and only when
+# that path is config-managed.
 git submodule status 2>/dev/null | awk '$1 ~ /^-/ { print $2 }' | while read -r path; do
     [ -n "$path" ] || continue
-    echo "init-submodules: initializing '$path'"
-    git submodule update --init --recursive -- "$path" \
-        || echo "init-submodules: WARNING — could not initialize '$path' (offline?)." >&2
+    if printf '%s\n' "$managed" | grep -qxF -- "$path"; then
+        echo "init-submodules: initializing '$path'"
+        git submodule update --init --recursive -- "$path" \
+            || echo "init-submodules: WARNING — could not initialize '$path' (offline?)." >&2
+    else
+        echo "init-submodules: skipping consumer-owned '$path' (not config-managed)." >&2
+    fi
 done
 
 exit 0


### PR DESCRIPTION
## Problem

Addresses [#697 (comment)](https://github.com/SpineEventEngine/config/pull/697#discussion_r3432637633).

`init-submodules` runs automatically from a `SessionStart` hook. The original
loop consumed **every** uninitialized (`-`) entry from `git submodule status`,
not just the config-managed ones. In any repo with an unrelated uninitialized
submodule — a private Hugo theme, a vendored library, doc-example submodules —
the hook would try to clone it on **every** session start, which can block
startup or fail on credentials for a submodule `config` deliberately leaves
alone.

## Fix

Scope the bootstrap to **config-managed** submodules only — exactly the set
`./config/pull` floats:

- `config` itself (the bootstrap target; it carries no tracked `branch` in a
  consumer's `.gitmodules`, so it is added explicitly — mirroring `pull`'s
  step 1), plus
- every submodule that declares a tracked `branch` in `.gitmodules`
  (`.agents/shared`, and any shared submodule added later).

A new `config_managed_paths()` helper computes that set by parsing `.gitmodules`
with the same branch-tracking rule `pull` uses, so the two scripts can never
disagree about what is shared. The init loop now skips any `-` path that is not
in the set (noting the skip on stderr). Consumer-owned submodules are left
untouched.

`AGENTS.md` is updated to document the narrowed behavior.

## Verification

- `bash -n init-submodules` — clean.
- Computed managed set in this repo: `config`, `.agents/shared` — matches
  `pull`'s branch-tracked rule.
- Simulated `git submodule status` with mixed entries: `config` and
  `.agents/shared` → INIT; a Hugo theme and a vendored lib → SKIP; an
  already-initialized submodule → untouched.
- Ran `./init-submodules` live: clean no-op (the one submodule here is already
  initialized), exit 0.
- `review-docs` on the `AGENTS.md` change: APPROVE, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
