### PR TITLE
Adopt Ubuntu CI improvements from core-jvm-compiler#103

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -6,7 +6,6 @@ jobs:
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-latest
-    timeout-minutes: 90   # Avoid premature job termination on slow runners.
     concurrency:  # Avoid canceling in-progress runs for the same branch.
       group: ubuntu-ci-${{ github.ref }}
       cancel-in-progress: false

--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -6,6 +6,10 @@ jobs:
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 90   # Avoid premature job termination on slow runners.
+    concurrency:  # Avoid canceling in-progress runs for the same branch.
+      group: ubuntu-ci-${{ github.ref }}
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6
@@ -19,13 +23,24 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
+      # Mirrors the pagefile step in build-on-windows.yml. The Linux runner
+      # ships with effectively no swap, so a memory peak becomes an instant
+      # OOM kill; this gives the kernel somewhere to fall back to.
+      - name: Add swap space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 8
+
+      - name: Build project, run tests
+        shell: bash
+        run: ./gradlew build --stacktrace
+
       # `build` does not run Dokka — its tasks are gated to the publishing
       # graph — so `dokkaGenerate` is appended to surface documentation
       # warnings on each push, before merge, instead of only in the post-merge
       # `Publish` job. `failOnWarning` is enabled in the Dokka setup.
-      - name: Build project, run tests, and check documentation
-        shell: bash
-        run: ./gradlew build dokkaGenerate --stacktrace
+      - name: Check documentation
+        run: ./gradlew dokkaGenerate --stacktrace
 
       # See: https://github.com/marketplace/actions/junit-report-action
       - name: Publish Test Report


### PR DESCRIPTION
## What

Port the improvements made to `build-on-ubuntu.yml` in
[`SpineEventEngine/core-jvm-compiler#103`](https://github.com/SpineEventEngine/core-jvm-compiler/pull/103)
into this repo's distributed workflow template (`.github-workflows/build-on-ubuntu.yml`):

- **Concurrency** — a same-branch `concurrency` group (`ubuntu-ci-${{ github.ref }}`) with
  `cancel-in-progress: false`.
- **Swap space** — a new "Add swap space" step (`pierotofy/set-swap-space@v1.0`, 8 GB)
  mirroring the pagefile step in `build-on-windows.yml`, to avoid OOM kills on the Linux runner.
- **Split steps** — the combined `./gradlew build dokkaGenerate` step is split into a
  "Build project, run tests" step and a "Check documentation" step.

The source PR's job-level `timeout-minutes: 90` was intentionally **not** carried over.
In a template consumed by many repositories it would lower the limit below GitHub's inherited
360-minute default for every consumer, risking premature cancellation of legitimately long
builds (per review feedback). Consumers that want a tighter cap can set `timeout-minutes` in
their own copy.

## Note

As requested, the explanatory comment dropped in the source PR is **restored** on the
concurrency line:

```yaml
concurrency:  # Avoid canceling in-progress runs for the same branch.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLzkeP4gSPkeYVSJCTy1G9