### PR TITLE
Let `migrate` skip distributed workflows a repo replaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,36 @@ as such cannot be placed under `.github/workflows`.
 
 These scripts are copied by the `pull` script when `config` is applied to a new repository.
 
+### Replacing a distributed workflow in a single repository
+
+Occasionally a repository needs a CI workflow that diverges from the uniform one
+distributed here — for example, [`gcloud-java`][gcloud-java] decrypts a
+service-account key on Ubuntu and skips the Datastore-emulator suites on the
+Windows runner. Keep the repo-specific variant under a **distinct name** (e.g.
+`build-on-ubuntu-gcloud.yml`) and add a directive comment naming the distributed
+file it stands in for:
+
+```yaml
+# config:replaces build-on-ubuntu.yml
+name: Ubuntu CI with Google Cloud SDK
+```
+
+`migrate` reads these `config:replaces` directives and will not copy the named
+generic workflow into that repository, so only the repo-specific variant runs.
+The directive is an ordinary YAML comment, so GitHub Actions ignores it.
+
+`migrate` never deletes a generic workflow the repository already committed: when
+you first introduce a variant, delete the generic file (e.g. `build-on-ubuntu.yml`)
+by hand once. From then on, `./config/pull` leaves the variant in place and does
+not re-add the generic.
+
 ## Further reading
 
   * [GitHub: Working with submodules][working-with-submodules]
   * [Pro Git: Git Tools - Git Submodules][submodule-tools]
   
 [agents-repo]: https://github.com/SpineEventEngine/agents
+[gcloud-java]: https://github.com/SpineEventEngine/gcloud-java
 [base]: https://github.com/SpineEventEngine/base
 [base-types]: https://github.com/SpineEventEngine/base-types
 [core-jvm]: https://github.com/SpineEventEngine/core-jvm

--- a/migrate
+++ b/migrate
@@ -129,11 +129,17 @@ cp .github/copilot-instructions.md ../.github/copilot-instructions.md
 
 # Names of distributed workflows a repo-specific variant stands in for, gathered
 # from `config:replaces` directives in the consumer's own workflows (one per line).
-OVERRIDDEN=$(grep -rhoE 'config:replaces[[:space:]]+[A-Za-z0-9._-]+' \
-             ../.github/workflows 2>/dev/null | awk '{print $2}' | sort -u)
+# The directive is a YAML *comment*, so the pattern is anchored to a comment line
+# (optional leading whitespace, then `#`) — this avoids an accidental match on the
+# literal string appearing inside a workflow's values. The filename is the last
+# whitespace-separated field of the match, regardless of spacing after `#`.
+OVERRIDDEN=$(grep -rhoE '^[[:space:]]*#[[:space:]]*config:replaces[[:space:]]+[A-Za-z0-9._-]+' \
+             ../.github/workflows 2>/dev/null | awk '{print $NF}' | sort -u)
 if [ -n "$OVERRIDDEN" ]; then
     echo "Repo-specific workflow overrides detected; not distributing:"
-    printf '  %s\n' $OVERRIDDEN
+    printf '%s\n' "$OVERRIDDEN" | while IFS= read -r wf; do
+        echo "  $wf"
+    done
 fi
 
 # Whether the distributed workflow named by $1 is replaced by a repo-specific

--- a/migrate
+++ b/migrate
@@ -111,6 +111,53 @@ echo "Updating GitHub Copilot instructions"
 cp .github/copilot-instructions.md ../.github/copilot-instructions.md
 
 # ---------------------------------------------------------------------------
+# Repo-specific workflow overrides
+#
+# A consumer repository sometimes needs a CI workflow that diverges from the
+# uniform one `config` distributes — e.g. `gcloud-java` decrypts a service-account
+# key and skips the Datastore-emulator suites on the Windows runner. Such a repo
+# keeps its own variant under a distinct name (e.g. `build-on-ubuntu-gcloud.yml`)
+# and marks it with a directive comment — ignored by GitHub Actions — naming the
+# distributed file it stands in for:
+#
+#     # config:replaces build-on-ubuntu.yml
+#
+# `migrate` then refrains from copying that generic workflow here, so only the
+# repo-specific variant runs. It does NOT delete a generic file the consumer has
+# already committed: that one-time cleanup is left to the developer.
+# ---------------------------------------------------------------------------
+
+# Names of distributed workflows a repo-specific variant stands in for, gathered
+# from `config:replaces` directives in the consumer's own workflows (one per line).
+OVERRIDDEN=$(grep -rhoE 'config:replaces[[:space:]]+[A-Za-z0-9._-]+' \
+             ../.github/workflows 2>/dev/null | awk '{print $2}' | sort -u)
+if [ -n "$OVERRIDDEN" ]; then
+    echo "Repo-specific workflow overrides detected; not distributing:"
+    printf '  %s\n' $OVERRIDDEN
+fi
+
+# Whether the distributed workflow named by $1 is replaced by a repo-specific
+# variant in the consumer (per a `config:replaces` directive).
+function is_overridden() {
+    printf '%s\n' "$OVERRIDDEN" | grep -qxF "$1"
+}
+
+# Copies every workflow from the source directory ($1) into the consumer's
+# `.github/workflows`, skipping any the consumer has chosen to replace.
+function copy_workflows() {
+    local f name
+    for f in "$1"/*; do
+        [ -e "$f" ] || continue
+        name=$(basename "$f")
+        if is_overridden "$name"; then
+            echo "Skipping '$name' (replaced by a repo-specific workflow)"
+            continue
+        fi
+        cp -a "$f" ../.github/workflows/
+    done
+}
+
+# ---------------------------------------------------------------------------
 # Claude settings — the commands/agents/skills come from the submodule above;
 # only the permission settings are repo configuration distributed by `config`.
 # ---------------------------------------------------------------------------
@@ -139,7 +186,11 @@ if [ "$IS_HUGO_DOCS" = "true" ]; then
     cp lychee.toml ..
 
     echo "Updating GitHub workflows (Hugo)"
-    cp .github/workflows/check-links.yml ../.github/workflows/
+    if is_overridden check-links.yml; then
+        echo "Skipping 'check-links.yml' (replaced by a repo-specific workflow)"
+    else
+        cp .github/workflows/check-links.yml ../.github/workflows/
+    fi
 
     # On a Hugo-only repo, remove any JVM workflows that may be present from
     # a previous non-Hugo pull. On a repo that is also JVM, leave them — the
@@ -199,8 +250,8 @@ if [ "$IS_JVM" = "true" ]; then
     rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
 
     echo "Updating GitHub workflows (JVM)"
-    cp -a .github-workflows/. ../.github/workflows
-    cp -a .github/workflows/. ../.github/workflows
+    copy_workflows .github-workflows
+    copy_workflows .github/workflows
     rm -f ../.github/workflows/detekt-code-analysis.yml # config-only workflow
 
     echo "Updating Gradle Wrapper"


### PR DESCRIPTION
## What

Teach `migrate` to honor a per-repository **workflow override** so it stops re-adding a generic CI workflow that a consumer has deliberately replaced.

A consumer marks its repo-specific variant (kept under a distinct name, e.g. `build-on-ubuntu-gcloud.yml`) with a directive comment naming the distributed file it stands in for:

```yaml
# config:replaces build-on-ubuntu.yml
name: Ubuntu CI with Google Cloud SDK
```

`migrate` collects these `config:replaces` directives from the consumer's existing workflows **before** copying, then skips distributing any named generic file. The directive is an ordinary YAML comment, so GitHub Actions ignores it.

## Why

`migrate` copied everything from `.github-workflows/` and `.github/workflows/` via two unconditional `cp -a …/.` calls. Repositories that need a divergent workflow — `gcloud-java` decrypts a Spine-Dev service-account key on Ubuntu and excludes the Datastore-emulator suites (Linux-container-only) on the Windows runner — keep their own `*-gcloud.yml` variants. Every `./config/pull` re-added the generic `build-on-ubuntu.yml` / `build-on-windows.yml` next to them, causing **duplicate CI runs** and a recurring manual deletion (see `gcloud-java`'s "Remove duplicated workflow" commit).

## How

- Compute an `OVERRIDDEN` set once, up front, from `config:replaces` directives in the consumer's `.github/workflows/`.
- Replace the two bulk `cp -a …/.` copies with a `copy_workflows` helper that copies each file individually and skips overridden ones; guard the Hugo `check-links.yml` copy the same way for uniformity.
- **Skip-only** semantics: `migrate` never deletes a generic the consumer already committed. Introducing a variant requires deleting the generic by hand once; from then on `pull` leaves the variant alone.
- Documented the convention in the README's `.github-workflows` section.

## Reviewer notes

- Kept bash-3.2-compatible (macOS default): no `mapfile`/`compgen`; uses BSD-compatible `grep -rhoE` and `grep -qxF`.
- Empty override set ⇒ behavior is byte-for-byte identical to before. A brand-new repo with no `.github/workflows/` yields an empty set with no stderr noise.
- The companion change — adding the `config:replaces` markers to `gcloud-java`'s `build-on-{ubuntu,windows}-gcloud.yml` — lives in the `gcloud-java` repo and is not part of this PR.

## Verification

- `bash -n migrate` passes.
- Simulated a `gcloud-java`-style consumer against the real `config` source dirs: `build-on-ubuntu.yml` / `build-on-windows.yml` skipped; all other distributed workflows plus both `-gcloud` variants present; `detekt-code-analysis.yml` still removed.
- Regression: a no-marker repo copies all 9 distributed workflows as before.
- Pre-PR: PASS — `review-docs` and `spine-code-review` both APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
