### PR TITLE
Build Ubuntu CI on master pushes and pull requests

### DIFF
--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -1,14 +1,18 @@
 name: Ubuntu CI
 
 # Triggers:
-#   * push to `master` — refreshes the Codecov baseline. `Publish` runs
-#     `publish -x test` and uploads no coverage, so this build is the only
-#     source of master coverage that `target: auto` in `.codecov.yml` compares
-#     pull requests against.
+#   * push to a default or release-line branch — those ending in `master` or
+#     `main`, the same set `increment-guard.yml` guards as PR bases (e.g.
+#     `master`, `2.x-jdk8-master`). These post-merge runs are the only source
+#     of base-branch coverage, since `Publish` runs `publish -x test` and
+#     uploads none; `target: auto` in `.codecov.yml` compares each pull request
+#     against its base baseline.
 #   * pull_request — gates a change on its merge result, not the branch tip.
 on:
   push:
-    branches: [master]
+    branches:
+      - '**master'
+      - '**main'
   pull_request:
 
 jobs:

--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -15,14 +15,6 @@ jobs:
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-latest
-
-    # Hoisted to a job-level env so the coverage-upload step can gate on it.
-    # Forked and Dependabot pull requests run without repository secrets, so
-    # the token is empty there. The `secrets` context is not available in a
-    # step `if:`, but `env` is.
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
     concurrency:  # Avoid canceling in-progress runs for the same branch.
       group: ubuntu-ci-${{ github.ref }}
       cancel-in-progress: false
@@ -66,6 +58,22 @@ jobs:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found
 
+      # Probe whether the upload token is available without exposing its value
+      # to the build/test steps. Scoping `CODECOV_TOKEN` to this trivial step
+      # (and to the upload step's `with.token`) keeps PR-authored code in
+      # `./gradlew build` from ever seeing the secret. The `secrets` context is
+      # not available in a step `if:`, so the upload gates on this output.
+      - name: Detect Codecov token
+        id: codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "$CODECOV_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # On `push` (master) always upload — these runs are the only source of
       # the `target: auto` baseline, so an absent token there is a
       # misconfiguration that should fail loudly rather than silently stop
@@ -74,9 +82,9 @@ jobs:
       # would otherwise redden a healthy PR (coverage gating is meaningless
       # there anyway).
       - name: Upload code coverage report
-        if: env.CODECOV_TOKEN != '' || github.event_name == 'push'
+        if: steps.codecov.outputs.available == 'true' || github.event_name == 'push'
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -15,6 +15,14 @@ jobs:
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-latest
+
+    # Hoisted to a job-level env so the coverage-upload step can gate on it.
+    # Forked and Dependabot pull requests run without repository secrets, so
+    # the token is empty there. The `secrets` context is not available in a
+    # step `if:`, but `env` is.
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
     concurrency:  # Avoid canceling in-progress runs for the same branch.
       group: ubuntu-ci-${{ github.ref }}
       cancel-in-progress: false
@@ -58,9 +66,14 @@ jobs:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found
 
+      # Skipped on forked and Dependabot PRs, where `CODECOV_TOKEN` is empty:
+      # otherwise the tokenless upload fails, and `fail_ci_if_error: true`
+      # would turn that into a red build on an otherwise-healthy PR. Coverage
+      # gating is not meaningful in those contexts anyway.
       - name: Upload code coverage report
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -66,12 +66,15 @@ jobs:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found
 
-      # Skipped on forked and Dependabot PRs, where `CODECOV_TOKEN` is empty:
-      # otherwise the tokenless upload fails, and `fail_ci_if_error: true`
-      # would turn that into a red build on an otherwise-healthy PR. Coverage
-      # gating is not meaningful in those contexts anyway.
+      # On `push` (master) always upload — these runs are the only source of
+      # the `target: auto` baseline, so an absent token there is a
+      # misconfiguration that should fail loudly rather than silently stop
+      # refreshing coverage. On `pull_request`, skip when the token is absent:
+      # forked and Dependabot PRs run without secrets, and `fail_ci_if_error`
+      # would otherwise redden a healthy PR (coverage gating is meaningless
+      # there anyway).
       - name: Upload code coverage report
-        if: env.CODECOV_TOKEN != ''
+        if: env.CODECOV_TOKEN != '' || github.event_name == 'push'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ env.CODECOV_TOKEN }}

--- a/.github-workflows/build-on-ubuntu.yml
+++ b/.github-workflows/build-on-ubuntu.yml
@@ -1,6 +1,15 @@
 name: Ubuntu CI
 
-on: push
+# Triggers:
+#   * push to `master` — refreshes the Codecov baseline. `Publish` runs
+#     `publish -x test` and uploads no coverage, so this build is the only
+#     source of master coverage that `target: auto` in `.codecov.yml` compares
+#     pull requests against.
+#   * pull_request — gates a change on its merge result, not the branch tip.
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:
@@ -36,8 +45,8 @@ jobs:
 
       # `build` does not run Dokka — its tasks are gated to the publishing
       # graph — so `dokkaGenerate` is appended to surface documentation
-      # warnings on each push, before merge, instead of only in the post-merge
-      # `Publish` job. `failOnWarning` is enabled in the Dokka setup.
+      # warnings before merge, instead of only in the post-merge `Publish`
+      # job. `failOnWarning` is enabled in the Dokka setup.
       - name: Check documentation
         run: ./gradlew dokkaGenerate --stacktrace
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.413"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.420"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.420"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.053"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.054"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.053"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.054"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.376"
+    const val version = "2.0.0-SNAPSHOT.380"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.077"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.079"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.077"
+    const val version = "2.0.0-SNAPSHOT.079"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.400"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.400"
+    const val version = "2.0.0-SNAPSHOT.401"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.401"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"


### PR DESCRIPTION
## Summary

Two changes to the distributed CI config, plus a local dependency refresh kept on
the same branch:

1. **Unify the Ubuntu CI trigger** so it runs on pushes to integration branches
   *and* pull requests, with the Codecov upload hardened for the new PR contexts.
2. **Refresh `local/` Spine SDK snapshots** — five dependency objects bumped to
   their latest Artifact Registry snapshot.

---

## 1. Ubuntu CI trigger

`build-on-ubuntu.yml` triggered on every `push`, while `build-on-windows.yml`
used `pull_request` — an undocumented divergence dating to 2021. This unifies the
Ubuntu build on:

```yaml
on:
  push:
    branches: ['**master', '**main']
  pull_request:
```

### Why both events

- **`push` to integration branches** keeps the Codecov baseline fresh. `Publish`
  runs `./gradlew publish -x test` and uploads no coverage, so this build is the
  only source of base-branch coverage that `target: auto` in `.codecov.yml`
  compares each PR against. The filter matches the guarded-base set from
  `increment-guard.yml` (branches ending in `master`/`main`, e.g.
  `2.x-jdk8-master`), so release lines keep their baseline too — not only literal
  `master`.
- **`pull_request`** gates a change on its merge result rather than the branch
  tip, matching `build-on-windows.yml`, `increment-guard.yml`, and
  `ensure-reports-updated.yml`.

Windows stays `pull_request`-only: it uploads no coverage and Windows runner
minutes are ~2× Linux.

### Codecov upload, hardened for PR contexts

Adding `pull_request` makes the upload run for forked / Dependabot PRs, where
secrets are withheld. Final shape:

- A step-scoped `Detect Codecov token` probe emits a boolean; the token value
  never enters the build/test steps' environment.
- The upload runs when the token is present **or** the event is a `push` — so
  master/release pushes always upload (a missing token fails loudly instead of
  silently rotting the baseline), while token-less fork/Dependabot PRs skip it
  and stay green.

### ⚠️ Before merge — verify branch-protection check names

This is a **distributed** workflow: it lands in every consumer repo. Moving a
PR's build from `push` to `pull_request` shifts check names, e.g.
`JUnit Test Report (push)` → `JUnit Test Report (pull_request)`. If any consumer
repo pins the **`(push)`** variant as a *required* status check, its PRs will
block on a check that no longer runs (the "required check stuck Pending" failure
seen in the `version-guard-aux-base-branches` work). Audit org branch-protection
rules and update the pinned names before/with rollout.

### Benign side effects

- The Ubuntu build now runs `checkVersionIncrement` (wired into `check`) on PRs
  into `master` — redundant with `Version Guard`, still skipped for auxiliary
  bases (the guard keys off `GITHUB_BASE_REF`).
- No-PR scratch branches stop building; PR builds test the merge result.
- Drops the now-inaccurate "on each push" wording from the Dokka comment.

---

## 2. Local dependency refresh

Via `/dependency-update local`: five `dependency/local/` Spine SDK objects bumped
to their latest Artifact Registry snapshot. Each is a forward `2.0.0-SNAPSHOT.x`
increment verified against the registry; the other 9 local objects were already
current. Dogfooding / build-script version constants moved in lockstep.

| Object | Bump |
|---|---|
| Base | `.413` → `.420` |
| Compiler | `.053` → `.054` |
| CoreJvm | `.376` → `.380` |
| CoreJvmCompiler | `.077` → `.079` |
| ToolBase | `.400` → `.401` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
