### PR TITLE
Add Google Cloud dependency objects from `gcloud-jvm`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/GoogleApis.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/GoogleApis.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,13 @@ object GoogleApis {
     const val client = "com.google.api-client:google-api-client:1.32.2"
 
     // https://github.com/googleapis/api-common-java
-    const val common = "com.google.api:api-common:2.1.1"
+    const val common = "com.google.api:api-common:2.64.0"
 
     // https://github.com/googleapis/java-common-protos
-    const val commonProtos = "com.google.api.grpc:proto-google-common-protos:2.7.0"
+    const val commonProtos = "com.google.api.grpc:proto-google-common-protos:2.72.0"
 
     // https://github.com/googleapis/gax-java
-    const val gax = "com.google.api:gax:2.7.1"
+    const val gax = "com.google.api:gax:2.80.0"
 
     // https://github.com/googleapis/java-iam
     const val protoAim = "com.google.api.grpc:proto-google-iam-v1:1.2.0"
@@ -52,7 +52,7 @@ object GoogleApis {
 
     // https://github.com/googleapis/google-auth-library-java
     object AuthLibrary {
-        const val version = "1.3.0"
+        const val version = "1.47.0"
         const val credentials = "com.google.auth:google-auth-library-credentials:$version"
         const val oAuth2Http = "com.google.auth:google-auth-library-oauth2-http:$version"
     }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/PerfMark.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/PerfMark.kt
@@ -29,6 +29,6 @@ package io.spine.dependency.lib
 // https://github.com/perfmark/perfmark
 @Suppress("unused", "ConstPropertyName")
 object PerfMark {
-    private const val version = "0.26.0"
+    private const val version = "0.27.0"
     const val api = "io.perfmark:perfmark-api:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/PerfMark.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/PerfMark.kt
@@ -26,21 +26,9 @@
 
 package io.spine.dependency.lib
 
-/**
- * https://github.com/googleapis/google-cloud-java
- */
+// https://github.com/perfmark/perfmark
 @Suppress("unused", "ConstPropertyName")
-object GoogleCloud {
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/sdk-platform-java/java-core
-    const val core = "com.google.cloud:google-cloud-core:2.71.0"
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/java-pubsub/proto-google-cloud-pubsub-v1
-    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.151.0"
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/java-trace
-    const val trace = "com.google.cloud:google-cloud-trace:2.93.0"
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/java-datastore
-    const val datastore = "com.google.cloud:google-cloud-datastore:2.31.2"
+object PerfMark {
+    private const val version = "0.26.0"
+    const val api = "io.perfmark:perfmark-api:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
@@ -24,23 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.test
 
-/**
- * https://github.com/googleapis/google-cloud-java
- */
+// https://github.com/testcontainers/testcontainers-java
 @Suppress("unused", "ConstPropertyName")
-object GoogleCloud {
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/sdk-platform-java/java-core
-    const val core = "com.google.cloud:google-cloud-core:2.71.0"
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/java-pubsub/proto-google-cloud-pubsub-v1
-    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.151.0"
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/java-trace
-    const val trace = "com.google.cloud:google-cloud-trace:2.93.0"
-
-    // https://github.com/googleapis/google-cloud-java/tree/main/java-datastore
-    const val datastore = "com.google.cloud:google-cloud-datastore:2.31.2"
+object Testcontainers {
+    private const val version = "1.21.4"
+    private const val group = "org.testcontainers"
+    const val lib = "$group:testcontainers:$version"
+    const val junitJupiter = "$group:junit-jupiter:$version"
+    const val gcloud = "$group:gcloud:$version"
 }


### PR DESCRIPTION
## What

Upstreams the Google Cloud-related dependency objects that were being maintained
locally in the `gcloud-jvm` repository into `config`'s `buildSrc`.

**Modified** (version bumps adopted from `gcloud-jvm`; copyright → 2026):
- `GoogleApis` — `api-common` 2.1.1→2.64.0, `proto-google-common-protos` 2.7.0→2.72.0, `gax` 2.7.1→2.80.0, `google-auth-library` 1.3.0→1.47.0
- `GoogleCloud` — `google-cloud-core` 2.3.3→2.71.0, `proto-google-cloud-pubsub-v1` 1.97.0→1.151.0, `google-cloud-trace` 2.1.0→2.93.0, `google-cloud-datastore` 2.2.1→2.31.2 (plus a class KDoc and refreshed `google-cloud-java` monorepo comment URLs)

**New** dependency objects (used by the gcloud/gRPC stack):
- `PerfMark` — `io.perfmark:perfmark-api:0.26.0`
- `Testcontainers` — `org.testcontainers` 1.21.4 (`testcontainers`, `junit-jupiter`, `gcloud`)

## Why

`config` distributes `buildSrc` to consumer repos. These Google Cloud declarations
lived only in `gcloud-jvm`, so each `config` pull risked overwriting them. Making
`config` the source of truth — with the files **byte-identical** to `gcloud-jvm`'s —
turns the next pull into a no-op for them and makes the objects available org-wide.

## Blast radius

The `GoogleApis`/`GoogleCloud` version bumps reach every consumer using those objects
on its next `config` pull. `PerfMark`/`Testcontainers` are additive — only repos that
reference them are affected (today, just `gcloud-jvm`).

## Verification

- `./gradlew :buildSrc:build detekt` → **BUILD SUCCESSFUL**.
- Files confirmed byte-identical to `gcloud-jvm`'s working tree.
- Reviewers (`dependency-audit`, `spine-code-review`, `kotlin-engineer`, `review-docs`): **no Must-fix**.

## Reviewer notes (Should-fix — intentionally not applied)

Two style advisories on `GoogleCloud.kt`, both inherited verbatim from `gcloud-jvm`:
- the pubsub line's `//` comment URL exceeds 100 chars (a comment, exempt from the detekt gate);
- the new class KDoc is a bare URL rather than the package's prose-plus-link style.

Left as-is to preserve byte-identity with `gcloud-jvm`. If we want the polish, it should
be applied in `gcloud-jvm` too so the two stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
