### PR TITLE
Verify version increment before publishing to Maven Local

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -28,14 +28,21 @@
 
 package io.spine.gradle.publish
 
+import io.spine.gradle.Build
 import io.spine.gradle.SpineTaskGroup
+import io.spine.gradle.base.check
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
 
 /**
- * Gradle plugin that adds a [CheckVersionIncrement] task.
+ * Gradle plugin that adds a [CheckVersionIncrement] task verifying that the
+ * project version was incremented before its artifacts are published.
  *
- * The task is called `checkVersionIncrement` inserted before the `check` task.
+ * The task — named `checkVersionIncrement` — runs before the `check` task and
+ * before any `publishToMavenLocal` task. It actually executes only when the
+ * verification is meaningful; see [apply].
  */
 class IncrementGuard : Plugin<Project> {
 
@@ -57,39 +64,73 @@ class IncrementGuard : Plugin<Project> {
             }
             return baseBranch.endsWith("master") || baseBranch.endsWith("main")
         }
+
+        /**
+         * Tells whether the [CheckVersionIncrement] action must actually run for
+         * the current build.
+         *
+         * The increment is verified in two situations:
+         *  1. [ciPullRequest] — a CI pull request that must check the version
+         *     (see [shouldCheckVersion]); or
+         *  2. a local build (not [onCi]) that is going to publish to Maven Local
+         *     ([localPublish]).
+         *
+         * CI pushes and tag builds that publish to Maven Local — e.g. to feed
+         * integration tests — deliberately skip the check, so that re-publishing
+         * an already released version does not fail them.
+         */
+        internal fun mustVerify(
+            ciPullRequest: Boolean,
+            onCi: Boolean,
+            localPublish: Boolean,
+        ): Boolean = ciPullRequest || (!onCi && localPublish)
     }
 
     /**
-     * Adds the [CheckVersionIncrement] task to the project.
+     * Adds the [CheckVersionIncrement] task to the [target] project and wires it
+     * into two execution paths:
      *
-     * The task is created anyway, but it is enabled only if:
-     *  1. The project is built on GitHub CI, and
-     *  2. The job is a pull request targeting a default (`master` or `main`) or
-     *     a release-line (e.g. `2.x-jdk8-master`) branch.
+     *  1. The `check` task depends on it, so that CI pull requests verify
+     *     the increment.
+     *  2. Every `publishToMavenLocal` task depends on it, so that a local publish —
+     *     used by integration tests that consume artifacts from `~/.m2` — cannot
+     *     overwrite an already published version.
+     *
+     * The task is always created and wired, but its action runs only when:
+     *  1. the build is a GitHub Actions pull request targeting a default
+     *     (`master` or `main`) or a release-line (e.g. `2.x-jdk8-master`) branch; or
+     *  2. the build runs locally (outside CI) and is going to publish artifacts
+     *     to Maven Local.
      *
      * It is the responsibility of a branch that aims to merge into a default
      * (or otherwise protected) branch to bump the version. Auxiliary branches do not
      * deal with the versions in the release cycle, so pull requests targeting them,
-     * direct pushes, and tag builds do not run the check. This also prevents unexpected
-     * CI fails when re-building `master` multiple times, creating git tags, and in other
-     * cases that go outside the "usual" development cycle.
+     * direct pushes, and tag builds do not run the check. In particular, the
+     * Maven Local guard is restricted to local builds: re-building `master`,
+     * creating git tags, and other CI jobs that publish locally (e.g. to feed
+     * integration tests) keep succeeding even though their version is already
+     * published. Ordinary local builds that do not publish stay free from the
+     * network-bound version check as well.
      */
     override fun apply(target: Project) {
         val tasks = target.tasks
-        tasks.register(taskName, CheckVersionIncrement::class.java) {
+        val checkVersion = tasks.register(taskName, CheckVersionIncrement::class.java) {
             group = SpineTaskGroup.name
             description = "Verifies that the project version was incremented before publishing"
             repository = CloudArtifactRegistry.repository
-            tasks.getByName("check").dependsOn(this)
-
-            if (!shouldCheckVersion()) {
-                logger.info(
-                    "The build does not represent a GitHub Actions pull request job " +
-                            "targeting a default or a release-line branch, " +
-                            "the `checkVersionIncrement` task is disabled."
-                )
-                this.enabled = false
+            onlyIf {
+                mustVerify(shouldCheckVersion(), Build.ci, it.publishesToMavenLocal())
             }
+        }
+
+        // Verify the increment on CI pull requests via the `check` lifecycle task.
+        tasks.check.configure { dependsOn(checkVersion) }
+
+        // Verify it before publishing to Maven Local too: integration tests in this
+        // and sibling projects consume the freshly published artifacts from `~/.m2`,
+        // so a non-incremented version would let them pick up a stale artifact.
+        tasks.withType(PublishToMavenLocal::class.java).configureEach {
+            dependsOn(checkVersion)
         }
     }
 
@@ -110,3 +151,18 @@ class IncrementGuard : Plugin<Project> {
         return shouldCheckVersion(event, baseBranch)
     }
 }
+
+/**
+ * Tells whether the current build is going to publish artifacts to Maven Local.
+ *
+ * Integration tests in this and sibling projects consume freshly built artifacts
+ * from `~/.m2`. Publishing them under a version that already exists would let those
+ * tests pick up a stale artifact, so the version increment must be verified before
+ * any local publication runs.
+ *
+ * The predicate is evaluated lazily as a task `onlyIf` spec, by which point
+ * the execution [task graph][org.gradle.api.execution.TaskExecutionGraph] is
+ * fully populated.
+ */
+private fun Task.publishesToMavenLocal(): Boolean =
+    project.gradle.taskGraph.allTasks.any { it is PublishToMavenLocal }

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -26,8 +26,14 @@
 
 package io.spine.gradle.publish
 
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.spine.gradle.publish.IncrementGuard.Companion.mustVerify
 import io.spine.gradle.publish.IncrementGuard.Companion.shouldCheckVersion
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -76,4 +82,76 @@ class IncrementGuardTest {
             shouldCheckVersion(null, null) shouldBe false
         }
     }
+
+    @Nested
+    inner class `actually run the check` {
+
+        @Test
+        fun `on a CI pull request to a protected branch`() {
+            mustVerify(ciPullRequest = true, onCi = true, localPublish = false) shouldBe true
+        }
+
+        @Test
+        fun `on a local build that publishes to Maven Local`() {
+            mustVerify(ciPullRequest = false, onCi = false, localPublish = true) shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `skip the check` {
+
+        @Test
+        fun `on a local build that does not publish`() {
+            mustVerify(ciPullRequest = false, onCi = false, localPublish = false) shouldBe false
+        }
+
+        @Test
+        fun `on a CI build that publishes to Maven Local outside a protected-branch PR`() {
+            // E.g. a push to `master` or a tag build running integration tests: the
+            // version is already published, so re-verifying it would fail the build.
+            mustVerify(ciPullRequest = false, onCi = true, localPublish = true) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `make 'checkVersionIncrement' a dependency of` {
+
+        @Test
+        fun `the 'check' task`() {
+            val project = guardedProject()
+            val check = project.tasks.getByName("check")
+
+            check.dependencyNames() shouldContain IncrementGuard.taskName
+        }
+
+        @Test
+        fun `every Maven Local publishing task`() {
+            val project = guardedProject()
+            val localPublish = project.tasks.register(
+                "publishFooPublicationToMavenLocal",
+                PublishToMavenLocal::class.java
+            ).get()
+
+            localPublish.dependencyNames() shouldContain IncrementGuard.taskName
+        }
+    }
 }
+
+/**
+ * Creates a project with the `base` plugin (for the `check` task), the
+ * `maven-publish` plugin (for [PublishToMavenLocal] tasks), and [IncrementGuard]
+ * applied.
+ */
+private fun guardedProject(): Project {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply("base")
+    project.pluginManager.apply("maven-publish")
+    project.pluginManager.apply(IncrementGuard::class.java)
+    return project
+}
+
+/**
+ * Obtains the names of the tasks this task directly depends on.
+ */
+private fun Task.dependencyNames(): Set<String> =
+    taskDependencies.getDependencies(this).map { it.name }.toSet()


### PR DESCRIPTION
## What

`IncrementGuard` now runs the `checkVersionIncrement` task **before publishing to Maven Local**, not only on CI pull requests.

* Every `publishToMavenLocal` task now depends on `checkVersionIncrement` (via `tasks.withType(PublishToMavenLocal::class.java).configureEach { dependsOn(...) }`).
* The static `enabled = false` gate is replaced with an `onlyIf` predicate, so the check actually runs for local (non-CI) Maven Local publishes.
* `check` is wired lazily through the existing `io.spine.gradle.base.check` accessor instead of eager `getByName`.

## Why

Projects like `core-jvm-compiler` publish artifacts to `~/.m2` so their integration tests consume them. Bumping the project version before `./gradlew build` is critical there: without a bump, a local publish overwrites an already-published version and the integration tests silently pick up a stale artifact. The previous guard only fired on CI pull requests, catching the problem too late.

## CI safety

The local-publish path is gated by `!Build.ci`. CI pushes and tag builds that publish locally (e.g. to feed integration tests) **keep succeeding** even when their version is already published — preserving the original behavior that avoids failing `master` re-builds. The decision is a pure function `mustVerify(ciPullRequest, onCi, localPublish)`:

| Build | Check runs? |
|---|---|
| CI PR → protected branch | ✅ (unchanged) |
| Local build, publishes to Maven Local | ✅ new |
| Local build, no publish | ⏭️ skipped, no network call (unchanged) |
| CI push/tag, publishes locally | ⏭️ skipped — `master` re-builds stay green |

## Trade-off

A local `publishToMavenLocal` now fetches `maven-metadata.xml` from the registry first — this is the intended safeguard. Offline local publishes need network access or the documented escape hatch `-x checkVersionIncrement`.

## Testing

`./gradlew :buildSrc:build detekt` (JDK 17) passes — compilation, `validatePlugins`, all tests, and detekt. Added 6 `IncrementGuardTest` cases: a 4-row truth table for `mustVerify` and 2 `ProjectBuilder` wiring tests asserting both `check` and a `PublishToMavenLocal` task depend on `checkVersionIncrement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
