### PR TITLE
Scope Maven Local publish detection to the guarded project

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -84,6 +84,17 @@ class IncrementGuard : Plugin<Project> {
             onCi: Boolean,
             localPublish: Boolean,
         ): Boolean = ciPullRequest || (!onCi && localPublish)
+
+        /**
+         * Tells whether [tasks] contains a Maven Local publishing task that
+         * belongs to the given [project].
+         *
+         * The scan is limited to [project]'s own publications so that, in a
+         * multi-project build, a sibling module's `publishToMavenLocal` does not
+         * trigger this module's check — which would verify an unrelated version.
+         */
+        internal fun localPublishPlanned(tasks: Iterable<Task>, project: Project): Boolean =
+            tasks.any { it is PublishToMavenLocal && it.project == project }
     }
 
     /**
@@ -153,16 +164,18 @@ class IncrementGuard : Plugin<Project> {
 }
 
 /**
- * Tells whether the current build is going to publish artifacts to Maven Local.
+ * Tells whether the current build is going to publish this task's project to
+ * Maven Local.
  *
  * Integration tests in this and sibling projects consume freshly built artifacts
  * from `~/.m2`. Publishing them under a version that already exists would let those
  * tests pick up a stale artifact, so the version increment must be verified before
  * any local publication runs.
  *
- * The predicate is evaluated lazily as a task `onlyIf` spec, by which point
- * the execution [task graph][org.gradle.api.execution.TaskExecutionGraph] is
- * fully populated.
+ * Only this task's own project is considered: a sibling module's local publish in
+ * the same invocation must not trigger this module's check. The predicate is
+ * evaluated lazily as a task `onlyIf` spec, by which point the execution
+ * [task graph][org.gradle.api.execution.TaskExecutionGraph] is fully populated.
  */
 private fun Task.publishesToMavenLocal(): Boolean =
-    project.gradle.taskGraph.allTasks.any { it is PublishToMavenLocal }
+    IncrementGuard.localPublishPlanned(project.gradle.taskGraph.allTasks, project)

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -28,6 +28,7 @@ package io.spine.gradle.publish
 
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.spine.gradle.publish.IncrementGuard.Companion.localPublishPlanned
 import io.spine.gradle.publish.IncrementGuard.Companion.mustVerify
 import io.spine.gradle.publish.IncrementGuard.Companion.shouldCheckVersion
 import org.gradle.api.Project
@@ -110,6 +111,33 @@ class IncrementGuardTest {
             // E.g. a push to `master` or a tag build running integration tests: the
             // version is already published, so re-verifying it would fail the build.
             mustVerify(ciPullRequest = false, onCi = true, localPublish = true) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `detect a Maven Local publish` {
+
+        @Test
+        fun `for the task's own project`() {
+            val project = guardedProject()
+            val publish = project.tasks
+                .register("publishFooPublicationToMavenLocal", PublishToMavenLocal::class.java)
+                .get()
+
+            localPublishPlanned(listOf(publish), project) shouldBe true
+        }
+
+        @Test
+        fun `but not when only a sibling project publishes`() {
+            val root = ProjectBuilder.builder().build()
+            val lib = ProjectBuilder.builder().withParent(root).withName("lib").build()
+            val app = ProjectBuilder.builder().withParent(root).withName("app").build()
+            app.pluginManager.apply("maven-publish")
+            val appPublish = app.tasks
+                .register("publishFooPublicationToMavenLocal", PublishToMavenLocal::class.java)
+                .get()
+
+            localPublishPlanned(listOf(appPublish), lib) shouldBe false
         }
     }
 


### PR DESCRIPTION
## Why

Follow-up to #708. That PR was auto-merged at its first commit before the fix for the Codex **P2** review comment ([discussion_r3476210627](https://github.com/SpineEventEngine/config/pull/708#discussion_r3476210627)) could land, so the issue is still present on `master`. This PR carries that fix.

## The problem

`IncrementGuard`'s `onlyIf` predicate scanned the **entire** multi-project task graph for any `PublishToMavenLocal` task. In a multi-module local invocation such as `:lib:check :app:publishToMavenLocal`, `:lib:checkVersionIncrement` (pulled in by `:lib:check`) would see `:app`'s local-publish task and run the remote version check for `:lib` — even though `:lib` is not being published. That adds an unexpected network call and can fail the unrelated `:lib:check` when `:lib`'s version already exists remotely.

## The fix

Filter the task-graph scan to publish tasks owned by the **same project** as the check task, matching the already-per-project `dependsOn` wiring:

```kotlin
internal fun localPublishPlanned(tasks: Iterable<Task>, project: Project): Boolean =
    tasks.any { it is PublishToMavenLocal && it.project == project }
```

The scan is extracted into this pure, testable companion function; `Task.publishesToMavenLocal()` delegates to it.

## Testing

`./gradlew :buildSrc:build detekt` (JDK 17) passes. Two new `ProjectBuilder` tests cover the predicate: a publish task in the task's own project → `true`; a sibling project's publish task → `false` (the exact scenario from the review comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
