### PR TITLE
Run the version increment check only where the base ref is fetched

### DIFF
--- a/.agents/tasks/version-guard-parallel-pr-revalidation.md
+++ b/.agents/tasks/version-guard-parallel-pr-revalidation.md
@@ -70,8 +70,12 @@ publish-collision check on the publish path. Keep it load-bearing.
       The existing network "already published?" check (`checkNotPublished()`) stays.
 - [x] Promoted `VersionComparator` `report.pom` → `io.spine.gradle` (`git mv`,
       still `internal`); updated `DependencyWriter` import. **No `sort -V` in Kotlin.**
-- [x] `IncrementGuard.kt`: no wiring change needed (both paths inherit the task);
-      class KDoc already accurate.
+- [x] `IncrementGuard.kt`: **wiring change was needed** (see 2026-06-26 log). The
+      task was a `dependsOn` of `check`, so the new base-compare ran in *every*
+      `./gradlew build` — including `build-on-ubuntu.yml`, which never fetches the
+      base ref — and failed closed. The `check` dependency was removed; the CI check
+      now runs only via the `Version Guard` workflow (which fetches the base) and
+      before `publishToMavenLocal` (which does not base-compare).
 - [x] `.github-workflows/increment-guard.yml`: targeted base fetch
       `git fetch --no-tags --depth=1 origin +refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF`.
 
@@ -140,3 +144,14 @@ publish-collision check on the publish path. Keep it load-bearing.
   `sort -V` (headless comparator dropped); the publish backstop is registry
   immutability (no extra network probe). Status: in-review. Remaining: G (agents
   repo) and H (repo-admin).
+- 2026-06-26 — **regression fix.** Applying this config to `compiler` broke its
+  Ubuntu CI: `checkVersionIncrement` was a `dependsOn` of `check`, so `./gradlew
+  build` ran the new base-compare in `build-on-ubuntu.yml`, which does a shallow
+  checkout and never fetches `origin/master` — `git show origin/master:...` →
+  exit 128 → fail-closed. Windows CI survived only by accident (`fetch-depth: 0`).
+  The draft's "no wiring change needed (both paths inherit the task)" missed that
+  the `check` path also fires in the plain build workflows, not just the dedicated
+  `Version Guard` one. Fix: dropped `tasks.check.dependsOn(checkVersion)` so the
+  base-compare runs only where the base ref is guaranteed — the `Version Guard`
+  workflow (fetches base) and `publishToMavenLocal` (local; no base-compare).
+  Added a regression test asserting `check` does **not** depend on the task.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -30,7 +30,6 @@ package io.spine.gradle.publish
 
 import io.spine.gradle.Build
 import io.spine.gradle.SpineTaskGroup
-import io.spine.gradle.base.check
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -40,9 +39,10 @@ import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
  * Gradle plugin that adds a [CheckVersionIncrement] task verifying that the
  * project version was incremented before its artifacts are published.
  *
- * The task — named `checkVersionIncrement` — runs before the `check` task and
- * before any `publishToMavenLocal` task. It actually executes only when the
- * verification is meaningful; see [apply].
+ * The task — named `checkVersionIncrement` — is run directly by the `Version Guard`
+ * CI workflow and before any `publishToMavenLocal` task. It is deliberately kept out
+ * of the `check` lifecycle, and actually executes only when the verification is
+ * meaningful; see [apply].
  */
 class IncrementGuard : Plugin<Project> {
 
@@ -98,14 +98,19 @@ class IncrementGuard : Plugin<Project> {
     }
 
     /**
-     * Adds the [CheckVersionIncrement] task to the [target] project and wires it
-     * into two execution paths:
+     * Adds the [CheckVersionIncrement] task to the [target] project and makes every
+     * `publishToMavenLocal` task depend on it, so that a local publish — used by
+     * integration tests that consume artifacts from `~/.m2` — cannot overwrite an
+     * already published version.
      *
-     *  1. The `check` task depends on it, so that CI pull requests verify
-     *     the increment.
-     *  2. Every `publishToMavenLocal` task depends on it, so that a local publish —
-     *     used by integration tests that consume artifacts from `~/.m2` — cannot
-     *     overwrite an already published version.
+     * The CI pull-request check is driven separately by the `Version Guard` workflow
+     * (`increment-guard.yml`), which invokes `checkVersionIncrement` by name after
+     * fetching the base branch. The task is deliberately **not** wired into the
+     * `check` lifecycle task: [CheckVersionIncrement] compares against
+     * `origin/<base>:version.gradle.kts`, a ref that only the `Version Guard` workflow
+     * fetches. Wiring it into `check` would run it during every `./gradlew build`
+     * (e.g. the Ubuntu and Windows CI builds), where the base ref is absent, and the
+     * task — which fails closed on an unresolvable base — would break those builds.
      *
      * The task is always created and wired, but its action runs only when:
      *  1. the build is a GitHub Actions pull request targeting a default
@@ -134,12 +139,15 @@ class IncrementGuard : Plugin<Project> {
             }
         }
 
-        // Verify the increment on CI pull requests via the `check` lifecycle task.
-        tasks.check.configure { dependsOn(checkVersion) }
+        // The CI pull-request increment check is run by the `Version Guard` workflow,
+        // which calls `checkVersionIncrement` directly after fetching the base branch.
+        // It is intentionally not a dependency of `check`: that would run it in every
+        // `./gradlew build` (e.g. the Ubuntu/Windows CI builds), where `origin/<base>`
+        // is not fetched and the fail-closed base comparison would break the build.
 
-        // Verify it before publishing to Maven Local too: integration tests in this
-        // and sibling projects consume the freshly published artifacts from `~/.m2`,
-        // so a non-incremented version would let them pick up a stale artifact.
+        // Verify before publishing to Maven Local: integration tests in this and
+        // sibling projects consume the freshly published artifacts from `~/.m2`, so a
+        // non-incremented version would let them pick up a stale artifact.
         tasks.withType(PublishToMavenLocal::class.java).configureEach {
             dependsOn(checkVersion)
         }

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -27,6 +27,7 @@
 package io.spine.gradle.publish
 
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.spine.gradle.publish.IncrementGuard.Companion.localPublishPlanned
 import io.spine.gradle.publish.IncrementGuard.Companion.mustVerify
@@ -145,14 +146,6 @@ class IncrementGuardTest {
     inner class `make 'checkVersionIncrement' a dependency of` {
 
         @Test
-        fun `the 'check' task`() {
-            val project = guardedProject()
-            val check = project.tasks.getByName("check")
-
-            check.dependencyNames() shouldContain IncrementGuard.taskName
-        }
-
-        @Test
         fun `every Maven Local publishing task`() {
             val project = guardedProject()
             val localPublish = project.tasks.register(
@@ -161,6 +154,22 @@ class IncrementGuardTest {
             ).get()
 
             localPublish.dependencyNames() shouldContain IncrementGuard.taskName
+        }
+    }
+
+    @Nested
+    inner class `keep 'checkVersionIncrement' out of` {
+
+        @Test
+        fun `the 'check' lifecycle task`() {
+            // The CI check runs via the `Version Guard` workflow, which fetches the
+            // base branch first. Wiring it into `check` would run it in every
+            // `./gradlew build`, where `origin/<base>` is absent and the fail-closed
+            // base comparison would break the build.
+            val project = guardedProject()
+            val check = project.tasks.getByName("check")
+
+            check.dependencyNames() shouldNotContain IncrementGuard.taskName
         }
     }
 }


### PR DESCRIPTION
## Problem

Applying the latest `config` to a consumer repo (`compiler`) broke its **Ubuntu CI** build:

```
org.gradle.api.GradleException: Unable to read `version.gradle.kts` from base `origin/master`
(git exit code 128): fatal: invalid object name 'origin/master'..
Ensure the Version Guard workflow fetches the base branch before this check.
```

## Root cause

Commit 12e586fb taught `CheckVersionIncrement` to compare the project version against the base branch via `git show origin/<base>:version.gradle.kts`, and added the base-fetch step **only** to the dedicated `Version Guard` workflow (`increment-guard.yml`).

But `checkVersionIncrement` was a `dependsOn` of the `check` lifecycle task (added in #708), so it *also* ran inside `./gradlew build` on every CI pull request — including `build-on-ubuntu.yml`, which does a shallow checkout and never fetches `origin/master`. The fail-closed comparison then aborted the build. Windows CI survived only by accident (it uses `fetch-depth: 0`, which makes `origin/master` resolvable).

The design note in the task doc had even recorded the faulty assumption verbatim: *"no wiring change needed (both paths inherit the task)."* That "inheritance" is exactly the bug — the `check` path fires in the plain build workflows, not just the dedicated Version Guard one.

## Fix

Decouple the check from the `check`/`build` lifecycle so it runs only where its precondition (a fetched base ref) is guaranteed:

- **`IncrementGuard.kt`** — removed `tasks.check.configure { dependsOn(checkVersion) }` (and the now-unused `base.check` import). The CI gate stays with the `Version Guard` workflow (which fetches the base and posts the required status); the `publishToMavenLocal` dependency is unchanged for local integration-test publishes. KDoc/comments now explain *why* it is deliberately not wired into `check`.
- **`IncrementGuardTest.kt`** — replaced the old "depends on `check`" assertion with a regression guard asserting it does **not**, so this cannot silently regress.
- **task doc** — corrected the falsified design note and logged the incident.

## Why this is safe

No coverage is lost. Every case the `check` path handled on a protected-branch PR is already covered by the dedicated `Version Guard` workflow, and the registry's immutability remains the final publish backstop. Locally, `GITHUB_BASE_REF` is unset, so `publishToMavenLocal` never did the base comparison anyway. Decoupling at the task level also fixes any **consumer-specific** build workflow, not just config's own.

## Verification

`JAVA_HOME=17 ./gradlew :buildSrc:build detekt` is green; all `IncrementGuardTest` cases pass, including the new `keep 'checkVersionIncrement' out of › the 'check' lifecycle task`. Reviewed by `spine-code-review`, `kotlin-engineer`, and `review-docs` — all APPROVE.

## Reviewer notes

- After this lands and `compiler` re-applies config, its Ubuntu CI will stop running the base-compare during `build` and pass.
- The per-repo branch-protection item from the original design (requiring the `Version Guard` status context) is unaffected and still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)