### PR TITLE
Gate the base-version comparison to the Version Guard workflow

### DIFF
--- a/.agents/tasks/version-guard-parallel-pr-revalidation.md
+++ b/.agents/tasks/version-guard-parallel-pr-revalidation.md
@@ -155,3 +155,18 @@ publish-collision check on the publish path. Keep it load-bearing.
   base-compare runs only where the base ref is guaranteed — the `Version Guard`
   workflow (fetches base) and `publishToMavenLocal` (local; no base-compare).
   Added a regression test asserting `check` does **not** depend on the task.
+- 2026-06-26 — **regression fix, take 2 (the real one).** The `check` removal was
+  necessary but not sufficient: in `compiler`, `./gradlew build` still pulls
+  `checkVersionIncrement` into the graph via `publishToMavenLocal` (integration
+  tests consume fresh `~/.m2` artifacts), so Ubuntu CI hit the same exit-128
+  base-compare error. Root cause was deeper: the base-compare was gated on
+  `GITHUB_BASE_REF`, which GitHub sets in **every** PR build (Ubuntu/Windows CI
+  *and* the Version Guard workflow) — but only the Version Guard workflow fetches
+  the base. Fix: gate `checkIncrementedAgainstBase` on an explicit `VERSION_GUARD`
+  env var set **only** by `increment-guard.yml` (the one workflow that fetches the
+  base). New tested predicate `IncrementGuard.shouldCompareToBase(underVersionGuard,
+  baseRef)`. Outside the guard the comparison is skipped and `checkNotPublished`
+  stays the guard; inside it, fail-closed is preserved. `check` stays decoupled
+  (take 1) — harmless now, but a cleaner home for the check. Lesson:
+  `GITHUB_BASE_REF` is **not** a "this is the version-guard job" signal; it is
+  ambient in all PR builds. Distinguish the guard context explicitly.

--- a/.github-workflows/increment-guard.yml
+++ b/.github-workflows/increment-guard.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Check version increment
         id: guard
         shell: bash
+        # `VERSION_GUARD` enables the strict base-branch comparison in `checkVersionIncrement`.
+        # Only this workflow fetches the base ref (the step above), so the comparison is gated
+        # to it: other CI builds pull the task in via `publishToMavenLocal` on a shallow
+        # checkout and must not attempt to read `origin/<base>`.
+        env:
+          VERSION_GUARD: "true"
         run: ./gradlew checkVersionIncrement --stacktrace
 
       # Publish the verdict as the `Version Guard` commit status on the PR head. Posting it

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
@@ -41,11 +41,12 @@ import org.gradle.api.tasks.TaskAction
  *
  * Two independent checks run:
  *
- *  1. [checkIncrementedAgainstBase] — for a GitHub Actions pull request, the project
- *     [version] must be strictly greater than the version declared by `version.gradle.kts`
- *     on the PR's base branch. This is deterministic and network-independent: it catches a
- *     behavior-changing PR that forgot to bump, and two parallel PRs that bumped to the
- *     same value, regardless of what is (or is not yet) published.
+ *  1. [checkIncrementedAgainstBase] — inside the dedicated `Version Guard` workflow, the
+ *     project [version] must be strictly greater than the version declared by
+ *     `version.gradle.kts` on the PR's base branch. This is deterministic and
+ *     network-independent: it catches a behavior-changing PR that forgot to bump, and two
+ *     parallel PRs that bumped to the same value, regardless of what is (or is not yet)
+ *     published.
  *  2. [checkNotPublished] — the [version] must not already exist in the target Maven
  *     repository, so a publication cannot overwrite an immutable artifact.
  *
@@ -75,12 +76,15 @@ open class CheckVersionIncrement : DefaultTask() {
      * Verifies that the project [version] is strictly greater than the version declared by
      * `version.gradle.kts` on the pull request's base branch.
      *
-     * The check applies only inside a GitHub Actions pull request (when `GITHUB_BASE_REF`
-     * is set); local Maven Local publishes rely on [checkNotPublished] instead. The base
-     * branch tip is read with `git show origin/<base>:version.gradle.kts`, so the Version
-     * Guard workflow must fetch the base ref before running the task.
+     * The comparison reads the base branch tip with `git show origin/<base>:version.gradle.kts`,
+     * so it runs **only inside the dedicated `Version Guard` workflow** — the one context that
+     * fetches the base ref and signals it via the `VERSION_GUARD` environment variable (see
+     * [IncrementGuard.shouldCompareToBase]). Every other build skips it: a shallow CI checkout
+     * (e.g. the Ubuntu/Windows builds, which pull this task in via `publishToMavenLocal`) has
+     * no base ref to read, and local publishes are not pull requests. Those rely on
+     * [checkNotPublished] instead.
      *
-     * Failure modes are deliberately asymmetric:
+     * Within the `Version Guard` workflow, failure modes are deliberately asymmetric:
      *  - base ref unresolvable — **fail closed** (a workflow misconfiguration must not pass
      *    silently);
      *  - `version.gradle.kts` absent on base — treated as a newly introduced file (**pass**);
@@ -90,11 +94,17 @@ open class CheckVersionIncrement : DefaultTask() {
      */
     private fun checkIncrementedAgainstBase() {
         val baseRef = System.getenv("GITHUB_BASE_REF")
-        if (baseRef.isNullOrBlank()) {
-            // Not a GitHub Actions pull request; `checkNotPublished` is the relevant guard.
+        if (!IncrementGuard.shouldCompareToBase(underVersionGuard(), baseRef)) {
+            logger.info(
+                "Skipping the base-branch increment comparison: it runs only inside the " +
+                    "`Version Guard` workflow, which fetches the base branch. " +
+                    "`checkNotPublished` remains the active guard here."
+            )
             return
         }
-        val baseVersion = baseVersionToCompare(baseRef)
+        val baseVersion = baseVersionToCompare(
+            checkNotNull(baseRef) { "`shouldCompareToBase` guarantees a non-blank base ref." }
+        )
         if (baseVersion != null && VersionComparator.compare(version, baseVersion) <= 0) {
             throw GradleException(
                 """
@@ -112,6 +122,17 @@ open class CheckVersionIncrement : DefaultTask() {
             )
         }
     }
+
+    /**
+     * Tells whether the build runs inside the dedicated `Version Guard` workflow.
+     *
+     * That workflow fetches the base branch before invoking this task and signals it by
+     * setting the `VERSION_GUARD` environment variable to `true`. The variable is the
+     * authoritative marker that `origin/<base>` is present, so the base-branch comparison
+     * may run; see [IncrementGuard.shouldCompareToBase].
+     */
+    private fun underVersionGuard(): Boolean =
+        "true".equals(System.getenv("VERSION_GUARD"))
 
     /**
      * Resolves the base-branch publishing version to compare [version] against, or `null`

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -86,6 +86,25 @@ class IncrementGuard : Plugin<Project> {
         ): Boolean = ciPullRequest || (!onCi && localPublish)
 
         /**
+         * Tells whether [CheckVersionIncrement] should compare the project version against
+         * the base branch.
+         *
+         * The comparison reads `origin/<base>:version.gradle.kts`, so it needs the base
+         * branch to have been fetched. Only the dedicated `Version Guard` workflow fetches it
+         * and sets the `VERSION_GUARD` environment variable, which [CheckVersionIncrement]
+         * passes here as the [underVersionGuard] flag; the workflow runs for pull requests, so
+         * a non-blank [baseRef] is required as well.
+         *
+         * Every other CI build (e.g. the Ubuntu and Windows builds) pulls the check into the
+         * task graph through `publishToMavenLocal` but runs a shallow checkout without the
+         * base ref. Such builds report `underVersionGuard = false`, so the comparison is
+         * skipped and `checkNotPublished` stays the guard — otherwise the comparison would
+         * fail closed on `origin/<base>` and break every pull request.
+         */
+        internal fun shouldCompareToBase(underVersionGuard: Boolean, baseRef: String?): Boolean =
+            underVersionGuard && !baseRef.isNullOrBlank()
+
+        /**
          * Tells whether [tasks] contains a Maven Local publishing task that
          * belongs to the given [project].
          *
@@ -103,14 +122,16 @@ class IncrementGuard : Plugin<Project> {
      * integration tests that consume artifacts from `~/.m2` — cannot overwrite an
      * already published version.
      *
-     * The CI pull-request check is driven separately by the `Version Guard` workflow
-     * (`increment-guard.yml`), which invokes `checkVersionIncrement` by name after
-     * fetching the base branch. The task is deliberately **not** wired into the
-     * `check` lifecycle task: [CheckVersionIncrement] compares against
-     * `origin/<base>:version.gradle.kts`, a ref that only the `Version Guard` workflow
-     * fetches. Wiring it into `check` would run it during every `./gradlew build`
-     * (e.g. the Ubuntu and Windows CI builds), where the base ref is absent, and the
-     * task — which fails closed on an unresolvable base — would break those builds.
+     * The CI pull-request increment check is driven separately by the `Version Guard`
+     * workflow (`increment-guard.yml`), which invokes `checkVersionIncrement` by name after
+     * fetching the base branch and setting `VERSION_GUARD` — the signal that gates
+     * [CheckVersionIncrement]'s strict base-branch comparison (see [shouldCompareToBase]).
+     * The task is intentionally not wired into the `check` lifecycle: the version check
+     * belongs to the publishing path, not to generic `check` runs. A build that still pulls
+     * the task in through `publishToMavenLocal` (e.g. the Ubuntu/Windows CI builds, which
+     * publish locally to feed integration tests) stays green, because the base comparison —
+     * which reads `origin/<base>` and would otherwise fail closed on a shallow checkout — is
+     * skipped outside the `Version Guard` workflow.
      *
      * The task is always created and wired, but its action runs only when:
      *  1. the build is a GitHub Actions pull request targeting a default

--- a/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/publish/IncrementGuardTest.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.shouldBe
 import io.spine.gradle.publish.IncrementGuard.Companion.localPublishPlanned
 import io.spine.gradle.publish.IncrementGuard.Companion.mustVerify
 import io.spine.gradle.publish.IncrementGuard.Companion.shouldCheckVersion
+import io.spine.gradle.publish.IncrementGuard.Companion.shouldCompareToBase
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
@@ -112,6 +113,33 @@ class IncrementGuardTest {
             // E.g. a push to `master` or a tag build running integration tests: the
             // version is already published, so re-verifying it would fail the build.
             mustVerify(ciPullRequest = false, onCi = true, localPublish = true) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `compare against the base branch` {
+
+        @Test
+        fun `inside the Version Guard workflow with a base branch`() {
+            shouldCompareToBase(underVersionGuard = true, baseRef = "master") shouldBe true
+            shouldCompareToBase(underVersionGuard = true, baseRef = "2.x-jdk8-master") shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `not compare against the base branch` {
+
+        @Test
+        fun `outside the Version Guard workflow`() {
+            // The Ubuntu/Windows CI builds pull the task in via `publishToMavenLocal`,
+            // but they never fetch the base ref, so `VERSION_GUARD` is unset.
+            shouldCompareToBase(underVersionGuard = false, baseRef = "master") shouldBe false
+        }
+
+        @Test
+        fun `when no base branch is present`() {
+            shouldCompareToBase(underVersionGuard = true, baseRef = null) shouldBe false
+            shouldCompareToBase(underVersionGuard = true, baseRef = "") shouldBe false
         }
     }
 


### PR DESCRIPTION
## Problem

Follow-up to #711. After that merged, a consumer repo (`compiler`) re-applied config and its **Ubuntu CI** build still failed with the same error:

```
Execution failed for task ':api:checkVersionIncrement'
> Unable to read `version.gradle.kts` from base `origin/master`
  (git exit code 128): fatal: invalid object name 'origin/master'.
```

## Why #711 wasn't enough

#711 removed `checkVersionIncrement` from the `check` lifecycle. But in Spine repos `./gradlew build` still pulls the task into the graph via `publishToMavenLocal` (integration tests consume fresh `~/.m2` artifacts), so the base comparison ran again on a shallow CI checkout.

The real root cause is deeper than wiring: `checkIncrementedAgainstBase()` was gated on **`GITHUB_BASE_REF`**, which GitHub sets in *every* pull-request build — the Ubuntu and Windows CI builds **and** the dedicated Version Guard workflow alike — but only `increment-guard.yml` actually fetches the base ref. `GITHUB_BASE_REF` is not a "this is the version-guard job" signal; it's ambient in all PR builds.

## Fix

Gate the base comparison on an **explicit signal that the base was fetched**, set only by the one workflow that fetches it:

- **`increment-guard.yml`** sets `VERSION_GUARD: "true"` on the step that runs `checkVersionIncrement` (right after the base fetch).
- **`CheckVersionIncrement`** runs the comparison only when that signal is present — new private `underVersionGuard()` (mirrors the existing `Build.ci` env idiom) plus a tested pure predicate `IncrementGuard.shouldCompareToBase(underVersionGuard, baseRef)`.

Outside the Version Guard workflow the comparison is skipped (logged) and `checkNotPublished` remains the active guard; inside it, the fail-closed-on-unresolvable-base behavior is preserved. The `check` decoupling from #711 stays (harmless now, but a cleaner home for the check).

### Behavior matrix

| Context | `VERSION_GUARD` | base-compare | other guard |
|---|---|---|---|
| Ubuntu/Windows CI `build` (via `publishToMavenLocal`) | unset | **skipped** | `checkNotPublished` |
| Version Guard workflow | `true` | **runs** (fail-closed) | `checkNotPublished` |
| Local `publishToMavenLocal` | unset | skipped | `checkNotPublished` |

## Verification

`JAVA_HOME=17 ./gradlew :buildSrc:build detekt` green; new `shouldCompareToBase` tests pass. Reviewed by `spine-code-review` (which independently verified the gate blocks non-guard builds, the Version Guard stays fail-closed, `checkNotPublished`/local-publish are unchanged, and no other distributed workflow needs the signal), `kotlin-engineer`, and `review-docs` — all **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)