### PR TITLE
Fix `dokkaGenerate` for Kotlin Multiplatform modules

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,14 @@ fun doForceVersions(configurations: ConfigurationContainer) {
  */
 fun NamedDomainObjectContainer<Configuration>.forceVersions() {
     all {
+        // Dokka resolves its own generator/plugin classpath, whose dependency
+        // versions are pinned by Dokka itself and legitimately differ from the
+        // project's (for example, Jackson). Applying our version forcing and
+        // conflict failure to those configurations breaks `dokkaGenerate`, so
+        // leave Dokka's own configurations to resolve on their own.
+        if (name.startsWith("dokka")) {
+            return@all
+        }
         resolutionStrategy {
             failOnVersionConflict()
             cacheChangingModulesFor(0, "seconds")

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -30,6 +30,7 @@ import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.FindBugs
 import io.spine.dependency.build.JSpecify
+import io.spine.dependency.isDokka
 import io.spine.dependency.lib.Asm
 import io.spine.dependency.lib.AutoCommon
 import io.spine.dependency.lib.AutoService
@@ -73,12 +74,7 @@ fun doForceVersions(configurations: ConfigurationContainer) {
  */
 fun NamedDomainObjectContainer<Configuration>.forceVersions() {
     all {
-        // Dokka resolves its own generator/plugin classpath, whose dependency
-        // versions are pinned by Dokka itself and legitimately differ from the
-        // project's (for example, Jackson). Applying our version forcing and
-        // conflict failure to those configurations breaks `dokkaGenerate`, so
-        // leave Dokka's own configurations to resolve on their own.
-        if (name.startsWith("dokka")) {
+        if (isDokka) {
             return@all
         }
         resolutionStrategy {

--- a/buildSrc/src/main/kotlin/dokka-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-setup.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,15 @@ dependencies {
 tasks.withType<DokkaBaseTask>().configureEach {
     onlyIf {
         isInPublishingGraph()
+    }
+}
+
+// The Dokka Javadoc format does not support Kotlin Multiplatform source sets, so its
+// publication task fails for KMP modules ("No source set found for <module>/jvmMain").
+// KMP modules publish HTML documentation, so skip the Javadoc publication for them.
+plugins.withId("org.jetbrains.kotlin.multiplatform") {
+    tasks.matching { it.name == "dokkaGeneratePublicationJavadoc" }.configureEach {
+        enabled = false
     }
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/Dependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/Dependency.kt
@@ -111,6 +111,17 @@ abstract class DependencyWithBom : Dependency() {
 fun Configuration.diagSuffix(project: Project): String =
     "the configuration `$name` in the project: `${project.path}`."
 
+/**
+ * Tells if this configuration belongs to Dokka's own generator/plugin classpath.
+ *
+ * Dokka resolves these `dokka*` configurations using dependency versions pinned by
+ * Dokka itself (for example, Jackson or Kotlin), which legitimately differ from the
+ * project's. Forcing the project's versions onto them breaks `dokkaGenerate`, so such
+ * configurations must be excluded from the project's version forcing.
+ */
+val Configuration.isDokka: Boolean
+    get() = name.startsWith("dokka")
+
 private fun ResolutionStrategy.forceWithLogging(
     project: Project,
     configuration: Configuration,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -29,6 +29,7 @@ package io.spine.dependency.boms
 import io.gitlab.arturbosch.detekt.getSupportedKotlinVersion
 import io.spine.dependency.DependencyWithBom
 import io.spine.dependency.diagSuffix
+import io.spine.dependency.isDokka
 import io.spine.dependency.kotlinx.Coroutines
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.test.JUnit
@@ -88,7 +89,7 @@ class BomsPlugin : Plugin<Project>  {
                 applyBoms(project, Boms.core + Boms.testing)
             }
 
-            matching { !supportsBom(it.name) }.all {
+            matching { !supportsBom(it.name) && !it.isDokka }.all {
                 resolutionStrategy.eachDependency {
                     if (requested.group == Kotlin.group) {
                         val kotlinVersion = Kotlin.runtimeVersion
@@ -170,7 +171,7 @@ private fun supportsBom(name: String) =
 private fun Project.forceArtifacts() =
     configurations.all {
         resolutionStrategy {
-            if (!isDetekt) {
+            if (!isDetekt && !isDokka) {
                 val rs = this@resolutionStrategy
                 val project = this@forceArtifacts
                 val cfg = this@all

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -132,6 +132,12 @@ fun Module.forceConfigurations() {
         forceVersions()
         excludeProtobufLite()
         all {
+            // Dokka resolves its own generator/plugin classpath, whose dependency
+            // versions are pinned by Dokka itself (e.g. Jackson). Don't force the
+            // project's versions onto it — that breaks `dokkaGenerate`.
+            if (name.startsWith("dokka")) {
+                return@all
+            }
             resolutionStrategy {
                 val cfg = this@all
                 val rs = this@resolutionStrategy

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -29,6 +29,7 @@ import io.spine.dependency.build.CheckerFramework
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.JSpecify
+import io.spine.dependency.isDokka
 import io.spine.dependency.lib.Guava
 import io.spine.dependency.lib.Jackson
 import io.spine.dependency.lib.Kotlin
@@ -132,10 +133,7 @@ fun Module.forceConfigurations() {
         forceVersions()
         excludeProtobufLite()
         all {
-            // Dokka resolves its own generator/plugin classpath, whose dependency
-            // versions are pinned by Dokka itself (e.g. Jackson). Don't force the
-            // project's versions onto it — that breaks `dokkaGenerate`.
-            if (name.startsWith("dokka")) {
+            if (isDokka) {
                 return@all
             }
             resolutionStrategy {

--- a/buildSrc/src/main/kotlin/kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp-module.gradle.kts
@@ -83,6 +83,12 @@ fun Project.forceConfigurations() {
     with(configurations) {
         forceVersions()
         all {
+            // Dokka resolves its own generator/plugin classpath, whose dependency
+            // versions are pinned by Dokka itself (e.g. Jackson). Don't force the
+            // project's versions onto it — that breaks `dokkaGenerate`.
+            if (name.startsWith("dokka")) {
+                return@all
+            }
             resolutionStrategy {
                 val cfg = this@all
                 val rs = this@resolutionStrategy

--- a/buildSrc/src/main/kotlin/kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp-module.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import io.spine.dependency.boms.BomsPlugin
+import io.spine.dependency.isDokka
 import io.spine.dependency.lib.Jackson
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.local.Reflect
@@ -83,10 +84,7 @@ fun Project.forceConfigurations() {
     with(configurations) {
         forceVersions()
         all {
-            // Dokka resolves its own generator/plugin classpath, whose dependency
-            // versions are pinned by Dokka itself (e.g. Jackson). Don't force the
-            // project's versions onto it — that breaks `dokkaGenerate`.
-            if (name.startsWith("dokka")) {
+            if (isDokka) {
                 return@all
             }
             resolutionStrategy {


### PR DESCRIPTION
## Problem

Under Dokka **2.2.0**, `./gradlew dokkaGenerate` fails for any repository that has
Kotlin Multiplatform modules (reproduced in `SpineEventEngine/logging`). Two distinct
issues combine:

1. **Version forcing leaks into Dokka's tool classpath.** `forceVersions()` applies the
   project's version forcing and `failOnVersionConflict()` to **every** configuration,
   including Dokka's isolated `dokka*GeneratorRuntimeResolver` classpath. Dokka 2.2.0
   pins its own dependencies (e.g. `jackson-*:2.15.3`, `kotlin-stdlib:2.0.21`), which
   conflict with the project's forced versions (e.g. `Jackson.bom` 2.22.0):
   `Could not resolve … Conflict found for module 'com.fasterxml.jackson…': between
   versions 2.22.0 and 2.15.3`.

2. **The Dokka Javadoc format can't handle KMP source sets.** The
   `org.jetbrains.dokka-javadoc` plugin's `dokkaGeneratePublicationJavadoc` task fails
   for every KMP module with `No source set found for <module>/jvmMain`.

## Fix

- `DependencyResolution.forceVersions()` — skip configurations whose name starts with
  `dokka`, leaving Dokka's own classpath to resolve as Dokka intends.
- `dokka-setup.gradle.kts` — disable `dokkaGeneratePublicationJavadoc` for KMP modules
  (they publish HTML docs via `htmlDocsJar`).

## Verification

Applied to `SpineEventEngine/logging` (which has many KMP modules): `./gradlew
dokkaGenerate` now completes successfully (it previously failed on `:logging`,
`:context-tests`, and every other KMP module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)