### PR TITLE
Accept `extra.set(...)` in version parsers; bump Compiler; tidy imports

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -27,8 +27,6 @@
 package io.spine.dependency.local
 
 import io.spine.dependency.Dependency
-import io.spine.dependency.local.Compiler.DF_VERSION_ENV
-import io.spine.dependency.local.Compiler.VERSION_ENV
 
 /**
  * Dependencies on the Spine Compiler modules.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -74,7 +74,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.057"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.059"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -83,7 +83,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.057"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.059"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/VersionGradleFile.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/VersionGradleFile.kt
@@ -33,14 +33,20 @@ import org.gradle.api.GradleException
  * Reads a `version.gradle.kts` file and resolves the `extra` properties it declares.
  *
  * [contentUnder] and [contentInBase] read the file (from the working tree or a base branch);
- * [keyForValue] and [valueForKey] resolve its `extra` properties. The following declaration
- * shapes are handled (see the `bump-version` skill):
+ * [keyForValue] and [valueForKey] resolve its `extra` properties. Each property is registered
+ * either with the current `extra.set("name", …)` call or the legacy `by extra(…)` property
+ * delegate that Gradle deprecated (the `bump-version` skill migrates the latter to the former);
+ * both spellings are recognized, so a file is read correctly whether or not it has migrated.
+ * The following value shapes are handled:
  *
- *  1. a literal: `val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")`;
- *  2. an alias to another `extra`: `val versionToPublish by extra(compilerVersion)` paired
- *     with `val compilerVersion: String by extra("2.0.0-SNAPSHOT.043")`;
- *  3. an alias to a plain `val`: `val versionToPublish by extra(base)` paired with
- *     `val base = "2.0.0-SNAPSHOT.043"`.
+ *  1. a literal:
+ *     `extra.set("versionToPublish", "2.0.0-SNAPSHOT.182")`, or the legacy
+ *     `val versionToPublish: String by extra("2.0.0-SNAPSHOT.182")`;
+ *  2. an alias to a plain `val` (or, in the legacy spelling, to another `extra`):
+ *     `extra.set("versionToPublish", compilerVersion)` paired with
+ *     `val compilerVersion = "2.0.0-SNAPSHOT.043"`, or the legacy
+ *     `val versionToPublish by extra(compilerVersion)` paired with
+ *     `val compilerVersion: String by extra("2.0.0-SNAPSHOT.043")`.
  *
  * The publishing-version property is identified by [keyForValue] using the already-resolved
  * project version as an oracle, so the specific property name (`versionToPublish`,
@@ -56,10 +62,19 @@ internal object VersionGradleFile {
      */
     const val NAME = "version.gradle.kts"
 
+    // Legacy `by extra(…)` property-delegate spellings (deprecated by Gradle).
     private val literalExtra =
         Regex("""val\s+(\w+)\s*(?::\s*String)?\s+by\s+extra\(\s*"([^"]+)"\s*\)""")
     private val aliasExtra =
         Regex("""val\s+(\w+)\s*(?::\s*String)?\s+by\s+extra\(\s*([A-Za-z_]\w*)\s*\)""")
+
+    // Current `extra.set("name", …)` spellings.
+    private val literalSet =
+        Regex("""extra\.set\(\s*"(\w+)"\s*,\s*"([^"]+)"\s*\)""")
+    private val aliasSet =
+        Regex("""extra\.set\(\s*"(\w+)"\s*,\s*([A-Za-z_]\w*)\s*\)""")
+
+    // A plain `val name = "value"` that an alias may reference.
     private val plainAssignment =
         Regex("""val\s+(\w+)\s*(?::\s*String)?\s*=\s*"([^"]+)"""")
 
@@ -68,12 +83,12 @@ internal object VersionGradleFile {
      * string value.
      */
     private fun parse(content: String): Map<String, String> {
-        val literals = literalExtra.findAll(content)
+        val literals = (literalExtra.findAll(content) + literalSet.findAll(content))
             .associate { it.groupValues[1] to it.groupValues[2] }
         val plains = plainAssignment.findAll(content)
             .associate { it.groupValues[1] to it.groupValues[2] }
         val resolved = literals.toMutableMap()
-        aliasExtra.findAll(content).forEach { match ->
+        (aliasExtra.findAll(content) + aliasSet.findAll(content)).forEach { match ->
             val name = match.groupValues[1]
             val source = match.groupValues[2]
             if (name !in resolved) {

--- a/buildSrc/src/test/kotlin/io/spine/gradle/VersionGradleFileSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/VersionGradleFileSpec.kt
@@ -65,6 +65,28 @@ internal class VersionGradleFileSpec {
     }
 
     @Test
+    fun `declared as a literal via 'extra set'`() {
+        val content = """
+            extra.set("versionToPublish", "2.0.0-SNAPSHOT.182")
+        """.trimIndent()
+
+        VersionGradleFile.keyForValue(content, "2.0.0-SNAPSHOT.182") shouldBe "versionToPublish"
+        VersionGradleFile.valueForKey(content, "versionToPublish") shouldBe "2.0.0-SNAPSHOT.182"
+    }
+
+    @Test
+    fun `declared as an alias via 'extra set'`() {
+        val content = """
+            val compilerVersion = "2.0.0-SNAPSHOT.043"
+            extra.set("compilerVersion", compilerVersion)
+            extra.set("versionToPublish", compilerVersion)
+        """.trimIndent()
+
+        VersionGradleFile.valueForKey(content, "versionToPublish") shouldBe "2.0.0-SNAPSHOT.043"
+        VersionGradleFile.valueForKey(content, "compilerVersion") shouldBe "2.0.0-SNAPSHOT.043"
+    }
+
+    @Test
     fun `identified by the resolved project version, not a hard-coded name`() {
         val content = """
             val kotlinVersion: String by extra("2.1.0")

--- a/scripts/publish-documentation/publish.sh
+++ b/scripts/publish-documentation/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2023, TeamDev. All rights reserved.
+# Copyright 2026, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ do
   jenv local 1.8
 
   # The version that will show up in Dokka-generated documentation.
-  echo "val versionToPublish: String by extra(\"$version\")" >> "../version.gradle.kts"
+  echo "extra.set(\"versionToPublish\", \"$version\")" >> "../version.gradle.kts"
 
   for path in $(echo "$paths" | tr "," "\n")
   do

--- a/scripts/revalidate-versions.sh
+++ b/scripts/revalidate-versions.sh
@@ -85,25 +85,45 @@ discover_key() {
 }
 
 # Parses the version literal for the given key out of `version.gradle.kts` content.
-# Handles a direct literal and one alias hop (via another `extra` or a plain `val`).
-# Mirrors `version-bumped.sh`.
+# Handles a direct literal and one alias hop (via another `extra` or a plain `val`), in
+# both the current `extra.set("key", …)` spelling and the legacy `by extra(…)` delegate
+# that Gradle deprecated. Mirrors `version-bumped.sh`.
 parse_version() {
   local content="$1" name="$2" v src
   # `|| true` on each pipeline: under `pipefail` a no-match `grep` (or a `grep`
   # that receives SIGPIPE when `head` closes early) exits non-zero and would
   # otherwise abort this `set -e` script before the fallback branches run.
+  # Shape 1 — literal. Current `extra.set` spelling first, then legacy `by extra`.
   v=$(printf '%s\n' "$content" \
-      | grep -E "val[[:space:]]+${name}([[:space:]]*:[[:space:]]*String)?[[:space:]]+by[[:space:]]+extra\(\"" \
-      | head -n1 | sed -nE 's/.*extra\("([^"]+)".*/\1/p' || true)
-  if [ -n "$v" ]; then printf '%s' "$v"; return 0; fi
-  src=$(printf '%s\n' "$content" \
-      | grep -E "val[[:space:]]+${name}([[:space:]]*:[[:space:]]*String)?[[:space:]]+by[[:space:]]+extra\(" \
-      | head -n1 | sed -nE 's/.*extra\(([A-Za-z_][A-Za-z0-9_]*)\).*/\1/p' || true)
-  if [ -n "$src" ]; then
+      | grep -E "extra\.set\([[:space:]]*\"${name}\"[[:space:]]*,[[:space:]]*\"" \
+      | head -n1 | sed -nE 's/.*extra\.set\([^,]*,[[:space:]]*"([^"]+)".*/\1/p' || true)
+  if [ -z "$v" ]; then
     v=$(printf '%s\n' "$content" \
-        | grep -E "val[[:space:]]+${src}([[:space:]]*:[[:space:]]*String)?[[:space:]]+by[[:space:]]+extra\(\"" \
+        | grep -E "val[[:space:]]+${name}([[:space:]]*:[[:space:]]*String)?[[:space:]]+by[[:space:]]+extra\(\"" \
         | head -n1 | sed -nE 's/.*extra\("([^"]+)".*/\1/p' || true)
+  fi
+  if [ -n "$v" ]; then printf '%s' "$v"; return 0; fi
+  # Shapes 2 & 3 — alias. Extract the source identifier, current spelling then legacy.
+  src=$(printf '%s\n' "$content" \
+      | grep -E "extra\.set\([[:space:]]*\"${name}\"[[:space:]]*,[[:space:]]*[A-Za-z_]" \
+      | head -n1 | sed -nE 's/.*extra\.set\([^,]*,[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\).*/\1/p' || true)
+  if [ -z "$src" ]; then
+    src=$(printf '%s\n' "$content" \
+        | grep -E "val[[:space:]]+${name}([[:space:]]*:[[:space:]]*String)?[[:space:]]+by[[:space:]]+extra\(" \
+        | head -n1 | sed -nE 's/.*extra\(([A-Za-z_][A-Za-z0-9_]*)\).*/\1/p' || true)
+  fi
+  if [ -n "$src" ]; then
+    # Source literal — `extra.set` spelling, then legacy `by extra`.
+    v=$(printf '%s\n' "$content" \
+        | grep -E "extra\.set\([[:space:]]*\"${src}\"[[:space:]]*,[[:space:]]*\"" \
+        | head -n1 | sed -nE 's/.*extra\.set\([^,]*,[[:space:]]*"([^"]+)".*/\1/p' || true)
     if [ -z "$v" ]; then
+      v=$(printf '%s\n' "$content" \
+          | grep -E "val[[:space:]]+${src}([[:space:]]*:[[:space:]]*String)?[[:space:]]+by[[:space:]]+extra\(\"" \
+          | head -n1 | sed -nE 's/.*extra\("([^"]+)".*/\1/p' || true)
+    fi
+    if [ -z "$v" ]; then
+      # Source plain val — `val SRC[: String]? = "X"`.
       v=$(printf '%s\n' "$content" \
           | grep -E "val[[:space:]]+${src}([[:space:]]*:[[:space:]]*String)?[[:space:]]*=[[:space:]]*\"" \
           | head -n1 | sed -nE 's/.*=[[:space:]]*"([^"]+)".*/\1/p' || true)


### PR DESCRIPTION
This is a `misc-fixes` branch bundling three commits.

## 1. Accept `extra.set(...)` in the version tooling — companion to SpineEventEngine/agents#29

Gradle deprecated the `by extra(...)` property delegate used in `version.gradle.kts`.
The `agents` PR extends the `bump-version` skill to migrate declarations to
`extra.set("name", value)`; this PR teaches the config repo's version tooling to
read/write the new form while still accepting the legacy spelling, so the transition
is safe for lazily-migrated repos (a migrating branch is compared against an
old-form base).

- `buildSrc/.../VersionGradleFile.kt` — the CI **Version Guard** parser: add
  `extra.set` literal/alias regexes, fold them into `parse()`, and document both
  spellings in the KDoc. Two new spec cases cover the literal and alias forms.
- `scripts/publish-documentation/publish.sh` — emit `extra.set(...)` when stamping
  the Dokka publishing version (copyright header bumped to 2026).
- `scripts/revalidate-versions.sh` — `parse_version()` reads both spellings.

**Merge ordering:** land this **before** any repo migrates its `version.gradle.kts`,
so the Version Guard recognizes the new form. Both sides are backward-compatible, so
beyond that, order doesn't matter.

## 2. Bump Compiler fallback versions to `2.0.0-SNAPSHOT.059`

Updates `fallbackVersion` and `fallbackDfVersion` in `Compiler` from `.057` to
`.059`. (The commit message was corrected from an earlier inaccurate
"Remove redundant imports" — the diff was always this version bump.)

## 3. Remove redundant imports

Drops two redundant private property imports in `Compiler.kt`. 
The imports were accidentally (and forcibly) added by IntelliJ IDEA.

## Verification

`./gradlew -p buildSrc build` → **BUILD SUCCESSFUL** (compiles + `VersionGradleFileSpec`
passes). Reviewed by `spine-code-review`, `kotlin-engineer` (both APPROVE),
`review-docs` (APPROVE WITH CHANGES — minor KDoc-wording nits), and `dependency-audit`
(the Compiler bump is a clean forward bump — no rollback/BOM mismatch). Version gate
not applicable (config has no root `version.gradle.kts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
