### PR TITLE
Credit Spine Compiler codegen execution to coverage

### DIFF
--- a/.agents/memory/project/porting-buildsrc-from-consumer-repos.md
+++ b/.agents/memory/project/porting-buildsrc-from-consumer-repos.md
@@ -26,3 +26,15 @@ filter) and repo-local convention plugins/helpers living in X's `buildSrc`
 `PatchGeneratedTemplateString.kt`). Cross-check direction on each remaining
 file — if `config` HEAD is newer (version bumps), the consumer copy is stale,
 not improved.
+
+Two port-time adaptations recur (both hit the validation#317 port):
+
+- `config` runs detekt over `buildSrc`; consumer repos do not. A port that
+  was green in the consumer repo can fail here (e.g. `TooManyFunctions`,
+  top-level threshold 11 per file). Fix by refactoring — merge copy-paste
+  helpers, reuse an existing `config` helper the consumer-side author did
+  not know about (e.g. `consumesCoverageBinaryReports()` from
+  `SiblingCoverage.kt`) — never by suppressing.
+- Generalize consumer-specific KDoc (module names such as `java`/`context`,
+  plugin names such as `JavaValidationPlugin`): `config` distributes these
+  files to every repo, where such references mean nothing.

--- a/.agents/tasks/port-compiler-coverage.md
+++ b/.agents/tasks/port-compiler-coverage.md
@@ -1,0 +1,72 @@
+---
+slug: port-compiler-coverage
+branch: port-compiler-coverage
+owner: claude
+status: in-review
+started: 2026-07-06
+related-memories:
+  - porting-buildsrc-from-consumer-repos
+  - config-build-verification
+---
+
+## Goal
+
+Upstream the Spine Compiler coverage helpers introduced in
+[validation#317][pr-317] into `config`'s `buildSrc`, so every consumer
+repo receives them via `./config/pull` and can credit forked-compiler
+codegen execution to its root Kover report.
+
+## Context
+
+The `launch*SpineCompiler` tasks fork a JVM that Kover/JaCoCo do not
+instrument, so codegen plugins report ~0% coverage in consumer repos.
+[validation#317][pr-317] fixed this in `validation` (root coverage
+12% → 86%) and its description names upstreaming the `buildSrc` helpers
+to `config` as the follow-up. Only `buildSrc` files port; validation's
+root `build.gradle.kts` wiring
+(`subprojects { enableSpineCompilerCoverage() }`) stays consumer-owned.
+
+## Plan
+
+- [x] Fetch the four changed `buildSrc` files from the PR branch
+      `credit-codegen-coverage` and diff against `config` HEAD
+      (confirmed purely additive; no reverse drift).
+- [x] `io/spine/dependency/test/Jacoco.kt` — add the `agent` coordinate
+      constant.
+- [x] `io/spine/gradle/testing/SpineCompilerCoverage.kt` — new file:
+      `enableSpineCompilerCoverage()`, cacheable per-task exec output.
+- [x] `io/spine/gradle/testing/TestKitCoverage.kt` — replace the inline
+      agent coordinate with `Jacoco.agent`.
+- [x] `io/spine/gradle/report/coverage/KoverConfig.kt` — feed compiler
+      exec files into the root report's `additionalBinaryReports`.
+- [x] Verify: `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew
+      :buildSrc:build detekt`.
+- [x] Review diff with `spine-code-review`, `kotlin-engineer`,
+      `dependency-audit`, and `review-docs`.
+- [x] Commit on branch `port-compiler-coverage`, run the pre-PR gate,
+      open the PR.
+
+## Log
+
+- 2026-07-06 — drafted and started; user prompt authorizes the port
+  (edits only, no commits).
+- 2026-07-06 — KDoc generalized while porting: validation-specific
+  references (`java`/`context` modules, `JavaValidationPlugin`) removed,
+  since `config` distributes these files to all consumer repos.
+- 2026-07-06 — detekt (which covers `buildSrc` only here in `config`)
+  flagged `TooManyFunctions` in `KoverConfig.kt` after the port; merged
+  the duplicate `testKitExecFiles`/`compilerExecFiles` helpers into one
+  `execFiles(project, dirName)`. Build + detekt green afterwards.
+- 2026-07-06 — all four reviewers APPROVE. Applied their improvements
+  on top of the verbatim port: reuse `consumesCoverageBinaryReports()`
+  from `SiblingCoverage.kt` (promoted to `internal`) instead of a
+  duplicate predicate; early-return guard makes
+  `enableSpineCompilerCoverage()` truly idempotent (a second call would
+  have double-loaded the agent); `dependsOn` comment no longer reads as
+  ordering-only; KDoc polish (grammar, `testFixtures` spelling,
+  `[Jacoco.agent]` links in `TestKitCoverage.kt`).
+- 2026-07-06 — work complete; committed on branch
+  `port-compiler-coverage` (two commits), pre-PR gate re-run green (all
+  four reviewers APPROVE), PR opened for human review.
+
+[pr-317]: https://github.com/SpineEventEngine/validation/pull/317

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Jacoco.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Jacoco.kt
@@ -34,4 +34,12 @@ package io.spine.dependency.test
 @Suppress("ConstPropertyName")
 object Jacoco {
     const val version = "0.8.15"
+
+    /**
+     * The Maven coordinates of the standalone JaCoCo agent JAR (the `runtime`
+     * classifier), attached via `-javaagent:` to forked JVMs — Gradle TestKit
+     * workers and the Spine Compiler process — so their execution is credited
+     * to coverage.
+     */
+    const val agent = "org.jacoco:org.jacoco.agent:$version:runtime"
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
@@ -28,14 +28,15 @@ package io.spine.gradle.report.coverage
 
 import io.spine.dependency.test.Jacoco
 import io.spine.dependency.test.Kover
-import io.spine.gradle.testing.COMPILER_COVERAGE_DIR
 import io.spine.gradle.testing.TESTKIT_COVERAGE_DIR
+import io.spine.gradle.testing.isSpineCompilerLaunchTask
 import java.io.File
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Project
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -265,12 +266,26 @@ class KoverConfig private constructor(
      * aggregated production modules. Resolved at task-graph time, after the
      * launch tasks have written them.
      *
+     * The files are the `.exec` outputs that each subproject's **currently
+     * configured** `launch*SpineCompiler` tasks still declare — read from the task
+     * outputs, not by scanning the coverage directory. A stale exec left in an
+     * un-`clean`ed workspace is therefore never credited, whether its launch task
+     * was removed or the module simply stopped enabling the helper (in which case
+     * the task no longer declares the exec as an output). Filtering by the `exec`
+     * extension drops any non-coverage outputs the compiler task may also declare.
+     *
      * @see io.spine.gradle.testing.enableSpineCompilerCoverage
      */
     private fun rootCompilerExecFilesProvider(): Provider<Iterable<File>> =
         rootProject.provider {
             rootProject.subprojects.asSequence()
-                .flatMap { execFiles(it, COMPILER_COVERAGE_DIR).asSequence() }
+                .flatMap { sub ->
+                    sub.tasks.withType(JavaExec::class.java)
+                        .matching { it.isSpineCompilerLaunchTask() }
+                        .asSequence()
+                        .flatMap { it.outputs.files.asSequence() }
+                }
+                .filter { it.isFile && it.extension == "exec" }
                 .toList()
         }
 
@@ -319,11 +334,13 @@ class KoverConfig private constructor(
  * directory under the [project]'s `build` directory, or an empty list if the
  * module produced none.
  *
- * Serves both out-of-process coverage collectors: the Gradle TestKit workers
- * write into [TESTKIT_COVERAGE_DIR] when a module opts in via
- * [io.spine.gradle.testing.enableTestKitCoverage], and the forked Spine
- * Compiler JVMs write into [COMPILER_COVERAGE_DIR] when a module opts in via
- * [io.spine.gradle.testing.enableSpineCompilerCoverage].
+ * Used for the Gradle TestKit workers, which write into [TESTKIT_COVERAGE_DIR]
+ * when a module opts in via [io.spine.gradle.testing.enableTestKitCoverage]. A
+ * directory scan is safe there because the exec directory is wiped once per build
+ * (see `enableTestKitCoverage`); the Spine Compiler collector instead gathers its
+ * files from the current launch tasks (see
+ * [io.spine.gradle.testing.enableSpineCompilerCoverage]), because its cacheable
+ * tasks cannot wipe the directory.
  */
 private fun execFiles(project: Project, dirName: String): List<File> {
     val dir = project.layout.buildDirectory.dir(dirName).get().asFile

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/KoverConfig.kt
@@ -28,6 +28,7 @@ package io.spine.gradle.report.coverage
 
 import io.spine.dependency.test.Jacoco
 import io.spine.dependency.test.Kover
+import io.spine.gradle.testing.COMPILER_COVERAGE_DIR
 import io.spine.gradle.testing.TESTKIT_COVERAGE_DIR
 import java.io.File
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
@@ -104,6 +105,13 @@ private const val KOTLIN_FILE_CLASS_SUFFIX: String = "Kt"
  *    the probe level against each module's actual bytecode: a line hit both
  *    in-process and out-of-process is counted once. Summing pre-aggregated XML
  *    reports instead would double-count such lines.
+ *  - Feeds the JaCoCo execution data produced by the forked Spine Compiler JVMs
+ *    (see [io.spine.gradle.testing.enableSpineCompilerCoverage]) into the **root**
+ *    `total` report as `additionalBinaryReports`. This credits code-generation
+ *    plugins — renderers and generators that run out-of-process in the compiler
+ *    fork and are otherwise reported at ~0%. Fed only at the root: Codecov ingests
+ *    the root report, whose aggregation owns those classes, so a per-module feed
+ *    would be redundant.
  *
  * This is the Kover-based successor to the deprecated JaCoCo-based
  * coverage aggregation pipeline. The behaviour mirrors what
@@ -198,6 +206,7 @@ class KoverConfig private constructor(
                         onCheck.set(true)
                     }
                     additionalBinaryReports.addAll(rootTestKitExecFilesProvider())
+                    additionalBinaryReports.addAll(rootCompilerExecFilesProvider())
                 }
                 filters {
                     excludes {
@@ -239,7 +248,29 @@ class KoverConfig private constructor(
         rootProject.provider {
             rootProject.subprojects.asSequence()
                 .filter { it.pluginManager.hasPlugin(Kover.id) }
-                .flatMap { testKitExecFiles(it).asSequence() }
+                .flatMap { execFiles(it, TESTKIT_COVERAGE_DIR).asSequence() }
+                .toList()
+        }
+
+    /**
+     * Lazy `Provider` of the JaCoCo execution-data files produced by the forked
+     * Spine Compiler JVMs across every subproject.
+     *
+     * These files credit the out-of-process execution of compiler plugins —
+     * renderers and generators that run inside the compiler fork — to the root
+     * coverage rollup. Unlike the TestKit files, they are collected from **all**
+     * subprojects regardless of whether the producing module applies Kover: the
+     * exec may be produced by a module that does not itself apply Kover
+     * (typically a test-only module), while the classes it credits belong to the
+     * aggregated production modules. Resolved at task-graph time, after the
+     * launch tasks have written them.
+     *
+     * @see io.spine.gradle.testing.enableSpineCompilerCoverage
+     */
+    private fun rootCompilerExecFilesProvider(): Provider<Iterable<File>> =
+        rootProject.provider {
+            rootProject.subprojects.asSequence()
+                .flatMap { execFiles(it, COMPILER_COVERAGE_DIR).asSequence() }
                 .toList()
         }
 
@@ -248,7 +279,7 @@ class KoverConfig private constructor(
      * TestKit workers of [sub]. See [rootTestKitExecFilesProvider] for timing notes.
      */
     private fun testKitExecFilesProvider(sub: Project): Provider<Iterable<File>> =
-        sub.provider { testKitExecFiles(sub) }
+        sub.provider { execFiles(sub, TESTKIT_COVERAGE_DIR) }
 
     /**
      * Lazy `Provider` of the generated-class FQN exclusion patterns
@@ -284,15 +315,18 @@ class KoverConfig private constructor(
 }
 
 /**
- * Returns the JaCoCo execution-data (`.exec`) files written by the Gradle TestKit
- * workers of the [project], or an empty list if the module produced none.
+ * Returns the JaCoCo execution-data (`.exec`) files found in the [dirName]
+ * directory under the [project]'s `build` directory, or an empty list if the
+ * module produced none.
  *
- * The files reside under `build/`[TESTKIT_COVERAGE_DIR] and are created by the
- * `plugin-testlib` test harness when a module opts in via
- * [io.spine.gradle.testing.enableTestKitCoverage].
+ * Serves both out-of-process coverage collectors: the Gradle TestKit workers
+ * write into [TESTKIT_COVERAGE_DIR] when a module opts in via
+ * [io.spine.gradle.testing.enableTestKitCoverage], and the forked Spine
+ * Compiler JVMs write into [COMPILER_COVERAGE_DIR] when a module opts in via
+ * [io.spine.gradle.testing.enableSpineCompilerCoverage].
  */
-private fun testKitExecFiles(project: Project): List<File> {
-    val dir = project.layout.buildDirectory.dir(TESTKIT_COVERAGE_DIR).get().asFile
+private fun execFiles(project: Project, dirName: String): List<File> {
+    val dir = project.layout.buildDirectory.dir(dirName).get().asFile
     if (!dir.isDirectory) {
         return emptyList()
     }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/SiblingCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/coverage/SiblingCoverage.kt
@@ -101,8 +101,10 @@ private fun Project.execFilesOf(testTasks: TaskCollection<Test>): Provider<Itera
 private const val BIN_REPORTS_DIR: String = "kover/bin-reports"
 
 /**
- * Tells whether this is a Kover task that reads the binary reports and therefore
- * must run only after the [contributor's][creditTestCoverageFrom] test data exists.
+ * Tells whether this is a Kover task that reads binary execution-data reports
+ * and therefore must run only after the tasks that produce them — the
+ * [contributor's][creditTestCoverageFrom] test tasks, or the forked Spine
+ * Compiler launch tasks (see [io.spine.gradle.testing.enableSpineCompilerCoverage]).
  *
  * This matches both the report tasks (`koverXmlReport`, `koverHtmlReport`,
  * `koverBinaryReport`) and the verification tasks (`koverVerify` and its
@@ -110,5 +112,5 @@ private const val BIN_REPORTS_DIR: String = "kover/bin-reports"
  * `Cached*` variants Kover registers, which are the ones that actually consume
  * the binary reports.
  */
-private fun Task.consumesCoverageBinaryReports(): Boolean =
+internal fun Task.consumesCoverageBinaryReports(): Boolean =
     name.startsWith("kover") && (name.endsWith("Report") || name.endsWith("Verify"))

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.testing
+
+import io.spine.dependency.test.Jacoco
+import io.spine.gradle.report.coverage.consumesCoverageBinaryReports
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.JavaExec
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * Configures the `launch*SpineCompiler` tasks of this project so that the JaCoCo
+ * agent is attached to the forked JVM that runs the Spine Compiler, and the
+ * resulting execution data is captured as a task output.
+ *
+ * The Spine Compiler executes plugin code — renderers, option generators, and
+ * other compiler plugins — in a **separate JVM** spawned by the
+ * `launch[<SourceSet>]SpineCompiler`
+ * [JavaExec][org.gradle.api.tasks.JavaExec] tasks. Kover (and JaCoCo) instrument
+ * only the `test` JVM, so this out-of-process execution is otherwise not credited
+ * to coverage, even though the module's `.proto` fixtures exercise it on every build.
+ *
+ * For every such launch task, this method:
+ *
+ *  1. Resolves the standalone JaCoCo agent JAR ([Jacoco.agent]) through a dedicated
+ *     [AGENT_CONFIGURATION] configuration.
+ *  2. Attaches
+ *     `-javaagent:<agent>=destfile=build/`[COMPILER_COVERAGE_DIR]`/<task>.exec,append=false`
+ *     to the forked JVM. Each launch variant (`main`, `test`, `testFixtures`)
+ *     writes its own per-task file, and `append=false` makes every run overwrite
+ *     it, so a re-run never accumulates a previous run's probes.
+ *  3. Declares that `.exec` file as a **task output**, which keeps the launch tasks
+ *     cacheable. A `JavaExec` task blocks until the forked JVM exits, and the agent
+ *     flushes the exec on that exit — so the file is already on disk when the task
+ *     action returns and *can* be a declared output. Declaring it lets Gradle's
+ *     build cache store and restore it, so the coverage survives both an
+ *     `UP-TO-DATE` skip (the file stays on disk from the previous run) and a
+ *     `FROM-CACHE` hit (the file is restored from the cache). This is the key
+ *     difference from [enableTestKitCoverage], whose TestKit workers flush their
+ *     exec only *after* the `Test` task completes, so the file cannot be declared
+ *     as a task output — which is why that helper must instead disable caching.
+ *
+ * The agent is attached from a `doFirst` action rather than a `jvmArgumentProviders`
+ * entry so that its absolute path stays out of the task's input fingerprint: the
+ * exec content depends on the compiler's own inputs (which drive what code runs), so
+ * keying up-to-dateness and the cache on those inputs is exactly right.
+ *
+ * The produced `.exec` files are merged into the **root** Kover report by
+ * [io.spine.gradle.report.coverage.KoverConfig]. Only classes the root aggregation
+ * owns — the project's own renderers and generators — are credited from them; the
+ * compiler loads those classes as their original, un-relocated artifacts, so
+ * JaCoCo's class IDs match. The agent emits binary execution data because Kover
+ * merges binary data at the probe level — see `KoverConfig` for why binary, not XML.
+ *
+ * The method is idempotent — a repeated call on the same project returns early
+ * instead of attaching the agent twice — and may be called on every subproject;
+ * it is a no-op for modules that declare no `launch*SpineCompiler` task.
+ */
+fun Project.enableSpineCompilerCoverage() {
+    if (configurations.findByName(AGENT_CONFIGURATION) != null) {
+        return
+    }
+    val agent = configurations.maybeCreate(AGENT_CONFIGURATION).apply {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+    dependencies.add(agent.name, Jacoco.agent)
+
+    val agentPath = agent.elements.map { it.single().asFile.absolutePath }
+    val execDir = layout.buildDirectory.dir(COMPILER_COVERAGE_DIR)
+
+    val launchTasks = tasks.withType<JavaExec>().matching { it.isSpineCompilerLaunchTask() }
+
+    launchTasks.configureEach {
+        val taskName = name
+        val execFile = execDir.map { it.file("$taskName.exec") }
+        // Captured as a task output so the build cache stores and restores it —
+        // see the KDoc for why a synchronous `JavaExec` can declare its agent exec
+        // while a TestKit worker cannot.
+        outputs.file(execFile)
+        doFirst {
+            val file = execFile.get().asFile
+            file.parentFile.mkdirs()
+            jvmArgs(
+                "-javaagent:${agentPath.get()}=destfile=${file.absolutePath},append=false"
+            )
+        }
+    }
+
+    // The root Kover report/verification tasks read these exec files as
+    // `additionalBinaryReports`, but do not otherwise depend on the (non-Kover)
+    // test modules that produce them. Make them depend on the launch tasks —
+    // a hard `dependsOn`, not mere ordering, so that running a report task by
+    // itself still triggers the launch tasks that write the exec files.
+    rootProject.tasks
+        .matching { it.consumesCoverageBinaryReports() }
+        .configureEach { dependsOn(launchTasks) }
+}
+
+/**
+ * Tells whether this is one of the `launch[<SourceSet>]SpineCompiler` tasks that
+ * fork the Spine Compiler — matched by name to avoid a compile-time dependency on
+ * the compiler Gradle plugin's task types.
+ */
+private fun Task.isSpineCompilerLaunchTask(): Boolean =
+    name.startsWith(LAUNCH_TASK_PREFIX) && name.endsWith(LAUNCH_TASK_SUFFIX)
+
+/**
+ * The name of the directory under a module's `build` directory where the coverage
+ * of forked Spine Compiler JVMs is collected.
+ *
+ * The directory holds JaCoCo execution-data (`.exec`) files — one per launch task —
+ * written by the JaCoCo agent attached to the compiler fork. `KoverConfig` picks
+ * these files up and feeds them into the root Kover report as additional binary
+ * reports.
+ *
+ * @see io.spine.gradle.report.coverage.KoverConfig
+ */
+internal const val COMPILER_COVERAGE_DIR: String = "jacoco-compiler"
+
+/**
+ * The name of the dedicated, resolvable configuration that holds the standalone
+ * JaCoCo agent JAR ([Jacoco.agent]) attached to the forked Spine Compiler JVMs.
+ *
+ * The configuration is hidden and non-consumable; it exists only to resolve the
+ * agent JAR.
+ */
+private const val AGENT_CONFIGURATION: String = "spineCompilerJacocoAgent"
+
+private const val LAUNCH_TASK_PREFIX: String = "launch"
+private const val LAUNCH_TASK_SUFFIX: String = "SpineCompiler"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
@@ -134,8 +134,12 @@ fun Project.enableSpineCompilerCoverage() {
  * Tells whether this is one of the `launch[<SourceSet>]SpineCompiler` tasks that
  * fork the Spine Compiler — matched by name to avoid a compile-time dependency on
  * the compiler Gradle plugin's task types.
+ *
+ * `internal` so [io.spine.gradle.report.coverage.KoverConfig] can collect the exec
+ * files of the **current** launch tasks (rather than scanning the directory) and
+ * thereby ignore stale execs from removed tasks.
  */
-private fun Task.isSpineCompilerLaunchTask(): Boolean =
+internal fun Task.isSpineCompilerLaunchTask(): Boolean =
     name.startsWith(LAUNCH_TASK_PREFIX) && name.endsWith(LAUNCH_TASK_SUFFIX)
 
 /**

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/SpineCompilerCoverage.kt
@@ -66,9 +66,13 @@ import org.gradle.kotlin.dsl.withType
  *     as a task output — which is why that helper must instead disable caching.
  *
  * The agent is attached from a `doFirst` action rather than a `jvmArgumentProviders`
- * entry so that its absolute path stays out of the task's input fingerprint: the
- * exec content depends on the compiler's own inputs (which drive what code runs), so
- * keying up-to-dateness and the cache on those inputs is exactly right.
+ * entry so that its *absolute path* — machine-specific, under the Gradle user home —
+ * stays out of the task's input fingerprint, where it would break build-cache reuse
+ * across machines. The agent *coordinate* ([Jacoco.agent]) is instead declared as an
+ * `inputs.property`, so bumping the JaCoCo version invalidates the launch tasks and
+ * regenerates the exec — a stale exec from an incompatible agent can never survive an
+ * `UP-TO-DATE` skip or a `FROM-CACHE` hit. The exec content otherwise depends on the
+ * compiler's own inputs, which already key up-to-dateness.
  *
  * The produced `.exec` files are merged into the **root** Kover report by
  * [io.spine.gradle.report.coverage.KoverConfig]. Only classes the root aggregation
@@ -99,6 +103,10 @@ fun Project.enableSpineCompilerCoverage() {
     launchTasks.configureEach {
         val taskName = name
         val execFile = execDir.map { it.file("$taskName.exec") }
+        // Track the agent *coordinate*, not the resolved absolute path, so a JaCoCo
+        // version bump invalidates the task and regenerates the exec while the cache
+        // key stays machine-independent — see the KDoc.
+        inputs.property(JACOCO_AGENT_INPUT, Jacoco.agent)
         // Captured as a task output so the build cache stores and restores it —
         // see the KDoc for why a synchronous `JavaExec` can declare its agent exec
         // while a TestKit worker cannot.
@@ -151,6 +159,13 @@ internal const val COMPILER_COVERAGE_DIR: String = "jacoco-compiler"
  * agent JAR.
  */
 private const val AGENT_CONFIGURATION: String = "spineCompilerJacocoAgent"
+
+/**
+ * The name of the task input property that records the JaCoCo agent coordinate
+ * ([Jacoco.agent]), so a version bump invalidates the `launch*SpineCompiler` tasks
+ * and their cached `.exec` outputs.
+ */
+private const val JACOCO_AGENT_INPUT: String = "jacocoAgentCoordinate"
 
 private const val LAUNCH_TASK_PREFIX: String = "launch"
 private const val LAUNCH_TASK_SUFFIX: String = "SpineCompiler"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
@@ -43,8 +43,8 @@ import org.gradle.kotlin.dsl.withType
  *
  * This method:
  *
- *  1. Resolves the standalone JaCoCo agent JAR pinned to [Jacoco.version]
- *     through a dedicated [AGENT_CONFIGURATION] configuration.
+ *  1. Resolves the standalone JaCoCo agent JAR ([Jacoco.agent]) through a
+ *     dedicated [AGENT_CONFIGURATION] configuration.
  *  2. Passes the agent JAR path and a per-module exec directory
  *     (`build/`[TESTKIT_COVERAGE_DIR]) to the test JVM as system properties.
  *     The `plugin-testlib` harness reads these and writes a `gradle.properties`
@@ -84,7 +84,7 @@ fun Project.enableTestKitCoverage() {
         isCanBeConsumed = false
         isCanBeResolved = true
     }
-    dependencies.add(agent.name, "org.jacoco:org.jacoco.agent:${Jacoco.version}:runtime")
+    dependencies.add(agent.name, Jacoco.agent)
 
     val agentPath = agent.elements.map { it.single().asFile.absolutePath }
     val execDir = layout.buildDirectory.dir(TESTKIT_COVERAGE_DIR)
@@ -150,8 +150,7 @@ private const val EXEC_DIR_PROPERTY: String =
 
 /**
  * The name of the dedicated, resolvable configuration that holds the standalone
- * JaCoCo agent JAR (`org.jacoco:org.jacoco.agent:<version>:runtime`) attached to
- * TestKit worker JVMs.
+ * JaCoCo agent JAR ([Jacoco.agent]) attached to TestKit worker JVMs.
  *
  * The configuration is hidden and non-consumable; it exists only to resolve the
  * agent JAR and to register it as an input of the `test` tasks.


### PR DESCRIPTION
## What & why

Ports the `buildSrc` coverage helpers from
[validation#317](https://github.com/SpineEventEngine/validation/pull/317)
into `config`, so every consumer repo receives them via `./config/pull`.

The Spine Compiler runs plugin code — renderers, option generators, and
other codegen plugins — in a **forked `launch*SpineCompiler` JVM** during the
build, which Kover/JaCoCo do not instrument. That out-of-process execution is
otherwise reported at ~0% line coverage even though each repo's `.proto`
fixtures exercise it on every build. In `validation`, wiring this in took the
root report from **12% → 86%**. This change distributes the mechanism; each
consumer opts in with a single `subprojects { enableSpineCompilerCoverage() }`
line in its own root build script (that wiring stays consumer-owned and is
**not** part of this PR).

## How

- **`enableSpineCompilerCoverage()`** (new
  `buildSrc/.../gradle/testing/SpineCompilerCoverage.kt`) attaches
  `-javaagent:<JaCoCo agent>=destfile=…/<task>.exec,append=false` to every
  `launch*SpineCompiler` `JavaExec` task, one exec file per launch variant.
- The `.exec` is **declared as a task output**, so the launch tasks stay
  **cacheable**: a `JavaExec` blocks until the fork exits and the agent flushes
  on exit, so the file is on disk when the action returns. Coverage survives
  both an `UP-TO-DATE` skip and a `FROM-CACHE` hit — unlike the TestKit worker
  daemon, which is why `enableTestKitCoverage()` must instead disable caching.
- **`KoverConfig`** feeds the exec files into the **root** report's
  `additionalBinaryReports` (the report Codecov ingests) and orders the
  `kover*Report`/`kover*Verify` tasks after the launch tasks.
- The JaCoCo agent coordinate is centralized as **`Jacoco.agent`**, shared with
  `enableTestKitCoverage()` (which previously inlined the same literal).

## Deviations from the source PR (behavior identical)

- **KDoc generalized** — validation-specific references (`java`/`context`
  modules, `JavaValidationPlugin`) removed, since these files land in ~40 repos.
- **detekt-driven dedup** — `config` runs detekt over `buildSrc` (consumers
  don't); the verbatim port tripped `TooManyFunctions`. The twin
  `testKitExecFiles`/`compilerExecFiles` helpers are now one
  `execFiles(project, dirName)`, and the Kover-task predicate reuses the
  pre-existing `consumesCoverageBinaryReports()` from `SiblingCoverage.kt`
  (promoted `private` → `internal`) rather than duplicating it.
- **Idempotency guard** — an early return makes `enableSpineCompilerCoverage()`
  safe to call more than once per project; without it a second call would
  append a second `-javaagent:` and double-load the agent in the fork.

## Verification

- `JAVA_HOME=17 ./gradlew :buildSrc:build detekt` — green (tests included).
  `config`'s root has no `build` lifecycle task and does not register
  `dokkaGenerate`, so this is the applicable command.
- No root `version.gradle.kts` in `config`, so the version-bump gate is not
  applicable.
- Reviewers on the final diff — `spine-code-review`, `kotlin-engineer`,
  `review-docs`, `dependency-audit` — all **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)