### PR TITLE
Stop tracking .idea/misc.xml; treat it as project-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,12 @@
 .idea/modules
 .idea/shelf
 
+# `.idea/misc.xml` is intentionally NOT re-included below. It is project-local —
+# it holds the per-project JDK name and IDEA's own churn (entry-point list
+# indices, external-storage toggles) — so `.idea/*.xml` above keeps it ignored.
+# `./config/pull` (via `migrate`) untracks any copy an earlier pull committed.
+
 # Do not ignore the following IDEA settings
-!.idea/misc.xml
 !.idea/codeStyleSettings.xml
 !.idea/codeStyles/
 !.idea/copyright/

--- a/migrate
+++ b/migrate
@@ -354,7 +354,11 @@ fi
 #     (which `git add -A` re-adds) instead of ignored. The merge already ran
 #     above; scrub the negation from its result.
 #  2. Untrack any copy an earlier pull committed. `--cached` keeps the working
-#     file; the `git ls-files` guard makes a re-run a quiet no-op.
+#     file; `--force` overrides `git rm`'s up-to-date check so a consumer that
+#     staged `misc.xml` IDE churn (its index differing from both HEAD and the
+#     work tree) is still migrated — otherwise `git rm` fails and, as `migrate`
+#     runs without `set -e`, silently leaves the file tracked. The `git ls-files`
+#     guard makes a re-run a quiet no-op.
 # ---------------------------------------------------------------------------
 if [ -f .gitignore ] && grep -qxF '!.idea/misc.xml' .gitignore; then
     echo "Dropping the retired '!.idea/misc.xml' negation from .gitignore"
@@ -368,7 +372,7 @@ fi
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
    && git ls-files --error-unmatch .idea/misc.xml >/dev/null 2>&1; then
     echo "Untracking '.idea/misc.xml' (now project-local, git-ignored)"
-    git rm --cached --quiet .idea/misc.xml
+    git rm --cached --force --quiet .idea/misc.xml
 fi
 
 if [ "$IS_JVM" = "true" ]; then

--- a/migrate
+++ b/migrate
@@ -319,14 +319,30 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# Stop tracking `.idea/misc.xml`. It is project-local — it carries the
-# per-project JDK name and IDEA's own churn (entry-point list indices,
-# external-storage toggles) — so a tracked copy collides with the consumer's
-# local IDE state on every `./config/pull`. It is now git-ignored (see
-# `.gitignore`); drop any copy an earlier pull committed. `--cached` keeps the
-# working file; the `git ls-files` guard makes a re-run a quiet no-op once the
-# removal has been committed.
+# Make `.idea/misc.xml` project-local. It carries the per-project JDK name and
+# IDEA's own churn (entry-point list indices, external-storage toggles), so a
+# tracked copy collides with the consumer's local IDE state on every
+# `./config/pull`. Two steps:
+#
+#  1. Drop any surviving `!.idea/misc.xml` negation. The shared baseline no
+#     longer rescues the file, but `update-gitignore.sh` preserves a legacy
+#     raw-copied `.gitignore`'s negations into the repo-local block, so the
+#     retired rescue can outlive the baseline and — `.gitignore` being
+#     last-match-wins — un-ignore the file, leaving it `?? .idea/misc.xml`
+#     (which `git add -A` re-adds) instead of ignored. The merge already ran
+#     above; scrub the negation from its result.
+#  2. Untrack any copy an earlier pull committed. `--cached` keeps the working
+#     file; the `git ls-files` guard makes a re-run a quiet no-op.
 # ---------------------------------------------------------------------------
+if [ -f .gitignore ] && grep -qxF '!.idea/misc.xml' .gitignore; then
+    echo "Dropping the retired '!.idea/misc.xml' negation from .gitignore"
+    gi_tmp=$(mktemp ./.gitignore.XXXXXX)
+    if grep -vxF '!.idea/misc.xml' .gitignore > "$gi_tmp"; then
+        mv "$gi_tmp" .gitignore
+    else
+        rm -f "$gi_tmp"
+    fi
+fi
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
    && git ls-files --error-unmatch .idea/misc.xml >/dev/null 2>&1; then
     echo "Untracking '.idea/misc.xml' (now project-local, git-ignored)"

--- a/migrate
+++ b/migrate
@@ -318,6 +318,21 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# Stop tracking `.idea/misc.xml`. It is project-local — it carries the
+# per-project JDK name and IDEA's own churn (entry-point list indices,
+# external-storage toggles) — so a tracked copy collides with the consumer's
+# local IDE state on every `./config/pull`. It is now git-ignored (see
+# `.gitignore`); drop any copy an earlier pull committed. `--cached` keeps the
+# working file; the `git ls-files` guard makes a re-run a quiet no-op once the
+# removal has been committed.
+# ---------------------------------------------------------------------------
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+   && git ls-files --error-unmatch .idea/misc.xml >/dev/null 2>&1; then
+    echo "Untracking '.idea/misc.xml' (now project-local, git-ignored)"
+    git rm --cached --quiet .idea/misc.xml
+fi
+
 if [ "$IS_JVM" = "true" ]; then
     echo "Adding \`buildSrc\` sources to Git..."
     git add ./buildSrc/src

--- a/migrate
+++ b/migrate
@@ -72,7 +72,29 @@ function initialize() {
 }
 
 echo "Updating IDEA configuration"
+# Preserve a project's `.idea/misc.xml` (do not overwrite it). It is project-local
+# — the per-project JDK name plus IDEA's own churn — so it is ignored and untracked
+# further below; letting this shared `.idea` overlay clobber it with config's copy
+# would defeat that (the reset is git-silent, but still resets the consumer's JDK
+# on every pull). Config's copy still seeds a consumer that has none yet, carrying
+# the shared `EntryPointsManager` / nullness defaults; an existing project-local
+# copy wins. Same approach as `module.gradle.kts` below.
+DEST_MISC="../.idea/misc.xml"
+MISC_PRESERVE_TMP=""
+if [ -f "$DEST_MISC" ]; then
+  echo "Preserving existing \`.idea/misc.xml\`"
+  MISC_PRESERVE_TMP=$(mktemp -t misc.XXXXXX)
+  cp -a "$DEST_MISC" "$MISC_PRESERVE_TMP"
+fi
+
 cp -R .idea ..
+
+# Restore preserved `.idea/misc.xml`, if any.
+if [ -n "$MISC_PRESERVE_TMP" ] && [ -f "$MISC_PRESERVE_TMP" ]; then
+  echo "Restoring existing \`.idea/misc.xml\`"
+  cp -a "$MISC_PRESERVE_TMP" "$DEST_MISC"
+  rm -f "$MISC_PRESERVE_TMP"
+fi
 
 echo "Updating Contributor's Guide"
 # CONTRIBUTING.md is identical org-wide and static; copy it only if the repo


### PR DESCRIPTION
## What

`.idea/misc.xml` is treated as a project-local IntelliJ IDEA file: ignored,
untracked in consumers, and **preserved** across `./config/pull` rather than
overwritten.

- **`.gitignore`** — drop the `!.idea/misc.xml` negation so the existing
  `.idea/*.xml` rule ignores it; add a comment so the rescue line is not
  re-added. This baseline propagates to every consumer via
  `scripts/update-gitignore.sh`.
- **`migrate`**:
  1. **Preserve a consumer's existing `.idea/misc.xml`** across the shared
     `cp -R .idea ..` (save + restore, mirroring the `module.gradle.kts`
     preservation already used for `buildSrc`). Config's copy still seeds a
     consumer that has none yet — carrying the shared `EntryPointsManager` /
     nullness defaults — but an existing project-local copy wins.
  2. After `cd ..`, **scrub any surviving `!.idea/misc.xml` negation** from the
     merged `.gitignore`. `update-gitignore.sh` preserves a legacy raw-copied
     file's negations into the repo-local block, where the retired rescue can
     outlive the baseline and — last-match-wins — un-ignore the file; without
     scrubbing it, `git rm --cached` would leave `?? .idea/misc.xml` (re-added by
     `git add -A`) instead of ignored.
  3. **Untrack any copy an earlier pull committed** (`git rm --cached`), guarded
     by `git ls-files --error-unmatch` so re-pulls are silent no-ops.

## Why

`.idea/misc.xml` carries the per-project JDK name and IDEA's own churn
(entry-point list indices, external-storage toggles). Because `config` tracked,
distributed, and overwrote it, every `./config/pull` collided with the consumer's
local IDE state — the "constant issues with auto-update" this resolves.

## Notes for reviewers

- **`config` keeps tracking its own `misc.xml`** — it is the seed for fresh
  consumers and `config`'s own curated IDE settings. Git never un-tracks an
  already-tracked file, so the new ignore rule is inert in `config` itself
  (intended); it only bites once a consumer is untracked by `migrate`.
- **Trade-off:** because an existing `misc.xml` is now preserved, existing
  consumers no longer receive `EntryPointsManager` updates through it — the same
  trade-off already accepted for `module.gradle.kts` (config cannot update a
  project-specific file it must not clobber). That is the cost of the file being
  genuinely local. If the team would rather keep distributing those shared IDE
  settings, this preserve step is the one thing to reconsider.
- All three `migrate` steps are idempotent and CWD-correct.

## Verification

- `git check-ignore --no-index .idea/misc.xml` → matched by `.idea/*.xml`;
  sibling settings (`codeStyles/`, `copyright/`) stay tracked.
- `bash -n migrate` passes; `scripts/test-update-gitignore.sh` → 23/23 pass.
- **Preserve:** a consumer's custom `misc.xml` (different JDK) survives the copy,
  shared `.idea` files still distribute, a fresh consumer is seeded, re-runs are
  idempotent, no stray temp files.
- **Scrub:** validated against the real `scripts/update-gitignore.sh` for both
  marker-format and raw-pre-marker consumers — the file ends up ignored, the
  untrack sticks, `git add -A` does not re-add it, other repo-local entries are
  preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
