### PR TITLE
Bump Spine SDK local dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.421"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.421"
+    const val version = "2.0.0-SNAPSHOT.423"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.423"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.059"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.061"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.059"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.061"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.381"
+    const val version = "2.0.0-SNAPSHOT.420"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.419"
+    const val version = "2.0.0-SNAPSHOT.422"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -40,7 +40,7 @@ import io.spine.dependency.Dependency
 )
 object Time : Dependency() {
     override val group = Spine.group
-    override val version = "2.0.0-SNAPSHOT.242"
+    override val version = "2.0.0-SNAPSHOT.244"
     private const val infix = "spine-time"
 
     fun lib(version: String): String = "$group:$infix:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.446"
+    const val version = "2.0.0-SNAPSHOT.450"
 
     const val group = Spine.toolsGroup
     private const val prefix = "validation"


### PR DESCRIPTION
## Summary
- Refreshes six `local/` Spine SDK dependency snapshots to the latest builds in the Spine SDK Artifact Registry (`releases` + `snapshots` repos):
  - `Base`: `SNAPSHOT.421` → `SNAPSHOT.423`
  - `Logging`: `SNAPSHOT.419` → `SNAPSHOT.422`
  - `CoreJvm`: `SNAPSHOT.381` → `SNAPSHOT.420`
  - `Validation`: `SNAPSHOT.446` → `SNAPSHOT.450`
  - `Time`: `SNAPSHOT.242` → `SNAPSHOT.244`
  - `Compiler` (fallback/dogfooding version): `SNAPSHOT.059` → `SNAPSHOT.061`
- `BaseTypes`, `Change`, `CoreJvmCompiler`, `Reflect`, `ModelCompiler`, `ToolBase`, `ToolBase.JavadocFilter`, `TestLib`, and `ProtoTap` were already at their latest published version — no change.
- Scope was limited to `buildSrc/src/main/kotlin/io/spine/dependency/local/`; `buildSrc/build.gradle.kts` was not touched.

## Test plan
- [x] `./gradlew :buildSrc:build detekt` succeeds with the bumped Spine SDK snapshots
- [x] `version-bumped` check: N/A — this repo has no root `version.gradle.kts`
- [x] Reviewed by `spine-code-review`, `kotlin-engineer`, `dependency-audit` — all APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)