### PR TITLE
Record verified upstream status in the Gradle 9.6 deprecations tracker

### DIFF
--- a/.agents/tasks/gradle-9.6-deprecations.md
+++ b/.agents/tasks/gradle-9.6-deprecations.md
@@ -10,7 +10,7 @@ started: 2026-06-29
 
 Reach a clean Gradle 9.6 configuration/build with **no deprecation warnings**.
 All deprecations originating in `config`'s own sources have been fixed on the
-`address-deprecations` branch. The two warnings that remain originate **inside
+`address-deprecations` branch. The warnings that remain originate **inside
 third-party Gradle plugins** and cannot be fixed here — this note tracks them
 until upstream ships Gradle-9.x-compatible releases.
 
@@ -24,20 +24,35 @@ using a JDK 17 toolchain — point `JAVA_HOME` at a JDK 17 install for your OS
 ./gradlew help --warning-mode all --stacktrace
 ```
 
-Two deprecations surface during `> Configure project :`. Verified stack traces
-show both are raised from the plugins' own `apply()` code, not from `config`:
+Add `-Dorg.gradle.deprecation.trace=true` to print the full stack trace of
+every deprecation warning — the reliable way to attribute a nag to a plugin.
+
+Two deprecations surface during `> Configure project :`. A third hides in
+`buildSrc`: it fires while Gradle generates the precompiled-script-plugin
+accessors (our convention plugins are applied against a synthetic project),
+so it is **masked whenever those tasks are `FROM-CACHE`/`UP-TO-DATE`**.
+Reproduce it on a cold cache:
+
+```bash
+./gradlew :buildSrc:generatePrecompiledScriptPluginAccessors --rerun-tasks \
+    --warning-mode all -Dorg.gradle.deprecation.trace=true
+```
+
+Verified stack traces show all three are raised from the plugins' own
+`apply()` code, not from `config`:
 
 | Deprecation | Raised by | Plugin / version |
 |---|---|---|
 | `ReportingExtension.file(String)` (removed in Gradle 10) | `io.gitlab.arturbosch.detekt.DetektPlugin.apply` (`DetektPlugin.kt:28`) | detekt-gradle-plugin **1.23.8** |
-| `Project.getProperties` (fails in Gradle 10) | `com.osacky.doctor` → `RemoteCacheEstimation.<init>` (`RemoteCacheEstimation.kt:20`) | gradle-doctor **0.12.1** |
+| `Project.getProperties` (fails in Gradle 10) | `com.osacky.doctor` → `RemoteCacheEstimation.<init>` (`RemoteCacheEstimation.kt:20–22`, one warning per line) | gradle-doctor **0.12.1** |
+| `Project` object as a dependency notation (fails in Gradle 10) | `kotlinx.kover.gradle.plugin.KoverGradlePlugin.apply` → `PrepareKoverKt.prepare` (`PrepareKover.kt:29`) | kover-gradle-plugin **0.9.8** |
 
 Notes:
 - The detekt warning is *attributed* to `detekt-code-analysis.gradle.kts:67`,
   but line 67 is only the `id("io.gitlab.arturbosch.detekt")` apply site — the
   deprecated call is in the plugin bytecode.
-- Both calls happen unconditionally on plugin apply, so no `detekt { }` /
-  `doctor { }` configuration can avoid them.
+- All three calls happen unconditionally on plugin apply, so no `detekt { }` /
+  `doctor { }` / `kover { }` configuration can avoid them.
 - There is **nothing to upgrade to**: as of 2026-06-29, detekt's latest release
   is `1.23.8` (the version we use; no 2.x on the `detekt-gradle-plugin`
   coordinate) and gradle-doctor's latest is `0.12.1` (also what we use). Both
@@ -45,6 +60,25 @@ Notes:
 - Confirmed there is **no** `ReportingExtension.file` / `Project.getProperties`
   call anywhere in `buildSrc` (the `System.getProperties()` in
   `write-manifest.gradle.kts:46` is Java's, unrelated).
+- Upstream status, re-checked 2026-07-10:
+  - **detekt** — [detekt#8452](https://github.com/detekt/detekt/issues/8452)
+    (this exact deprecation) was closed as completed on 2025-08-31. The fix
+    (uses `ReportingExtension.baseDirectory`) lives only on `main` and ships
+    with detekt 2.0 — currently `2.0.0-alpha.5` — under the **new plugin ID
+    `dev.detekt`** and new `dev.detekt` Maven coordinates. 1.23.8 (2025-02)
+    is still the newest 1.x release.
+  - **gradle-doctor** — still unfixed even on upstream `master`
+    (`RemoteCacheEstimation.kt` last touched 2024-07); no upstream issue
+    tracks it. Note: 0.12.1 has no git tag or GitHub release — watch the
+    [Maven Central metadata](https://repo1.maven.org/maven2/com/osacky/doctor/doctor-plugin/maven-metadata.xml),
+    not the releases page.
+  - **Kover** — [kotlinx-kover#818](https://github.com/Kotlin/kotlinx-kover/issues/818)
+    (open) tracks its Gradle 9.6 deprecation; 0.9.8 is still the latest
+    release.
+- The Kover-plugin-internal call above is **distinct** from `config`'s own
+  `Project`-notation usage in `KoverConfig.kt:172`
+  (`rootProject.project(sub.path)`), which is addressed in a separate change.
+  Fixing `KoverConfig` does not clear the plugin-internal warning.
 
 Decision: do **not** suppress globally via `org.gradle.warning.mode=none` — that
 would also hide `config`'s own future deprecations, defeating the purpose of
@@ -53,18 +87,33 @@ this branch. Tolerate the two warnings (non-fatal on 9.6) and bump when fixed.
 ## Plan
 
 - [ ] Watch upstream for Gradle-9.x-compatible releases:
-  - [ ] detekt — Gradle 9 / `ReportingExtension` support (likely detekt 2.x).
+  - [ ] detekt — fix confirmed in 2.0 (alphas only so far); wait for a final.
         Releases: https://github.com/detekt/detekt/releases
-  - [ ] gradle-doctor — `Project.getProperties` removal.
-        Releases: https://github.com/runningcode/gradle-doctor/releases
-- [ ] When a fixed detekt release exists: bump `detektVersion` in
-      `buildSrc/build.gradle.kts` via the `dependency-update` flow, re-run the
-      reproduce command, confirm the `ReportingExtension.file` warning is gone.
+  - [ ] gradle-doctor — `Project.getProperties` removal. No upstream issue
+        exists yet; filing one (or a trivial PR replacing
+        `project.properties.containsKey(...)` with
+        `providers.gradleProperty(...)` presence checks) would unblock this.
+        Releases can be tagless — watch Maven Central metadata (link in Notes).
+  - [ ] Kover — release above 0.9.8 with
+        [kotlinx-kover#818](https://github.com/Kotlin/kotlinx-kover/issues/818)
+        resolved.
+- [ ] When a fixed detekt release exists: this is **not a plain bump** — the
+      plugin ID moves `io.gitlab.arturbosch.detekt` → `dev.detekt` and the
+      Maven group moves to `dev.detekt`, so `buildSrc/build.gradle.kts`
+      (`detektVersion` + the classpath dependency) and
+      `detekt-code-analysis.gradle.kts` (plugin ID) all change together, plus
+      any detekt-config migration 2.0 requires. Re-run the reproduce command,
+      confirm the `ReportingExtension.file` warning is gone.
 - [ ] When a fixed gradle-doctor release exists: bump `GradleDoctor.version` in
       `buildSrc/src/main/kotlin/io/spine/dependency/build/GradleDoctor.kt` via
       the `dependency-update` flow, re-run, confirm the `getProperties` warning
       is gone.
-- [ ] Once both clear, flip this task to `done` and delete it.
+- [ ] When a fixed Kover release exists: bump `koverVersion` in
+      `buildSrc/build.gradle.kts` **and** `Kover.version` in
+      `buildSrc/src/main/kotlin/io/spine/dependency/test/Kover.kt` via the
+      `dependency-update` flow, re-run the cold-`buildSrc` reproduce command,
+      confirm the dependency-notation warning is gone.
+- [ ] Once all three clear, flip this task to `done` and delete it.
 
 ## Log
 
@@ -74,6 +123,18 @@ this branch. Tolerate the two warnings (non-fatal on 9.6) and bump when fixed.
 - 2026-06-29 — Investigated the two remaining warnings; traced both to detekt
   1.23.8 and gradle-doctor 0.12.1 internals. Both plugins already at latest
   available; no fix exists yet. Status set to `blocked` (on upstream).
+- 2026-07-10 — Re-verified on Gradle 9.6.1 with full deprecation traces
+  (`:buildSrc:test detekt`, plus a cold
+  `:buildSrc:generatePrecompiledScriptPluginAccessors`). Both known warnings
+  unchanged; the doctor one fires ×3 (`RemoteCacheEstimation.kt:20–22`).
+  Upstream re-checked: detekt#8452 closed, fix ships only with detekt 2.0
+  (`dev.detekt` plugin ID; alphas only); gradle-doctor unfixed even on
+  `master`, no upstream issue, 0.12.1 is tagless. Added the third,
+  cache-masked warning from Kover 0.9.8 (`PrepareKover.kt:29`,
+  kotlinx-kover#818) — the follow-up suggested when closing PR #725; it is
+  distinct from `config`'s own `KoverConfig.kt` usage (handled separately).
+  Nothing to bump — all three plugins already at their latest releases;
+  still `blocked` on upstream.
 - NOTE: this tracker is blocked on external releases and is expected to outlive
   the `address-deprecations` branch merge — do not delete it on merge; keep it
-  (or promote the fact to `.agents/memory/`) until both bumps land.
+  (or promote the fact to `.agents/memory/`) until all bumps land.

--- a/.agents/tasks/gradle-9.6-deprecations.md
+++ b/.agents/tasks/gradle-9.6-deprecations.md
@@ -77,8 +77,12 @@ Notes:
     release.
 - The Kover-plugin-internal call above is **distinct** from `config`'s own
   `Project`-notation usage in `KoverConfig.kt:172`
-  (`rootProject.project(sub.path)`), which is addressed in a separate change.
-  Fixing `KoverConfig` does not clear the plugin-internal warning.
+  (`rootProject.project(sub.path)` passed to `dependencies.add`), which is
+  addressed in a separate change. Fixing `KoverConfig` does not clear the
+  plugin-internal warning, and bumping Kover will not fix `KoverConfig`.
+  The `KoverConfig` call fires only in consumer builds whose subprojects
+  apply Kover, so it never shows up in `config`'s own runs — the checklist
+  below keeps it visible until the separate change lands.
 
 Decision: do **not** suppress globally via `org.gradle.warning.mode=none` — that
 would also hide `config`'s own future deprecations, defeating the purpose of
@@ -113,7 +117,15 @@ this branch. Tolerate the two warnings (non-fatal on 9.6) and bump when fixed.
       `buildSrc/src/main/kotlin/io/spine/dependency/test/Kover.kt` via the
       `dependency-update` flow, re-run the cold-`buildSrc` reproduce command,
       confirm the dependency-notation warning is gone.
-- [ ] Once all three clear, flip this task to `done` and delete it.
+- [ ] Confirm the separate change fixing `config`-owned `KoverConfig.kt:172`
+      (a `Project` passed as dependency notation — the same Gradle 10
+      failure, config-owned rather than plugin-internal) has landed on
+      `master`. As of 2026-07-10 it has **not**; if it stalls, fix it from
+      this tracker instead.
+- [ ] Close only when the three plugin warnings are gone **and** the
+      `KoverConfig` item above is done, verified by a warning-free
+      cold-cache run of both reproduce commands; then flip this task to
+      `done` and delete it.
 
 ## Log
 
@@ -135,6 +147,11 @@ this branch. Tolerate the two warnings (non-fatal on 9.6) and bump when fixed.
   distinct from `config`'s own `KoverConfig.kt` usage (handled separately).
   Nothing to bump — all three plugins already at their latest releases;
   still `blocked` on upstream.
+- 2026-07-10 — Review follow-up on PR #732 (Codex): made the `config`-owned
+  `KoverConfig.kt:172` `Project`-notation call an explicit checklist item and
+  part of the exit criterion, so this tracker cannot be closed while that
+  Gradle 10 breakage is unfixed. It is being fixed in a separate change,
+  which has not landed on `master` yet.
 - NOTE: this tracker is blocked on external releases and is expected to outlive
   the `address-deprecations` branch merge — do not delete it on merge; keep it
   (or promote the fact to `.agents/memory/`) until all bumps land.


### PR DESCRIPTION
## What & why

Follow-up to #719's deprecation cleanup: attribute the deprecation warnings still reported by `./gradlew :buildSrc:test detekt --warning-mode all` to their sources using full deprecation stack traces (`-Dorg.gradle.deprecation.trace=true`), and record the verified findings in the standing tracker `.agents/tasks/gradle-9.6-deprecations.md`.

No build-logic changes — all remaining warnings originate inside third-party plugins, and none of them has a fixed release to bump to. All three become hard errors in Gradle 10.

| Warning | Plugin | Upstream status |
| --- | --- | --- |
| `ReportingExtension.file(String)` | detekt **1.23.8** (`DetektPlugin.kt:28`) | Fixed only in detekt 2.0 (alphas; new `dev.detekt` plugin ID and coordinates) — [detekt#8452](https://github.com/detekt/detekt/issues/8452), closed 2025-08-31 |
| `Project.getProperties` (×3) | gradle-doctor **0.12.1** (`RemoteCacheEstimation.kt:20–22`) | Unfixed even on upstream `master`; no upstream issue; 0.12.1 is tagless — watch Maven Central metadata |
| `Project` object as a dependency notation | Kover **0.9.8** (`PrepareKover.kt:29`) | [kotlinx-kover#818](https://github.com/Kotlin/kotlinx-kover/issues/818) (open); 0.9.8 is the latest release |

### Tracker changes

- Corrected the gradle-doctor entry to lines 20–22 (three warnings, not one).
- Added the upstream status re-checked on 2026-07-10 for detekt and gradle-doctor, including the `dev.detekt` plugin-ID/coordinate migration caveat for the future bump (not a plain version bump).
- Added the third, **cache-masked** Kover warning: it fires while `buildSrc` generates precompiled-script-plugin accessors and is invisible when those tasks are `FROM-CACHE`. Reproduce with:
  ```bash
  ./gradlew :buildSrc:generatePrecompiledScriptPluginAccessors --rerun-tasks \
      --warning-mode all -Dorg.gradle.deprecation.trace=true
  ```
  This is the follow-up suggested when closing #725. It is distinct from `config`'s own `Project`-notation usage in `KoverConfig.kt:172`, which is addressed separately — fixing `KoverConfig` does not clear the plugin-internal warning.
- Appended a dated Log entry; status remains `blocked` (on upstream releases).

## Reviewer notes

- Tracker-file-only change; no code, no dependency versions touched.
- Verified on Gradle 9.6.1 (JDK 17): `./gradlew :buildSrc:test detekt --warning-mode all --stacktrace` is green, and the cold accessor-generation run above reproduces the Kover warning with the quoted stack frame (`kotlinx.kover.gradle.plugin.appliers.PrepareKoverKt.prepare`).
- Why no bumps: detekt 2.0.0-alpha.x is a pre-release (rejected by our dependency-update conventions); gradle-doctor and Kover have no release containing a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
