### PR TITLE
Improve docs under `buildSrc`

### DIFF
--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -356,11 +356,12 @@ fun Project.allowDuplicationInSourcesJar() {
  *
  * Build script classpaths pin the module to the version used by the Kotlin
  * runtime embedded into Gradle (`strictly 13.0`, "Pinned to the embedded
- * Kotlin"), while `kotlinx-coroutines` and other transitive dependencies of
- * this plugin require `23.0.0`. Gradle 9.6 may fail to reconcile the two
- * declarations — the outcome depends on the shape of the consumer's dependency
- * graph — making the plugin unresolvable without a consumer-side workaround,
- * such as forcing the module version on the build script classpath.
+ * Kotlin"), while `kotlinx-coroutines` and other transitive dependencies require
+ * later versions such as `23.0.0`.
+ * Gradle 9.6 may fail to reconcile the two declarations — the outcome depends on
+ * the shape of the consumer's dependency graph — making the plugin unresolvable
+ * without a consumer-side workaround, such as forcing the module version on
+ * the build script classpath.
  *
  * The annotations are compile-time metadata, not needed at runtime.
  * Consumers still receive version `13.0` through the `kotlin-stdlib`

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
@@ -30,13 +30,6 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object Roaster {
 
-    /**
-     * This is the last version built with Java 11.
-     *
-     * Starting from the version
-     * [2.29.0.Final](https://github.com/forge/roaster/releases/tag/2.29.0.Final),
-     * Roaster requires Java 17.
-     */
     private const val version = "2.31.0.Final"
 
     const val group = "org.jboss.forge.roaster"


### PR DESCRIPTION
This PR:
 * Improves the wording of the `excludeJetBrainsAnnotations()` extension so that its usage does not trigger review comments by Copilot.
 * Removes the outdated comment of the pin of the Roaster version.