### PR TITLE
Remove the retired `ModelCompiler` object in `migrate`; bump Testcontainers to 2.0.5

### DIFF
--- a/.agents/tasks/testcontainers-2.md
+++ b/.agents/tasks/testcontainers-2.md
@@ -1,0 +1,47 @@
+---
+slug: testcontainers-2
+branch: master
+owner: claude
+status: in-review
+started: 2026-08-05
+---
+
+## Goal
+
+`Testcontainers.kt` in `buildSrc` pins `2.0.5` with the 2.x artifact names,
+so config floats stop reverting consumers that already upgraded
+(gcloud-jvm PR #202) and stop breaking their Testcontainers-2.x-based sources.
+
+## Context
+
+- Testcontainers 2.x renamed every module artifact with the `testcontainers-`
+  prefix; only the core library keeps the plain `testcontainers` name.
+  Verified on Maven Central at 2.0.5: `junit-jupiter`, `gcloud`, and `mysql`
+  return 404, while `testcontainers-junit-jupiter`, `testcontainers-gcloud`,
+  `testcontainers-mysql`, and `testcontainers-postgresql` exist.
+- gcloud-jvm already pins 2.0.5 locally (its PR #202); every `Update config`
+  commit reverts the pin and breaks `testlib` (`EmulatorContainer`).
+- jdbc-storage's local `buildSrc` copy adds a `postgresql` constant used by
+  `rdbms/build.gradle.kts`; config's copy must carry it, or the next float
+  breaks that build script with an unresolved reference.
+
+## Plan
+
+- [x] Bump `version` to `2.0.5`; rename module artifacts to the 2.x names.
+- [x] Add the `postgresql` constant so config's copy is a superset of
+      consumer usages (gcloud-jvm and jdbc-storage).
+- [x] Compile config's `buildSrc`.
+- [x] Sync gcloud-jvm's `buildSrc` copy to the canonical file; compile there.
+- [x] Run `dependency-audit` on the diff.
+
+## Log
+
+- 2026-08-05 — started; scope prescribed by the user request. Commit and
+  push are left to the human — changes are staged only.
+- 2026-08-05 — done and verified: config `./gradlew help` OK;
+  gcloud-jvm `:testlib:classes` OK against the synced canonical file
+  (byte-identical, so the next float is a no-op there);
+  `dependency-audit` verdict APPROVE, no findings.
+  jdbc-storage build scripts keep compiling (all referenced constants
+  present); its test sources still target the 1.x API and need their own
+  2.x migration when the float lands.

--- a/.agents/tasks/testcontainers-2.md
+++ b/.agents/tasks/testcontainers-2.md
@@ -38,6 +38,8 @@ so config floats stop reverting consumers that already upgraded
 
 - 2026-08-05 — started; scope prescribed by the user request. Commit and
   push are left to the human — changes are staged only.
+- 2026-08-05 — committed and pushed by the human's request as part of
+  PR #740, alongside the `migrate` `ModelCompiler` removal.
 - 2026-08-05 — done and verified: config `./gradlew help` OK;
   gcloud-jvm `:testlib:classes` OK against the synced canonical file
   (byte-identical, so the next float is a no-op there);

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Testcontainers.kt
@@ -33,12 +33,15 @@ package io.spine.dependency.test
  * The modules below are versioned and released together, so a single [version] applies to all
  * of them.
  *
+ * Starting with version 2.x, module artifacts are prefixed with `testcontainers-`,
+ * while the core [lib] artifact keeps the plain `testcontainers` name.
+ *
  * @see <a href="https://github.com/testcontainers/testcontainers-java">
  *     Testcontainers for Java at GitHub</a>
  */
 @Suppress("unused", "ConstPropertyName")
 object Testcontainers {
-    private const val version = "1.21.4"
+    private const val version = "2.0.5"
     private const val group = "org.testcontainers"
 
     /**
@@ -49,15 +52,20 @@ object Testcontainers {
     /**
      * The JUnit 5 (Jupiter) integration.
      */
-    const val junitJupiter = "$group:junit-jupiter:$version"
+    const val junitJupiter = "$group:testcontainers-junit-jupiter:$version"
 
     /**
      * The Google Cloud (GCP) emulator container support.
      */
-    const val gcloud = "$group:gcloud:$version"
+    const val gcloud = "$group:testcontainers-gcloud:$version"
 
     /**
      * The MySQL container support.
      */
-    const val mySql = "$group:mysql:$version"
+    const val mySql = "$group:testcontainers-mysql:$version"
+
+    /**
+     * The PostgreSQL container support.
+     */
+    const val postgresql = "$group:testcontainers-postgresql:$version"
 }

--- a/migrate
+++ b/migrate
@@ -328,9 +328,11 @@ if [ "$IS_JVM" = "true" ]; then
     # overlays the current sources but never deletes files dropped from `config`,
     # so a consumer that received these earlier keeps a stale copy that no longer
     # compiles against the rest of `buildSrc`. ProtoData was superseded by Spine
-    # Compiler (`io.spine.compiler`); McJava by CoreJvm Compiler (`io.spine.core-jvm`).
-    echo "Removing retired dependency objects (ProtoData, McJava)"
+    # Compiler (`io.spine.compiler`); Model Compiler by McJava, and McJava in turn
+    # by CoreJvm Compiler (`io.spine.core-jvm`).
+    echo "Removing retired dependency objects (ProtoData, ModelCompiler, McJava)"
     rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+    rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/ModelCompiler.kt
     rm -f ../buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
 
     # Remove the retired vanilla-JaCoCo script plugins for the same reason as the


### PR DESCRIPTION
Two independent `buildSrc`-distribution fixes.

## 1. `migrate` — remove the retired `ModelCompiler` dependency object

`ModelCompiler.kt` was dropped from `config` in cce5f575 ("Remove outdated local
dependency"), but `migrate` was never updated to delete stale copies in consumer
repositories.

`migrate` distributes `buildSrc` with `cp -R buildSrc ..`, which is a pure overlay:
it adds and overwrites, but never deletes. So every file `config` retires needs an
explicit `rm -f`, otherwise a consumer that pulled earlier keeps the retired object
forever — and `buildSrc` compiles as a single Kotlin source set, so a leftover
object can break the consumer's build.

`ModelCompiler.kt` now joins the existing removal block next to `ProtoData.kt` and
`McJava.kt`, and the block comment records the supersession chain:
Model Compiler → McJava → CoreJvm Compiler (`io.spine.core-jvm`).

## 2. `Testcontainers` — bump to 2.0.5 with the 2.x artifact names

Testcontainers 2.x prefixes every module artifact with `testcontainers-`; only the
core library keeps the plain `testcontainers` name. `Testcontainers.kt` now pins
`2.0.5` with the 2.x coordinates, so `config` floats stop reverting consumers that
already upgraded (gcloud-jvm PR #202) and stop breaking their
Testcontainers-2.x-based sources.

Also adds a `postgresql` constant so `config`'s copy is a superset of the consumer
usages — `jdbc-storage/rdbms/build.gradle.kts` references it, and without it the
next float breaks that build script with an unresolved reference.

Note the constant *names* (`junitJupiter`, `gcloud`, `mySql`) are unchanged — only
their coordinate values move — so no consumer reference breaks and no `@Deprecated`
shim is owed. `postgresql` intentionally keeps its lowercase spelling rather than
matching `mySql`'s camelCase, because that is the name jdbc-storage already
references.

## Verification

- `./gradlew -p buildSrc build` passes (JDK 17).
- `bash -n migrate` passes; the added `rm -f` path matches the historical file path
  exactly, sits inside the `IS_JVM` block after `cp -R buildSrc ..`, and `rm -f`
  keeps re-runs a no-op.
- Testcontainers coordinates verified against Maven Central at 2.0.5:
  `testcontainers`, `testcontainers-junit-jupiter`, `testcontainers-gcloud`,
  `testcontainers-mysql`, and `testcontainers-postgresql` all resolve, while the
  old unprefixed `junit-jupiter`, `gcloud`, and `mysql` return 404. 2.0.5 is the
  current release per `maven-metadata.xml`.
- `dependency-audit`: APPROVE — no version downgrade, no removed symbols, no
  stale coordinates left in the repo, copyright current.
- This repository has no root `version.gradle.kts`, so the version gate is not
  applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
