### PR TITLE
Bump Gradle Wrapper validation -> `@v6`

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6


### PR DESCRIPTION
This PR bumps the Gradle Wrapper validation action to `@v6` thus avoiding the warning for the deprecated Node.js v20.