### PR TITLE
Introduce `JacksonV2` dependency object

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/Boms.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/Boms.kt
@@ -28,7 +28,7 @@ package io.spine.dependency.boms
 
 import io.spine.dependency.DependencyWithBom
 import io.spine.dependency.kotlinx.Coroutines
-import io.spine.dependency.lib.Jackson
+import io.spine.dependency.lib.JacksonV2
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Grpc
 import io.spine.dependency.test.JUnit
@@ -60,7 +60,7 @@ object Boms {
      * Technology-based BOMs.
      */
     object Optional {
-        val jackson = Jackson.bom
+        val jackson = JacksonV2.bom
         val grpc = Grpc.bom
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Jackson.kt
@@ -37,6 +37,9 @@ import io.spine.dependency.DependencyWithBom
  * consuming the 2.x artifact, so both its coordinates and its
  * `com.fasterxml.jackson.annotation` package stay unchanged.
  *
+ * The Jackson 2.x artifacts, which some of our dependencies still consume,
+ * are declared by [JacksonV2].
+ *
  * See:
  *  - [Jackson Releases](https://github.com/FasterXML/jackson/wiki/Jackson-Releases)
  *  - [Migrating to Jackson 3](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)
@@ -50,7 +53,7 @@ object Jackson : DependencyWithBom() {
      * The version of `jackson-annotations`, which Jackson 3.x deliberately keeps
      * on the 2.x line.
      *
-     * Must match the `jackson.version.annotations` property declared by the [bom].
+     * Must match the `jackson.version.annotations` property declared by the [JacksonV2.bom].
      *
      * See: https://github.com/FasterXML/jackson-annotations?tab=readme-ov-file#release-notes
      */

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JacksonV2.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JacksonV2.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.lib
+
+import io.spine.dependency.Dependency
+import io.spine.dependency.DependencyWithBom
+
+/**
+ * Jackson 2.x dependencies.
+ *
+ * Jackson 2.x artifacts keep the `com.fasterxml.jackson.*` group IDs, unlike
+ * Jackson 3.x, which moved to `tools.jackson` (JSTEP-1). We declare the 2.x line
+ * to align the versions of the artifacts pulled transitively by third-party
+ * dependencies, while our own code uses Jackson 3.x declared by [Jackson].
+ *
+ * The `jackson-annotations` artifact, although it belongs to the 2.x line, is
+ * declared by [Jackson.annotations] because Jackson 3.x keeps consuming it.
+ *
+ * See:
+ *  - [Jackson Releases](https://github.com/FasterXML/jackson/wiki/Jackson-Releases)
+ *
+ * @see Jackson
+ */
+@Suppress("unused")
+object JacksonV2 : DependencyWithBom() {
+    override val group = "com.fasterxml.jackson"
+    override val version = "2.22.1"
+
+    // https://github.com/FasterXML/jackson-bom
+    override val bom = "$group:jackson-bom:$version"
+
+    private val groupPrefix = group
+
+    /**
+     * All Jackson 2.x modules we use are declared by the nested objects,
+     * such as [Core] or [DataType].
+     */
+    override val modules = emptyList<String>()
+
+    object Core : Dependency() {
+        override val version = JacksonV2.version
+        override val group = "$groupPrefix.core"
+
+        @Suppress("MemberNameEqualsClassName")
+        val core = "$group:jackson-core"
+        val databind = "$group:jackson-databind"
+
+        override val modules = listOf(core, databind)
+    }
+
+    object DataType : Dependency() {
+        override val version = JacksonV2.version
+        override val group = "$groupPrefix.datatype"
+
+        val jdk8 = "$group:jackson-datatype-jdk8"
+        val jsr310 = "$group:jackson-datatype-jsr310"
+        val guava = "$group:jackson-datatype-guava"
+
+        override val modules = listOf(jdk8, jsr310, guava)
+    }
+
+    object DataFormat : Dependency() {
+        override val version = JacksonV2.version
+        override val group = "$groupPrefix.dataformat"
+
+        val xml = "$group:jackson-dataformat-xml"
+        val yaml = "$group:jackson-dataformat-yaml"
+        val protobuf = "$group:jackson-dataformat-protobuf"
+
+        override val modules = listOf(xml, yaml, protobuf)
+    }
+
+    object Module : Dependency() {
+        override val version = JacksonV2.version
+        override val group = "$groupPrefix.module"
+
+        val parameterNames = "$group:jackson-module-parameter-names"
+
+        override val modules = listOf(parameterNames)
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Log4j2.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Log4j2.kt
@@ -39,4 +39,16 @@ package io.spine.dependency.lib
 object Log4j2 {
     private const val version = "2.26.0"
     const val core = "org.apache.logging.log4j:log4j-core:$version"
+
+    /**
+     * Routes the calls made through the [SLF4J API][Slf4J.lib] to the [core] backend.
+     *
+     * Add this artifact when a third-party library logs via SLF4J — such as Micronaut —
+     * and its output should reach the Log4j2 backend of the application.
+     *
+     * This is the binding for SLF4J 2.x, which [Slf4J] declares. The `log4j-slf4j-impl`
+     * artifact, which serves SLF4J 1.7, must not be on the same classpath.
+     */
+    // https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-slf4j2-impl
+    const val slf4j2Bridge = "org.apache.logging.log4j:log4j-slf4j2-impl:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Log4j2.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Log4j2.kt
@@ -37,7 +37,8 @@ package io.spine.dependency.lib
  */
 @Suppress("unused", "ConstPropertyName")
 object Log4j2 {
-    private const val version = "2.26.0"
+    const val version = "2.26.1"
+
     const val core = "org.apache.logging.log4j:log4j-core:$version"
 
     /**
@@ -46,9 +47,12 @@ object Log4j2 {
      * Add this artifact when a third-party library logs via SLF4J — such as Micronaut —
      * and its output should reach the Log4j2 backend of the application.
      *
-     * This is the binding for SLF4J 2.x, which [Slf4J] declares. The `log4j-slf4j-impl`
-     * artifact, which serves SLF4J 1.7, must not be on the same classpath.
+     * The artifact is `log4j-slf4j2-impl`, the binding for the SLF4J 2.x that [Slf4J]
+     * declares. Do not substitute `log4j-slf4j-impl`: it binds SLF4J 1.7 only, and
+     * under SLF4J 2.x it registers no provider, which leaves the logging silently
+     * unbound instead of failing the build.
+     *
+     * @see <a href="https://logging.apache.org/log4j/2.x/log4j-slf4j2-impl/">Log4j2 SLF4J 2.x binding</a>
      */
-    // https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-slf4j2-impl
     const val slf4j2Bridge = "org.apache.logging.log4j:log4j-slf4j2-impl:$version"
 }


### PR DESCRIPTION
This PR introduces the `JacksonV2` dependency object which is needed for forcing transitive dependencies on previous major version of Jackson. 

### Other notable changes
 * `Log4j2` dependency object got the property `slf4j2Bridge`. The version was also bumped to `2.26.1`.